### PR TITLE
fix: label-based cross-process cleanup with scoped resource lifecycle

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -46,6 +46,7 @@ export default withMermaid(
               { text: 'Magic Proxy System', link: '/guide/magic-proxy' },
               { text: 'JavaScript to CEL', link: '/guide/javascript-to-cel' },
               { text: 'Deployment Modes', link: '/guide/deployment-modes' },
+              { text: 'Resource Scopes & Lifecycle', link: '/guide/resource-scopes' },
               { text: 'External References', link: '/guide/external-references' },
               { text: 'Type Safety Patterns', link: '/guide/type-safety' },
               { text: 'Troubleshooting', link: '/guide/troubleshooting' },

--- a/docs/guide/resource-scopes.md
+++ b/docs/guide/resource-scopes.md
@@ -1,0 +1,142 @@
+# Resource Scopes & Lifecycle
+
+TypeKro's scope system controls which resources survive instance deletion and enables cross-process cleanup. It replaces the older binary `lifecycle: 'shared'` flag with a flexible, multi-scope model.
+
+## The Problem
+
+A typical TypeKro composition deploys a mix of:
+
+- **Instance-private resources** — the app's Deployment, Service, database Cluster. These belong exclusively to one deployment and should be deleted when the instance is torn down.
+- **Shared infrastructure** — the CNPG operator, the Valkey operator, Flux HelmRepositories. These are cluster-wide singletons shared across many consumers and should survive any individual instance deletion.
+
+Without scopes, `factory.deleteInstance('my-app')` would either delete everything (breaking other consumers of the operator) or require manual tracking of what's shared.
+
+## How Scopes Work
+
+Every resource can optionally belong to one or more **scopes** — string tags that describe its lifecycle boundary. Scopes are set in compositions via `setMetadataField` and are persisted as Kubernetes annotations on the live resource.
+
+```typescript
+import { setMetadataField } from 'typekro';
+
+// Tag as cluster-wide shared infrastructure
+setMetadataField(operatorRelease, 'scopes', ['cluster']);
+
+// Tag as team-shared (e.g., monitoring stack)
+setMetadataField(grafanaDashboard, 'scopes', ['team:platform']);
+
+// No scope = instance-private (default)
+// setMetadataField not needed — resources are instance-private by default
+```
+
+### Delete Behavior
+
+| Resource scopes | `deleteInstance(name)` | `deleteInstance(name, { scopes: ['cluster'] })` |
+|---|---|---|
+| `[]` (instance-private) | **Deleted** | **Deleted** |
+| `['cluster']` | **Preserved** | **Deleted** |
+| `['team:platform']` | **Preserved** | **Preserved** |
+| `['cluster', 'team:platform']` | **Preserved** | **Deleted** (any match) |
+
+The rule is simple:
+- **Instance-private** resources (no scopes) are always deleted
+- **Scoped** resources are deleted only when the caller explicitly targets at least one of their scopes
+
+This means `factory.deleteInstance('my-app')` is always safe — it can never accidentally tear down shared infrastructure.
+
+### Deploy Behavior
+
+You can also target scopes at deploy time to deploy only a subset of the resource graph:
+
+```typescript
+// Deploy only cluster-scoped resources (install operators first)
+await factory.deploy(spec, { targetScopes: ['cluster'] });
+
+// Deploy only instance-private resources (operators already running)
+await factory.deploy(spec, { targetScopes: [] });
+
+// Deploy everything (default)
+await factory.deploy(spec);
+```
+
+When `targetScopes` is `undefined` (the default), all resources deploy. When set, only matching resources deploy — others are silently skipped.
+
+## Built-in Scope: `'cluster'`
+
+TypeKro's bootstrap compositions use the `'cluster'` scope by default for operator installs:
+
+```typescript
+// In cnpg-bootstrap.ts (simplified)
+const isShared = spec.shared !== false; // default: true
+
+if (isShared) {
+  setMetadataField(operatorNamespace, 'scopes', ['cluster']);
+  setMetadataField(helmRepository, 'scopes', ['cluster']);
+  setMetadataField(helmRelease, 'scopes', ['cluster']);
+}
+```
+
+This means:
+- Multiple `webAppWithProcessing` deployments converge on one CNPG operator install
+- `deleteInstance` on any one consumer leaves the operator running
+- To remove the operator: `deleteInstance(name, { scopes: ['cluster'] })`
+- To opt out of sharing: `{ shared: false }` in the bootstrap config gives you a dedicated operator
+
+## Cross-Process Cleanup
+
+TypeKro stamps every deployed resource with ownership labels and annotations:
+
+**Labels** (selector-queryable):
+- `typekro.io/managed-by=typekro`
+- `typekro.io/factory-name=<name>`
+- `typekro.io/instance-name=<name>`
+
+**Annotations** (state data):
+- `typekro.io/deployment-id` — groups resources from a single deploy
+- `typekro.io/resource-id` — composition-local identifier
+- `typekro.io/scopes` — JSON array of scope names
+- `typekro.io/depends-on` — JSON array of dependency ids
+
+This means `factory.deleteInstance('my-app')` works even from a **completely different process** than the one that deployed — the factory discovers resources by label selector, reconstructs the dependency graph from annotations, and performs reverse-topological deletion. No shared database, no ConfigMap state backend. The cluster IS the state.
+
+```typescript
+// Process A: deploy
+const factory = webapp.factory('direct', { namespace: 'prod' });
+await factory.deploy({ name: 'my-app', ... });
+// Process A exits
+
+// Process B (hours later): clean up
+const factory = webapp.factory('direct', { namespace: 'prod' });
+await factory.deleteInstance('my-app');
+// Works! Resources discovered by labels, graph rebuilt from annotations
+```
+
+## Scope Naming Conventions
+
+Scope names are free-form strings. We recommend these conventions:
+
+| Scope | Meaning | Example |
+|---|---|---|
+| `'cluster'` | Cluster-wide singleton (operators, CRDs) | CNPG operator, Valkey operator |
+| `'team:<name>'` | Shared within a team | Team monitoring stack |
+| `'tenant:<name>'` | Shared within a tenant | Multi-tenant infra |
+| `'env:<name>'` | Shared within an environment | Staging-specific certs |
+
+Resources can belong to multiple scopes. A resource is deleted if **any** of its scopes matches the caller's filter.
+
+## Migration from `lifecycle: 'shared'`
+
+The older `lifecycle: 'shared'` mechanism continues to work as an alias. Resources with `lifecycle: 'shared'` are treated as having `scopes: ['shared']`. The scope name `'shared'` behaves the same as any other scope — it protects the resource from default deletion and requires explicit targeting.
+
+```typescript
+// Old way (still works)
+setMetadataField(resource, 'lifecycle', 'shared');
+
+// New way (recommended)
+setMetadataField(resource, 'scopes', ['cluster']);
+```
+
+The new API is more expressive: you can have multiple named scopes, target specific scopes for deploy/delete, and use any naming convention.
+
+## KRO Mode Limitations
+
+Scope-targeted deployment and deletion are currently supported in **direct mode** only. In KRO mode, `scopes` and `targetScopes` options are accepted but ignored (a warning is logged). KRO mode uses the Kro controller's own lifecycle management for resource deletion.

--- a/docs/guide/resource-scopes.md
+++ b/docs/guide/resource-scopes.md
@@ -37,9 +37,18 @@ setMetadataField(grafanaDashboard, 'scopes', ['team:platform']);
 | `['team:platform']` | **Preserved** | **Preserved** |
 | `['cluster', 'team:platform']` | **Preserved** | **Deleted** (any match) |
 
-The rule is simple:
-- **Instance-private** resources (no scopes) are always deleted
+The rules:
+- **Unscoped** resources (no scopes / instance-private) are deleted by default
 - **Scoped** resources are deleted only when the caller explicitly targets at least one of their scopes
+- Pass `includeUnscopedResources: false` to skip unscoped resources — useful for tearing down only shared infrastructure while leaving the app running
+
+```typescript
+// Cluster-only teardown: remove operators, keep app
+await factory.deleteInstance('my-app', {
+  scopes: ['cluster'],
+  includeUnscopedResources: false,
+});
+```
 
 This means `factory.deleteInstance('my-app')` is always safe — it can never accidentally tear down shared infrastructure.
 

--- a/docs/guide/resource-scopes.md
+++ b/docs/guide/resource-scopes.md
@@ -139,4 +139,4 @@ The new API is more expressive: you can have multiple named scopes, target speci
 
 ## KRO Mode Limitations
 
-Scope-targeted deployment and deletion are currently supported in **direct mode** only. In KRO mode, `scopes` and `targetScopes` options are accepted but ignored (a warning is logged). KRO mode uses the Kro controller's own lifecycle management for resource deletion.
+Scope-targeted deployment and deletion are currently supported in **direct mode** only. In KRO mode, passing `scopes` or `targetScopes` throws a `TypeKroError` with code `UNSUPPORTED_OPTION`. KRO mode uses the Kro controller's own lifecycle management for resource deletion.

--- a/src/core/deployment/deployment-state-discovery.ts
+++ b/src/core/deployment/deployment-state-discovery.ts
@@ -1,0 +1,394 @@
+/**
+ * Deployment State Discovery
+ *
+ * Reconstructs a DeploymentStateRecord for a factory+instance by querying
+ * the cluster for resources labeled with typekro ownership metadata.
+ *
+ * This module implements the "cluster IS the state" model: there is no
+ * separate state backend (ConfigMap, database, etc). Every typekro-managed
+ * resource is tagged at deploy time with labels and annotations via
+ * {@link applyTypekroTags}, and at delete time we walk the cluster to
+ * find those resources and rebuild the graph from their annotations.
+ *
+ * ## Discovery strategy
+ *
+ * To cover every GVK a typekro composition might have touched, we:
+ *
+ *   1. Issue label-filtered list calls against a hardcoded set of
+ *      built-in GVKs (Deployments, Services, Namespaces, etc.).
+ *   2. List all CRDs on the cluster, extract their (group, version, kind,
+ *      scope) tuples, and issue label-filtered list calls against each.
+ *   3. Merge the results.
+ *
+ * Each list is scoped by a label selector, so even on large clusters the
+ * response from a GVK with no matching resources is a near-empty payload.
+ * The main cost is the number of list calls, which is bounded by
+ * (built-in GVKs) + (CRDs on cluster) — typically 30-150 requests total
+ * for a fresh discovery. Requests are issued with bounded parallelism.
+ *
+ * ## Why not use /apis discovery?
+ *
+ * The Kubernetes discovery API (`/apis`, `/api/v1`) gives a complete
+ * list of API resources, but client-node 1.x doesn't expose a typed
+ * helper for walking it, and we'd need to issue one request per group-
+ * version anyway to get the `resources[]` list for each. Listing CRDs
+ * directly is simpler and covers every custom kind; the hardcoded
+ * built-in list covers the rest.
+ *
+ * ## Graph reconstruction
+ *
+ * Each discovered resource carries a `typekro.io/depends-on` annotation
+ * containing a JSON array of composition-local ids it depends on. We
+ * walk the discovered resources twice: first pass adds every id as a
+ * graph node, second pass adds edges. Dangling edges (pointing to a
+ * resource that no longer exists on the cluster) are silently dropped
+ * — that's the expected state after a partial delete.
+ */
+
+import type * as k8s from '@kubernetes/client-node';
+import { DependencyGraph } from '../dependencies/graph.js';
+import { getComponentLogger } from '../logging/index.js';
+import type { DeployedResource, DeploymentStateRecord } from '../types/deployment.js';
+import type {
+  CustomResourceDefinitionItem,
+  CustomResourceDefinitionList,
+  KubernetesResource,
+} from '../types.js';
+import {
+  buildFactoryInstanceSelector,
+  extractTypekroTags,
+} from './resource-tagging.js';
+
+const logger = getComponentLogger('deployment-state-discovery');
+
+/**
+ * GVK tuple used for per-kind list calls.
+ *
+ * `namespaced` is currently unused — all list calls use a cluster-wide
+ * scan (namespace=undefined) because typekro compositions can span
+ * multiple namespaces. The field is retained for a planned optimization
+ * where namespace-scoped listing could reduce API server load on large
+ * clusters by only querying namespaces the factory has touched.
+ */
+interface GvkTarget {
+  apiVersion: string;
+  kind: string;
+  namespaced: boolean;
+}
+
+/**
+ * Built-in Kubernetes GVKs that typekro compositions commonly deploy.
+ * Kept intentionally narrow: adding entries here costs one list call
+ * per delete, so we only include kinds that are actually used by typekro
+ * factories.
+ *
+ * If a user deploys a built-in kind not on this list (e.g., a
+ * NetworkPolicy) and then deletes across processes, the resource will
+ * be missed by discovery. The fix is to add it here. A broader
+ * solution (full /apis walk) would be a follow-up optimization.
+ */
+const BUILT_IN_GVKS: GvkTarget[] = [
+  // Core API (v1)
+  { apiVersion: 'v1', kind: 'Namespace', namespaced: false },
+  { apiVersion: 'v1', kind: 'ConfigMap', namespaced: true },
+  { apiVersion: 'v1', kind: 'Secret', namespaced: true },
+  { apiVersion: 'v1', kind: 'Service', namespaced: true },
+  { apiVersion: 'v1', kind: 'ServiceAccount', namespaced: true },
+  { apiVersion: 'v1', kind: 'PersistentVolumeClaim', namespaced: true },
+  { apiVersion: 'v1', kind: 'PersistentVolume', namespaced: false },
+  // Apps
+  { apiVersion: 'apps/v1', kind: 'Deployment', namespaced: true },
+  { apiVersion: 'apps/v1', kind: 'StatefulSet', namespaced: true },
+  { apiVersion: 'apps/v1', kind: 'DaemonSet', namespaced: true },
+  { apiVersion: 'apps/v1', kind: 'ReplicaSet', namespaced: true },
+  // Batch
+  { apiVersion: 'batch/v1', kind: 'Job', namespaced: true },
+  { apiVersion: 'batch/v1', kind: 'CronJob', namespaced: true },
+  // Networking
+  { apiVersion: 'networking.k8s.io/v1', kind: 'Ingress', namespaced: true },
+  { apiVersion: 'networking.k8s.io/v1', kind: 'NetworkPolicy', namespaced: true },
+  // RBAC
+  { apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'Role', namespaced: true },
+  { apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'RoleBinding', namespaced: true },
+  { apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'ClusterRole', namespaced: false },
+  { apiVersion: 'rbac.authorization.k8s.io/v1', kind: 'ClusterRoleBinding', namespaced: false },
+  // Autoscaling
+  { apiVersion: 'autoscaling/v2', kind: 'HorizontalPodAutoscaler', namespaced: true },
+  // Policy
+  { apiVersion: 'policy/v1', kind: 'PodDisruptionBudget', namespaced: true },
+];
+
+/**
+ * Enumerate every GVK typekro might need to query on this cluster:
+ * hardcoded built-ins + every active CRD version.
+ *
+ * CRD listing failures (RBAC, transient errors) are logged and the
+ * built-in list is returned alone so discovery can still make progress.
+ */
+export async function discoverClusterGvks(
+  k8sApi: k8s.KubernetesObjectApi
+): Promise<GvkTarget[]> {
+  const targets: GvkTarget[] = [...BUILT_IN_GVKS];
+
+  try {
+    const crdList = (await k8sApi.list(
+      'apiextensions.k8s.io/v1',
+      'CustomResourceDefinition'
+    )) as unknown as CustomResourceDefinitionList;
+
+    for (const crd of crdList.items ?? []) {
+      const crdTargets = gvkTargetsFromCrd(crd);
+      targets.push(...crdTargets);
+    }
+  } catch (err) {
+    logger.warn(
+      'Failed to list CRDs during discovery — proceeding with built-in GVKs only',
+      { error: err instanceof Error ? err.message : String(err) }
+    );
+  }
+
+  return targets;
+}
+
+/**
+ * Extract GVK targets from a single CRD. A CRD may have multiple served
+ * versions; we include each served+storage version as its own target
+ * because older resources may still exist at the non-storage version.
+ */
+function gvkTargetsFromCrd(crd: CustomResourceDefinitionItem): GvkTarget[] {
+  const group = crd.spec?.group;
+  const kind = crd.spec?.names?.kind;
+  // CRD spec.scope is "Namespaced" | "Cluster". The typed interface in
+  // typekro has [key: string]: unknown on spec, so cast to read it.
+  const scope = (crd.spec as { scope?: string } | undefined)?.scope;
+  if (!group || !kind) return [];
+  const versions = crd.spec?.versions ?? [];
+  const namespaced = scope !== 'Cluster';
+  const targets: GvkTarget[] = [];
+  for (const v of versions) {
+    if (!v.served || !v.name) continue;
+    targets.push({
+      apiVersion: `${group}/${v.name}`,
+      kind,
+      namespaced,
+    });
+  }
+  return targets;
+}
+
+/**
+ * Discover the full set of resources belonging to a factory+instance and
+ * rebuild a {@link DeploymentStateRecord} ready to feed into
+ * {@link DirectDeploymentEngine.rollbackRecord}.
+ *
+ * Returns `undefined` if no resources match — legitimate state when the
+ * instance has already been cleaned up, was never deployed, or was
+ * deployed by a typekro version that did not tag resources.
+ *
+ * Resources are queried cluster-wide (namespace undefined) because
+ * typekro compositions can span multiple namespaces (e.g., a webapp
+ * composition may deploy operator resources in `cnpg-system` and
+ * application resources in `default`). The label selector makes this
+ * cheap even on large clusters.
+ */
+export async function discoverDeployedResourcesByInstance(
+  k8sApi: k8s.KubernetesObjectApi,
+  opts: {
+    factoryName: string;
+    instanceName: string;
+  }
+): Promise<DeploymentStateRecord | undefined> {
+  const labelSelector = buildFactoryInstanceSelector(opts);
+  const gvkTargets = await discoverClusterGvks(k8sApi);
+
+  logger.debug('Discovering deployed resources by label', {
+    factoryName: opts.factoryName,
+    instanceName: opts.instanceName,
+    gvkCount: gvkTargets.length,
+    labelSelector,
+  });
+
+  // Issue list calls with bounded parallelism. Unbounded parallelism
+  // can flood the API server on large clusters; 8 concurrent lists is
+  // a reasonable default.
+  const matches = await listWithConcurrency(
+    gvkTargets,
+    8,
+    async (target) => {
+      try {
+        const result = await k8sApi.list<KubernetesResource>(
+          target.apiVersion,
+          target.kind,
+          undefined, // namespace: cluster-wide
+          undefined, // pretty
+          undefined, // exact
+          undefined, // exportt
+          undefined, // fieldSelector
+          labelSelector
+        );
+        return result.items ?? [];
+      } catch (err) {
+        // 404 on a GVK means the API server doesn't recognise that
+        // kind — expected for CRDs that were uninstalled mid-discovery.
+        // Log at debug so the noise doesn't drown out real errors.
+        logger.debug('List failed for GVK during discovery', {
+          apiVersion: target.apiVersion,
+          kind: target.kind,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return [];
+      }
+    }
+  );
+
+  // Flatten and deduplicate by (kind, namespace, name). The same
+  // resource shouldn't appear twice in practice, but defensive code
+  // guards against CRDs that are served at multiple versions.
+  const seen = new Set<string>();
+  const uniqueResources: KubernetesResource[] = [];
+  for (const item of matches.flat()) {
+    const key = `${item.kind}/${item.metadata?.namespace ?? ''}/${item.metadata?.name ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    uniqueResources.push(item);
+  }
+
+  if (uniqueResources.length === 0) {
+    logger.debug('No resources found for instance', {
+      factoryName: opts.factoryName,
+      instanceName: opts.instanceName,
+    });
+    return undefined;
+  }
+
+  return buildRecordFromResources(uniqueResources, opts);
+}
+
+/**
+ * Convert a set of discovered live resources into a DeploymentStateRecord.
+ * Each resource's ownership metadata is pulled from its labels and
+ * annotations, and the dependency graph is reconstructed from the
+ * per-resource `depends-on` annotations.
+ */
+function buildRecordFromResources(
+  resources: KubernetesResource[],
+  opts: { factoryName: string; instanceName: string }
+): DeploymentStateRecord {
+  const deployedResources: DeployedResource[] = [];
+  const idToResource = new Map<string, DeployedResource>();
+  const dependenciesById = new Map<string, string[]>();
+
+  // First pass: extract tags and build DeployedResource records
+  let deploymentId: string | undefined;
+  let earliestStart: Date | undefined;
+  let factoryNamespace: string | undefined;
+
+  for (const resource of resources) {
+    const tags = extractTypekroTags(resource);
+    const id = tags.resourceId;
+    if (!id) {
+      // A resource with no resource-id annotation can't participate in
+      // graph reconstruction — it must have been tagged by a partial
+      // upgrade or external mutator. Skip rather than crash.
+      logger.debug('Skipping discovered resource with no resource-id annotation', {
+        kind: resource.kind,
+        name: resource.metadata?.name,
+      });
+      continue;
+    }
+
+    if (!deploymentId && tags.deploymentId) deploymentId = tags.deploymentId;
+    if (!factoryNamespace && tags.factoryNamespace) {
+      factoryNamespace = tags.factoryNamespace;
+    }
+
+    const creationTimestamp = resource.metadata?.creationTimestamp;
+    if (creationTimestamp) {
+      const ts = new Date(creationTimestamp as string | number | Date);
+      if (!earliestStart || ts < earliestStart) earliestStart = ts;
+    }
+
+    const deployed: DeployedResource = {
+      id,
+      kind: resource.kind ?? 'Unknown',
+      name: resource.metadata?.name ?? 'unknown',
+      namespace: resource.metadata?.namespace ?? '',
+      manifest: resource,
+      status: 'deployed',
+      deployedAt: creationTimestamp
+        ? new Date(creationTimestamp as string | number | Date)
+        : new Date(),
+    };
+    deployedResources.push(deployed);
+    idToResource.set(id, deployed);
+    if (tags.dependencies.length > 0) {
+      dependenciesById.set(id, tags.dependencies);
+    }
+  }
+
+  // Second pass: rebuild the dependency graph
+  const dependencyGraph = new DependencyGraph();
+  for (const [id, deployed] of idToResource.entries()) {
+    // biome-ignore lint/suspicious/noExplicitAny: minimal plain manifest, not an Enhanced proxy
+    dependencyGraph.addNode(id, deployed.manifest as any);
+  }
+  for (const [from, deps] of dependenciesById.entries()) {
+    for (const to of deps) {
+      // Skip dangling edges — the dependency may have been deleted
+      // manually, or was never tagged (e.g., lifecycle: shared in an
+      // older typekro version that we now find via annotations only).
+      if (!idToResource.has(to)) continue;
+      try {
+        dependencyGraph.addEdge(from, to);
+      } catch (err) {
+        logger.debug('Failed to add edge during discovery — skipping', {
+          from,
+          to,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  return {
+    deploymentId: deploymentId ?? `discovered-${Date.now()}`,
+    resources: deployedResources,
+    dependencyGraph,
+    startTime: earliestStart ?? new Date(),
+    status: 'completed',
+    options: {
+      mode: 'direct',
+      ...(factoryNamespace && { namespace: factoryNamespace }),
+      factoryName: opts.factoryName,
+      instanceName: opts.instanceName,
+    },
+  };
+}
+
+/**
+ * Run an async function over an array with bounded parallelism. Used to
+ * cap the number of simultaneous API requests during discovery.
+ */
+async function listWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const workers: Promise<void>[] = [];
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      const item = items[idx];
+      if (item === undefined) continue;
+      results[idx] = await fn(item);
+    }
+  };
+  for (let i = 0; i < Math.min(concurrency, items.length); i++) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+  return results;
+}

--- a/src/core/deployment/deployment-state-discovery.ts
+++ b/src/core/deployment/deployment-state-discovery.ts
@@ -217,16 +217,19 @@ export async function discoverDeployedResourcesByInstance(
     ? opts.knownGvks
     : await discoverClusterGvks(k8sApi);
 
+  const usingHint = !!opts.knownGvks?.length;
   logger.debug('Discovering deployed resources by label', {
     factoryName: opts.factoryName,
     instanceName: opts.instanceName,
     gvkCount: gvkTargets.length,
+    source: usingHint ? 'knownGvks hint' : 'full cluster enumeration',
     labelSelector,
   });
 
   // Issue list calls with bounded parallelism. Unbounded parallelism
   // can flood the API server on large clusters; 8 concurrent lists is
   // a reasonable default.
+  const discoveryStart = Date.now();
   const matches = await listWithConcurrency(
     gvkTargets,
     8,
@@ -256,6 +259,15 @@ export async function discoverDeployedResourcesByInstance(
       }
     }
   );
+
+  const discoveryDuration = Date.now() - discoveryStart;
+  logger.info('Discovery list calls completed', {
+    factoryName: opts.factoryName,
+    instanceName: opts.instanceName,
+    gvkCount: gvkTargets.length,
+    source: usingHint ? 'knownGvks' : 'full-cluster',
+    durationMs: discoveryDuration,
+  });
 
   // Flatten, deduplicate by (kind, namespace, name), and post-filter
   // by raw annotation values. The label selector uses sanitized values

--- a/src/core/deployment/deployment-state-discovery.ts
+++ b/src/core/deployment/deployment-state-discovery.ts
@@ -158,8 +158,8 @@ export async function discoverClusterGvks(
 
 /**
  * Extract GVK targets from a single CRD. A CRD may have multiple served
- * versions; we include each served+storage version as its own target
- * because older resources may still exist at the non-storage version.
+ * versions; we include each served version as its own target because
+ * older resources may still exist at a non-storage version.
  */
 function gvkTargetsFromCrd(crd: CustomResourceDefinitionItem): GvkTarget[] {
   const group = crd.spec?.group;
@@ -379,10 +379,6 @@ function buildRecordFromResources(
 }
 
 /**
- * Run an async function over an array with bounded parallelism. Used to
- * cap the number of simultaneous API requests during discovery.
- */
-/**
  * Safely convert a Kubernetes `creationTimestamp` to a Date.
  * The client-node deserializer returns a `Date` object, but defensive
  * callers may receive strings from raw JSON or test mocks.
@@ -393,6 +389,10 @@ function toDate(value: unknown): Date | undefined {
   return undefined;
 }
 
+/**
+ * Run an async function over an array with bounded parallelism. Used to
+ * cap the number of simultaneous API requests during discovery.
+ */
 async function listWithConcurrency<T, R>(
   items: T[],
   concurrency: number,

--- a/src/core/deployment/deployment-state-discovery.ts
+++ b/src/core/deployment/deployment-state-discovery.ts
@@ -70,7 +70,7 @@ const logger = getComponentLogger('deployment-state-discovery');
  * where namespace-scoped listing could reduce API server load on large
  * clusters by only querying namespaces the factory has touched.
  */
-interface GvkTarget {
+export interface GvkTarget {
   apiVersion: string;
   kind: string;
   namespaced: boolean;
@@ -86,6 +86,12 @@ interface GvkTarget {
  * NetworkPolicy) and then deletes across processes, the resource will
  * be missed by discovery. The fix is to add it here. A broader
  * solution (full /apis walk) would be a follow-up optimization.
+ *
+ * With the `knownGvks` hint from the factory (see
+ * `discoverDeployedResourcesByInstance`), this list is only used as a
+ * fallback when the composition's resource templates are unavailable.
+ *
+ * Last audited: 2026-04-06.
  */
 const BUILT_IN_GVKS: GvkTarget[] = [
   // Core API (v1)
@@ -196,10 +202,20 @@ export async function discoverDeployedResourcesByInstance(
   opts: {
     factoryName: string;
     instanceName: string;
+    /**
+     * GVK hint from the factory's resource templates. When provided,
+     * only these kinds are queried — dropping a typical delete from
+     * 100+ list calls to 5-10. Falls back to full cluster GVK
+     * enumeration when omitted (e.g., bare engine calls without a
+     * composition in hand).
+     */
+    knownGvks?: GvkTarget[];
   }
 ): Promise<DeploymentStateRecord | undefined> {
   const labelSelector = buildFactoryInstanceSelector(opts);
-  const gvkTargets = await discoverClusterGvks(k8sApi);
+  const gvkTargets = opts.knownGvks?.length
+    ? opts.knownGvks
+    : await discoverClusterGvks(k8sApi);
 
   logger.debug('Discovering deployed resources by label', {
     factoryName: opts.factoryName,
@@ -219,10 +235,10 @@ export async function discoverDeployedResourcesByInstance(
         const result = await k8sApi.list<KubernetesResource>(
           target.apiVersion,
           target.kind,
-          undefined, // namespace: cluster-wide
+          undefined, // namespace — cluster-wide scan
           undefined, // pretty
-          undefined, // exact
-          undefined, // exportt
+          undefined, // exact (deprecated)
+          undefined, // export (deprecated)
           undefined, // fieldSelector
           labelSelector
         );
@@ -302,10 +318,9 @@ function buildRecordFromResources(
       factoryNamespace = tags.factoryNamespace;
     }
 
-    const creationTimestamp = resource.metadata?.creationTimestamp;
-    if (creationTimestamp) {
-      const ts = new Date(creationTimestamp as string | number | Date);
-      if (!earliestStart || ts < earliestStart) earliestStart = ts;
+    const deployedAt = toDate(resource.metadata?.creationTimestamp);
+    if (deployedAt && (!earliestStart || deployedAt < earliestStart)) {
+      earliestStart = deployedAt;
     }
 
     const deployed: DeployedResource = {
@@ -315,9 +330,7 @@ function buildRecordFromResources(
       namespace: resource.metadata?.namespace ?? '',
       manifest: resource,
       status: 'deployed',
-      deployedAt: creationTimestamp
-        ? new Date(creationTimestamp as string | number | Date)
-        : new Date(),
+      deployedAt: deployedAt ?? new Date(),
     };
     deployedResources.push(deployed);
     idToResource.set(id, deployed);
@@ -369,6 +382,17 @@ function buildRecordFromResources(
  * Run an async function over an array with bounded parallelism. Used to
  * cap the number of simultaneous API requests during discovery.
  */
+/**
+ * Safely convert a Kubernetes `creationTimestamp` to a Date.
+ * The client-node deserializer returns a `Date` object, but defensive
+ * callers may receive strings from raw JSON or test mocks.
+ */
+function toDate(value: unknown): Date | undefined {
+  if (value instanceof Date) return value;
+  if (typeof value === 'string' || typeof value === 'number') return new Date(value);
+  return undefined;
+}
+
 async function listWithConcurrency<T, R>(
   items: T[],
   concurrency: number,

--- a/src/core/deployment/deployment-state-discovery.ts
+++ b/src/core/deployment/deployment-state-discovery.ts
@@ -93,7 +93,7 @@ export interface GvkTarget {
  *
  * Last audited: 2026-04-06.
  */
-export const BUILT_IN_GVKS: GvkTarget[] = [
+export const BUILT_IN_GVKS: readonly GvkTarget[] = [
   // Core API (v1)
   { apiVersion: 'v1', kind: 'Namespace', namespaced: false },
   { apiVersion: 'v1', kind: 'ConfigMap', namespaced: true },
@@ -278,7 +278,7 @@ export async function discoverDeployedResourcesByInstance(
   const seen = new Set<string>();
   const uniqueResources: KubernetesResource[] = [];
   for (const item of matches.flat()) {
-    const key = `${item.kind}/${item.metadata?.namespace ?? ''}/${item.metadata?.name ?? ''}`;
+    const key = `${item.apiVersion}/${item.kind}/${item.metadata?.namespace ?? ''}/${item.metadata?.name ?? ''}`;
     if (seen.has(key)) continue;
     seen.add(key);
     // Post-filter: verify raw annotation matches requested identity

--- a/src/core/deployment/deployment-state-discovery.ts
+++ b/src/core/deployment/deployment-state-discovery.ts
@@ -93,7 +93,7 @@ export interface GvkTarget {
  *
  * Last audited: 2026-04-06.
  */
-const BUILT_IN_GVKS: GvkTarget[] = [
+export const BUILT_IN_GVKS: GvkTarget[] = [
   // Core API (v1)
   { apiVersion: 'v1', kind: 'Namespace', namespaced: false },
   { apiVersion: 'v1', kind: 'ConfigMap', namespaced: true },
@@ -257,15 +257,22 @@ export async function discoverDeployedResourcesByInstance(
     }
   );
 
-  // Flatten and deduplicate by (kind, namespace, name). The same
-  // resource shouldn't appear twice in practice, but defensive code
-  // guards against CRDs that are served at multiple versions.
+  // Flatten, deduplicate by (kind, namespace, name), and post-filter
+  // by raw annotation values. The label selector uses sanitized values
+  // which can collide (e.g., "my@factory" and "my#factory" both
+  // sanitize to "my-factory"). The raw factory/instance name stored in
+  // annotations is the authoritative match — reject resources whose
+  // annotation doesn't match the requested factory+instance.
   const seen = new Set<string>();
   const uniqueResources: KubernetesResource[] = [];
   for (const item of matches.flat()) {
     const key = `${item.kind}/${item.metadata?.namespace ?? ''}/${item.metadata?.name ?? ''}`;
     if (seen.has(key)) continue;
     seen.add(key);
+    // Post-filter: verify raw annotation matches requested identity
+    const tags = extractTypekroTags(item as { metadata?: { labels?: Record<string, string>; annotations?: Record<string, string> } });
+    if (tags.factoryName && tags.factoryName !== opts.factoryName) continue;
+    if (tags.instanceName && tags.instanceName !== opts.instanceName) continue;
     uniqueResources.push(item);
   }
 
@@ -407,8 +414,7 @@ async function listWithConcurrency<T, R>(
       // below, so `next++` can't be interleaved between workers.
       const idx = next++;
       if (idx >= items.length) return;
-      const item = items[idx];
-      if (item === undefined) continue;
+      const item = items[idx]!;
       results[idx] = await fn(item);
     }
   };

--- a/src/core/deployment/deployment-state-discovery.ts
+++ b/src/core/deployment/deployment-state-discovery.ts
@@ -403,8 +403,11 @@ function buildRecordFromResources(
  * callers may receive strings from raw JSON or test mocks.
  */
 function toDate(value: unknown): Date | undefined {
-  if (value instanceof Date) return value;
-  if (typeof value === 'string' || typeof value === 'number') return new Date(value);
+  if (value instanceof Date) return isNaN(value.getTime()) ? undefined : value;
+  if (typeof value === 'string' || typeof value === 'number') {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? undefined : d;
+  }
   return undefined;
 }
 

--- a/src/core/deployment/deployment-state-discovery.ts
+++ b/src/core/deployment/deployment-state-discovery.ts
@@ -403,6 +403,8 @@ async function listWithConcurrency<T, R>(
   const workers: Promise<void>[] = [];
   const worker = async (): Promise<void> => {
     while (true) {
+      // Safe: JS is single-threaded — workers only yield at the `await`
+      // below, so `next++` can't be interleaved between workers.
       const idx = next++;
       if (idx >= items.length) return;
       const item = items[idx];

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -224,17 +224,18 @@ export class DirectResourceFactoryImpl<
    * Both paths feed into the same graph-based reverse-topological
    * delete via `engine.rollbackRecord`.
    *
-   * **Scope filtering**: By default, only instance-private resources
-   * (empty scopes) are deleted. Resources with scopes (e.g., cluster-
-   * scoped operators installed by bootstrap compositions) are preserved.
-   * Pass `opts.scopes` to include broader-scope resources:
+   * **Scope filtering**: By default, unscoped (instance-private)
+   * resources are deleted and scoped resources are preserved. Pass
+   * `opts.scopes` to include broader-scope resources additively:
    *
    * ```ts
-   * await factory.deleteInstance('my-app');                     // safe default
-   * await factory.deleteInstance('my-app', { scopes: ['cluster'] }); // full teardown
+   * await factory.deleteInstance('my-app');                                         // unscoped only (safe default)
+   * await factory.deleteInstance('my-app', { scopes: ['cluster'] });               // unscoped + cluster
+   * await factory.deleteInstance('my-app', { scopes: ['cluster'],
+   *   includeUnscopedResources: false });                                           // cluster-only (leave app running)
    * ```
    */
-  async deleteInstance(name: string, opts?: { scopes?: string[] }): Promise<void> {
+  async deleteInstance(name: string, opts?: { scopes?: string[]; includeUnscopedResources?: boolean }): Promise<void> {
     const engine = this.getDeploymentEngine();
     const instance = this.deployedInstances.get(name);
 
@@ -246,7 +247,10 @@ export class DirectResourceFactoryImpl<
         const deploymentId = instance.metadata?.annotations?.['typekro.io/deployment-id'];
         if (deploymentId) {
           try {
-            rollbackResult = await engine.rollback(deploymentId, opts?.scopes ? { scopes: opts.scopes } : {});
+            rollbackResult = await engine.rollback(deploymentId, {
+              ...(opts?.scopes && { scopes: opts.scopes }),
+              ...(opts?.includeUnscopedResources === false && { includeUnscopedResources: false }),
+            });
           } catch (error: unknown) {
             // Fall through to path 2 (discovery) ONLY when the in-memory
             // deployment state is stale — i.e., the engine couldn't find
@@ -307,7 +311,10 @@ export class DirectResourceFactoryImpl<
           deploymentId: record.deploymentId,
           resourceCount: record.resources.length,
         });
-        rollbackResult = await engine.rollbackRecord(record, opts?.scopes ? { scopes: opts.scopes } : {});
+        rollbackResult = await engine.rollbackRecord(record, {
+              ...(opts?.scopes && { scopes: opts.scopes }),
+              ...(opts?.includeUnscopedResources === false && { includeUnscopedResources: false }),
+            });
       }
 
       // Wait for any namespaces to be fully deleted before returning.

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -312,9 +312,9 @@ export class DirectResourceFactoryImpl<
           resourceCount: record.resources.length,
         });
         rollbackResult = await engine.rollbackRecord(record, {
-              ...(opts?.scopes && { scopes: opts.scopes }),
-              ...(opts?.includeUnscopedResources === false && { includeUnscopedResources: false }),
-            });
+          ...(opts?.scopes && { scopes: opts.scopes }),
+          ...(opts?.includeUnscopedResources === false && { includeUnscopedResources: false }),
+        });
       }
 
       // Wait for any namespaces to be fully deleted before returning.

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -135,7 +135,10 @@ export class DirectResourceFactoryImpl<
   /**
    * Deploy a new instance with the given spec
    */
-  async deploy(spec: TSpec): Promise<Enhanced<TSpec, TStatus>> {
+  async deploy(
+    spec: TSpec,
+    opts?: { targetScopes?: string[] }
+  ): Promise<Enhanced<TSpec, TStatus>> {
     this.logger.debug('DirectResourceFactory deploy called', {
       factoryName: this.name,
       hasStatusBuilder: !!this.statusBuilder,
@@ -147,6 +150,12 @@ export class DirectResourceFactoryImpl<
     this.logger.debug('Got deployment strategy', {
       strategyType: strategy.constructor.name,
     });
+
+    // Thread targetScopes through to the deployment options so the
+    // engine can scope-filter which resources actually get deployed.
+    if (opts?.targetScopes !== undefined) {
+      strategy.setTargetScopes(opts.targetScopes);
+    }
 
     const instance = await strategy.deploy(spec);
 
@@ -206,29 +215,81 @@ export class DirectResourceFactoryImpl<
   }
 
   /**
-   * Delete a specific instance by name
+   * Delete a specific instance by name.
+   *
+   * Lookup order:
+   *   1. In-memory `deployedInstances` Map (same-process path) — uses
+   *      the deployment-id annotation on the Enhanced instance proxy.
+   *   2. Cluster-side label discovery (cross-process path) — queries
+   *      for all resources labeled `typekro.io/factory-name=<factory>,
+   *      typekro.io/instance-name=<instance>`, reconstructs the
+   *      dependency graph from per-resource `typekro.io/depends-on`
+   *      annotations, and performs reverse-topological deletion.
+   *
+   * Both paths feed into the same graph-based reverse-topological
+   * delete via `engine.rollbackRecord`.
+   *
+   * **Scope filtering**: By default, only instance-private resources
+   * (empty scopes) are deleted. Resources with scopes (e.g., cluster-
+   * scoped operators installed by bootstrap compositions) are preserved.
+   * Pass `opts.scopes` to include broader-scope resources:
+   *
+   * ```ts
+   * await factory.deleteInstance('my-app');                     // safe default
+   * await factory.deleteInstance('my-app', { scopes: ['cluster'] }); // full teardown
+   * ```
    */
-  async deleteInstance(name: string): Promise<void> {
+  async deleteInstance(name: string, opts?: { scopes?: string[] }): Promise<void> {
+    const engine = this.getDeploymentEngine();
     const instance = this.deployedInstances.get(name);
-    if (!instance) {
-      throw new TypeKroError(`Instance not found: ${name}`, 'INSTANCE_NOT_FOUND', {
-        instanceName: name,
-        factoryName: this.name,
-      });
-    }
 
     try {
-      // Use the deployment engine to delete resources using actual deployment ID
-      const engine = this.getDeploymentEngine();
-      const deploymentId = instance.metadata?.annotations?.['typekro.io/deployment-id'];
-      if (!deploymentId) {
-        throw new TypeKroError(
-          `Instance ${name} does not have a deployment ID annotation. Cannot perform cleanup.`,
-          'MISSING_DEPLOYMENT_ID',
-          { instanceName: name, factoryName: this.name }
-        );
+      // Path 1: same-process deleteInstance — use the deployment ID
+      // annotation on the in-memory Enhanced proxy.
+      let rollbackResult: import('../types/deployment.js').RollbackResult | undefined;
+      if (instance) {
+        const deploymentId = instance.metadata?.annotations?.['typekro.io/deployment-id'];
+        if (deploymentId) {
+          try {
+            rollbackResult = await engine.rollback(deploymentId, opts?.scopes ? { scopes: opts.scopes } : {});
+          } catch (error: unknown) {
+            const msg = ensureError(error).message;
+            // Fall through to path 2 (persisted lookup) when in-memory
+            // state is stale — the engine's Map may have been cleared
+            // by a previous rollback.
+            if (!msg.includes('not found') && !msg.includes('Cannot rollback')) {
+              throw error;
+            }
+          }
+        }
       }
-      const rollbackResult = await engine.rollback(deploymentId);
+
+      // Path 2: cross-process lookup via cluster-side label discovery.
+      // Fires when the factory has no in-memory record, OR path 1
+      // couldn't find the deployment ID, OR path 1's engine state was
+      // wiped. Queries the cluster for all resources tagged with this
+      // factory+instance's labels, rebuilds the graph from per-resource
+      // annotations, and delegates to the same graph-based rollback.
+      if (!rollbackResult) {
+        const record = await engine.loadDeploymentByInstance({
+          factoryName: this.name,
+          instanceName: name,
+        });
+        if (!record) {
+          throw new TypeKroError(
+            `Instance not found: ${name} (no in-memory state and no tagged resources on the cluster). The instance may have been cleaned up already, or was deployed with a typekro version that did not tag resources.`,
+            'INSTANCE_NOT_FOUND',
+            { instanceName: name, factoryName: this.name }
+          );
+        }
+        this.logger.info('Cross-process cleanup: discovered deployment from cluster labels', {
+          instanceName: name,
+          factoryName: this.name,
+          deploymentId: record.deploymentId,
+          resourceCount: record.resources.length,
+        });
+        rollbackResult = await engine.rollbackRecord(record, opts?.scopes ? { scopes: opts.scopes } : {});
+      }
 
       // Wait for any namespaces to be fully deleted before returning.
       // Namespace deletion is asynchronous (enters "Terminating" phase) and can
@@ -280,12 +341,20 @@ export class DirectResourceFactoryImpl<
       // Remove from tracking
       this.deployedInstances.delete(name);
     } catch (error: unknown) {
-      // If the deployment isn't found in the state, it may have already been cleaned up
-      // or the deployment ID format changed. Log and remove from tracking anyway.
+      // INSTANCE_NOT_FOUND bubbles up — the caller asked us to delete
+      // an instance that has neither in-memory state nor a persisted
+      // record. That's a legitimate error (wrong name, already cleaned
+      // up) and the caller needs to see it.
+      if (error instanceof TypeKroError && error.code === 'INSTANCE_NOT_FOUND') {
+        throw error;
+      }
+      // Soft-swallow "Cannot rollback" errors from the engine —
+      // they indicate the engine's in-memory deployment state has
+      // already been cleaned up (e.g., by a previous rollback call).
+      // The instance is effectively gone, so we remove from tracking.
       const errorMessage = ensureError(error).message;
-      if (errorMessage.includes('not found') || errorMessage.includes('Cannot rollback')) {
+      if (errorMessage.includes('Cannot rollback')) {
         this.deployedInstances.delete(name);
-        // Don't throw - the instance is already gone
         return;
       }
       throw new ResourceGraphFactoryError(

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -23,7 +23,7 @@ import {
 } from '../errors.js';
 import type { KubernetesClientProvider } from '../kubernetes/client-provider.js';
 import { getComponentLogger } from '../logging/index.js';
-import { copyResourceMetadata, getResourceId, setResourceId } from '../metadata/index.js';
+import { copyResourceMetadata, getMetadataField, getResourceId, setResourceId } from '../metadata/index.js';
 import type {
   DeploymentClosure,
   DeploymentError,
@@ -272,10 +272,15 @@ export class DirectResourceFactoryImpl<
           ...new Map(
             Object.values(this.resources)
               .filter((r) => r.apiVersion && r.kind)
-              .map((r) => [
-                `${r.apiVersion}/${r.kind}`,
-                { apiVersion: r.apiVersion!, kind: r.kind!, namespaced: true },
-              ])
+              .map((r) => {
+                // Pull scope from WeakMap metadata — 'cluster' means
+                // cluster-scoped (Namespace, ClusterRole, etc.).
+                const scope = getMetadataField(r as object, 'scope');
+                return [
+                  `${r.apiVersion}/${r.kind}`,
+                  { apiVersion: r.apiVersion!, kind: r.kind!, namespaced: scope !== 'cluster' },
+                ] as const;
+              })
           ).values(),
         ];
         const record = await engine.loadDeploymentByInstance({

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -248,12 +248,15 @@ export class DirectResourceFactoryImpl<
           try {
             rollbackResult = await engine.rollback(deploymentId, opts?.scopes ? { scopes: opts.scopes } : {});
           } catch (error: unknown) {
-            // Fall through to path 2 (discovery) when in-memory state
-            // is stale — engine throws ResourceGraphFactoryError when
-            // the deployment ID isn't in its Map (cleared by a previous
-            // rollback or lost with the process). Any other error type
-            // is a real failure and should propagate.
-            if (!(error instanceof ResourceGraphFactoryError)) {
+            // Fall through to path 2 (discovery) ONLY when the in-memory
+            // deployment state is stale — i.e., the engine couldn't find
+            // the deployment ID in its Map (cleared by a previous rollback
+            // or lost with the process). Any other error — including
+            // genuine API failures during rollback — should propagate.
+            const isNotFound =
+              error instanceof ResourceGraphFactoryError &&
+              error.operation === 'cleanup';
+            if (!isNotFound) {
               throw error;
             }
           }

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -151,13 +151,7 @@ export class DirectResourceFactoryImpl<
       strategyType: strategy.constructor.name,
     });
 
-    // Thread targetScopes through to the deployment options so the
-    // engine can scope-filter which resources actually get deployed.
-    if (opts?.targetScopes !== undefined) {
-      strategy.setTargetScopes(opts.targetScopes);
-    }
-
-    const instance = await strategy.deploy(spec);
+    const instance = await strategy.deploy(spec, opts);
 
     // Check if deployment failed and throw for user-facing error handling
     if (instance.metadata?.annotations?.['typekro.io/deployment-status'] === 'failed') {
@@ -271,9 +265,23 @@ export class DirectResourceFactoryImpl<
       // factory+instance's labels, rebuilds the graph from per-resource
       // annotations, and delegates to the same graph-based rollback.
       if (!rollbackResult) {
+        // Extract GVK hints from the factory's resource templates so
+        // discovery queries only the kinds this composition deploys
+        // (~5-10 list calls) instead of every GVK on the cluster.
+        const knownGvks = [
+          ...new Map(
+            Object.values(this.resources)
+              .filter((r) => r.apiVersion && r.kind)
+              .map((r) => [
+                `${r.apiVersion}/${r.kind}`,
+                { apiVersion: r.apiVersion!, kind: r.kind!, namespaced: true },
+              ])
+          ).values(),
+        ];
         const record = await engine.loadDeploymentByInstance({
           factoryName: this.name,
           instanceName: name,
+          ...(knownGvks.length > 0 && { knownGvks }),
         });
         if (!record) {
           throw new TypeKroError(

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_MAX_RECURSION_DEPTH,
 } from '../config/defaults.js';
 import { DependencyResolver } from '../dependencies/index.js';
+import { BUILT_IN_GVKS } from './deployment-state-discovery.js';
 import {
   ensureError,
   ResourceGraphFactoryError,
@@ -265,28 +266,29 @@ export class DirectResourceFactoryImpl<
       // factory+instance's labels, rebuilds the graph from per-resource
       // annotations, and delegates to the same graph-based rollback.
       if (!rollbackResult) {
-        // Extract GVK hints from the factory's resource templates so
-        // discovery queries only the kinds this composition deploys
-        // (~5-10 list calls) instead of every GVK on the cluster.
+        // Build GVK hint set: built-in baseline (Namespace, Deployment,
+        // Service, etc.) PLUS any CRD kinds from this factory's resource
+        // templates. The baseline ensures nested composition resources
+        // (e.g., HelmRelease from cnpgBootstrap) are always discoverable
+        // even though they aren't in the parent factory's `this.resources`
+        // map. The CRD hints add the factory's custom kinds on top so we
+        // don't need the expensive full-cluster CRD enumeration.
+        const crdHints = new Map<string, import('./deployment-state-discovery.js').GvkTarget>();
+        for (const r of Object.values(this.resources)) {
+          if (!r.apiVersion || !r.kind) continue;
+          const key = `${r.apiVersion}/${r.kind}`;
+          if (crdHints.has(key)) continue;
+          const scope = getMetadataField(r as object, 'scope');
+          crdHints.set(key, { apiVersion: r.apiVersion, kind: r.kind, namespaced: scope !== 'cluster' });
+        }
         const knownGvks = [
-          ...new Map(
-            Object.values(this.resources)
-              .filter((r) => r.apiVersion && r.kind)
-              .map((r) => {
-                // Pull scope from WeakMap metadata — 'cluster' means
-                // cluster-scoped (Namespace, ClusterRole, etc.).
-                const scope = getMetadataField(r as object, 'scope');
-                return [
-                  `${r.apiVersion}/${r.kind}`,
-                  { apiVersion: r.apiVersion!, kind: r.kind!, namespaced: scope !== 'cluster' },
-                ] as const;
-              })
-          ).values(),
+          ...BUILT_IN_GVKS,
+          ...crdHints.values(),
         ];
         const record = await engine.loadDeploymentByInstance({
           factoryName: this.name,
           instanceName: name,
-          ...(knownGvks.length > 0 && { knownGvks }),
+          knownGvks,
         });
         if (!record) {
           throw new TypeKroError(

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -248,11 +248,12 @@ export class DirectResourceFactoryImpl<
           try {
             rollbackResult = await engine.rollback(deploymentId, opts?.scopes ? { scopes: opts.scopes } : {});
           } catch (error: unknown) {
-            const msg = ensureError(error).message;
-            // Fall through to path 2 (persisted lookup) when in-memory
-            // state is stale — the engine's Map may have been cleared
-            // by a previous rollback.
-            if (!msg.includes('not found') && !msg.includes('Cannot rollback')) {
+            // Fall through to path 2 (discovery) when in-memory state
+            // is stale — engine throws ResourceGraphFactoryError when
+            // the deployment ID isn't in its Map (cleared by a previous
+            // rollback or lost with the process). Any other error type
+            // is a real failure and should propagate.
+            if (!(error instanceof ResourceGraphFactoryError)) {
               throw error;
             }
           }

--- a/src/core/deployment/engine.ts
+++ b/src/core/deployment/engine.ts
@@ -1372,6 +1372,7 @@ export class DirectDeploymentEngine {
   async loadDeploymentByInstance(opts: {
     factoryName: string;
     instanceName: string;
+    knownGvks?: import('./deployment-state-discovery.js').GvkTarget[];
   }): Promise<DeploymentStateRecord | undefined> {
     return discoverDeployedResourcesByInstance(this.k8sApi, opts);
   }

--- a/src/core/deployment/engine.ts
+++ b/src/core/deployment/engine.ts
@@ -15,7 +15,7 @@ import { DependencyResolver } from '../dependencies/index.js';
 import { CircularDependencyError, ensureError, ResourceGraphFactoryError } from '../errors.js';
 import { createBunCompatibleKubernetesObjectApi } from '../kubernetes/index.js';
 import { getComponentLogger } from '../logging/index.js';
-import { copyResourceMetadata, getMetadataField, getResourceId as getResourceMetadataId } from '../metadata/index.js';
+import { copyResourceMetadata, getResourceId as getResourceMetadataId } from '../metadata/index.js';
 import { ensureReadinessEvaluator } from '../readiness/index.js';
 import { DeploymentMode, ReferenceResolver } from '../references/index.js';
 import { getResourceId } from '../resources/id.js';
@@ -45,7 +45,9 @@ import type {
 import { analyzeClosureDependencies, integrateClosuresIntoPlan } from './closure-planner.js';
 import { CRDManager } from './crd-manager.js';
 import { createDebugLoggerFromDeploymentOptions, type DebugLogger } from './debug-logger.js';
+import { discoverDeployedResourcesByInstance } from './deployment-state-discovery.js';
 import { createEventMonitor, type EventMonitor } from './event-monitor.js';
+import { getEffectiveScopes, shouldDeleteForScopes } from './resource-tagging.js';
 import { ResourceReadinessChecker } from './readiness.js';
 import { ReadinessWaiter } from './readiness-waiter.js';
 import { ResourceApplier } from './resource-applier.js';
@@ -320,7 +322,8 @@ export class DirectDeploymentEngine {
         options,
         startTime,
         deployedResources,
-        deploymentLogger
+        deploymentLogger,
+        deploymentId
       );
 
       // Deploy resources and closures level by level with proper dependency handling
@@ -367,7 +370,7 @@ export class DirectDeploymentEngine {
       await this.cleanupDeployment(deploymentAbortController, timeoutId, deploymentLogger);
 
       // Store deployment state for rollback
-      this.deploymentState.set(deploymentId, {
+      const successRecord: DeploymentStateRecord = {
         deploymentId,
         resources: deployedResources,
         dependencyGraph: graph.dependencyGraph,
@@ -380,7 +383,14 @@ export class DirectDeploymentEngine {
               ? 'completed'
               : 'failed',
         options,
-      });
+      };
+      this.deploymentState.set(deploymentId, successRecord);
+
+      // Note: cross-process state is persisted via per-resource labels
+      // and annotations applied during `deploySingleResource` — no
+      // separate state backend is written here. `factory.deleteInstance`
+      // in a later process rediscovers the set via label selector
+      // (see `deployment-state-discovery.ts`).
 
       return result;
     } catch (error: unknown) {
@@ -403,7 +413,7 @@ export class DirectDeploymentEngine {
       });
 
       // Store deployment state even for failed deployments (for rollback)
-      this.deploymentState.set(deploymentId, {
+      const failureRecord: DeploymentStateRecord = {
         deploymentId,
         resources: deployedResources,
         dependencyGraph: graph.dependencyGraph,
@@ -411,7 +421,12 @@ export class DirectDeploymentEngine {
         endTime: new Date(),
         status: 'failed',
         options,
-      });
+      };
+      this.deploymentState.set(deploymentId, failureRecord);
+      // Failed-deploy resources remain tagged on the cluster (tagging
+      // happens per-resource during apply), so cross-process cleanup
+      // via `factory.deleteInstance` can still discover and clean up
+      // the partial deployment — no separate persistence step needed.
 
       return {
         deploymentId,
@@ -489,7 +504,8 @@ export class DirectDeploymentEngine {
     options: DeploymentOptions,
     startTime: number,
     deployedResources: DeployedResource[],
-    deploymentLogger: ReturnType<typeof this.logger.child>
+    deploymentLogger: ReturnType<typeof this.logger.child>,
+    deploymentId: string
   ): Promise<{
     enhancedPlan: EnhancedDeploymentPlan;
     context: ResolutionContext;
@@ -562,8 +578,15 @@ export class DirectDeploymentEngine {
       deployedResources,
       kubeClient: this.kubeClient,
       resourceKeyMapping,
+      deploymentId,
       ...(options.namespace && { namespace: options.namespace }),
       timeout: options.timeout || DEFAULT_READINESS_TIMEOUT,
+      // Closure captures the dependency graph so the tagging step in
+      // `deploySingleResource` can stamp per-resource `depends-on`
+      // annotations without the engine having to thread the graph
+      // through every call site.
+      dependenciesForResource: (resourceId: string) =>
+        graph.dependencyGraph.getDependencies(resourceId),
     };
 
     return { enhancedPlan, context, resourceKeyMapping };
@@ -695,6 +718,22 @@ export class DirectDeploymentEngine {
         kind: resource.manifest?.kind,
         name: resource.manifest?.metadata?.name,
       });
+
+      // Scope-targeted deploy: when `targetScopes` is set on the
+      // options, skip resources whose effective scopes don't match
+      // the filter. This lets callers deploy only cluster-scoped
+      // operators or only instance-private resources. When
+      // `targetScopes` is undefined (the default), everything deploys.
+      if (options.targetScopes !== undefined) {
+        const resourceScopes = getEffectiveScopes(resource.manifest);
+        if (!shouldDeleteForScopes(resourceScopes, options.targetScopes)) {
+          resourceLogger.debug('Skipping resource: scope does not match targetScopes', {
+            resourceScopes,
+            targetScopes: options.targetScopes,
+          });
+          return { success: true, resourceId } as LevelDeploymentResult;
+        }
+      }
 
       try {
         resourceLogger.debug('Calling deploySingleResource');
@@ -1073,6 +1112,14 @@ export class DirectDeploymentEngine {
     // and namespace application create new plain objects, losing WeakMap entries.
     copyResourceMetadata(resource, resolvedResource);
 
+    // 2.5. Apply typekro ownership metadata (labels + annotations) so the
+    //      resource can be rediscovered across process boundaries and
+    //      so cross-process delete can respect scope membership. No-op
+    //      when options.factoryName / options.instanceName aren't set.
+    if (resourceId) {
+      this.resourceApplier.applyOwnershipTags(resolvedResource, options, resourceId, context);
+    }
+
     // 3. Apply the resource to the cluster (or simulate for dry run)
     await this.resourceApplier.applyResourceToCluster(resolvedResource, options, resourceLogger);
 
@@ -1117,9 +1164,10 @@ export class DirectDeploymentEngine {
    */
   private async rollbackDeployedResources(
     deployedResources: DeployedResource[],
-    options: DeploymentOptions
+    options: DeploymentOptions,
+    rollbackOpts?: { preOrdered?: boolean }
   ): Promise<{ rolledBackResources: string[]; errors: DeploymentError[] }> {
-    return this.rollbackManager.rollbackDeployedResources(deployedResources, options);
+    return this.rollbackManager.rollbackDeployedResources(deployedResources, options, rollbackOpts);
   }
 
   /**
@@ -1164,12 +1212,18 @@ export class DirectDeploymentEngine {
   }
 
   /**
-   * Rollback a deployment by ID
+   * Rollback a deployment by ID.
+   *
+   * Looks up the deployment record by ID in the in-memory state. Throws
+   * if the ID isn't found — callers that may be operating in a new
+   * process should use {@link rollbackRecord} with a record loaded via
+   * {@link loadDeploymentByInstance} instead.
    */
-  async rollback(deploymentId: string): Promise<RollbackResult> {
-    const startTime = Date.now();
+  async rollback(
+    deploymentId: string,
+    opts: { scopes?: string[] } = {}
+  ): Promise<RollbackResult> {
     const deploymentRecord = this.deploymentState.get(deploymentId);
-
     if (!deploymentRecord) {
       throw new ResourceGraphFactoryError(
         `Deployment ${deploymentId} not found. Cannot rollback.`,
@@ -1177,28 +1231,65 @@ export class DirectDeploymentEngine {
         'cleanup'
       );
     }
+    return this.rollbackRecord(deploymentRecord, opts);
+  }
 
+  /**
+   * Rollback a deployment from an externally-provided record.
+   *
+   * This is the graph-based delete core, factored out so it can be
+   * driven by either the in-memory {@link deploymentState} Map
+   * (same-process) OR a record loaded from the cluster via
+   * {@link loadDeploymentByInstance} (cross-process). Performs
+   * reverse-topological deletion with scope-aware filtering.
+   *
+   * ## Scope filtering
+   *
+   * Each resource has an effective scope set derived from WeakMap
+   * `scopes` metadata, the `typekro.io/scopes` annotation on the
+   * live manifest, and the legacy `lifecycle: 'shared'` alias.
+   *
+   * - Resources with an empty scope set are "instance-private" and
+   *   are always deleted.
+   * - Resources with a non-empty scope set are deleted ONLY when the
+   *   caller's `scopes` filter contains at least one of them. Default
+   *   filter is `[]` (empty), so shared resources are preserved by
+   *   default and require opt-in to tear down.
+   */
+  async rollbackRecord(
+    deploymentRecord: DeploymentStateRecord,
+    opts: { scopes?: string[] } = {}
+  ): Promise<RollbackResult> {
+    const startTime = Date.now();
+    const deploymentId = deploymentRecord.deploymentId;
+    const scopeFilter = opts.scopes ?? [];
     try {
+      // Determine which resources the caller's scope filter allows us
+      // to delete. Resources outside the filter (shared/scoped) are
+      // skipped — passed to analyzeDeletionOrder as `sharedIds` so the
+      // topological walk treats them as pinned nodes.
+      const skippedIds = new Set<string>();
+      for (const r of deploymentRecord.resources) {
+        const effectiveScopes = getEffectiveScopes(r.manifest);
+        if (!shouldDeleteForScopes(effectiveScopes, scopeFilter)) {
+          skippedIds.add(r.id);
+        }
+      }
+
       // Use graph-based reverse-topological deletion when the dependency
       // graph is available. This ensures dependents are deleted before their
       // dependencies (e.g., App before Database, Database before Namespace),
       // preventing finalizer deadlocks and stuck namespace termination.
       let orderedResources = deploymentRecord.resources;
       if (deploymentRecord.dependencyGraph) {
-        const sharedIds = new Set<string>();
-        for (const r of deploymentRecord.resources) {
-          if (getMetadataField(r.manifest, 'lifecycle') === 'shared') {
-            sharedIds.add(r.id);
-          }
-        }
         try {
           const deletionPlan = this.dependencyResolver.analyzeDeletionOrder(
             deploymentRecord.dependencyGraph,
-            sharedIds.size > 0 ? sharedIds : undefined
+            skippedIds.size > 0 ? skippedIds : undefined
           );
 
           // Map graph node IDs to DeployedResource objects in deletion order
-          const resourceMap = new Map(deploymentRecord.resources.map(r => [r.id, r]));
+          const resourceMap = new Map(deploymentRecord.resources.map((r) => [r.id, r]));
           orderedResources = [];
           for (const level of deletionPlan.levels) {
             for (const id of level) {
@@ -1211,24 +1302,37 @@ export class DirectDeploymentEngine {
             deploymentId,
             levels: deletionPlan.levels.length,
             resourceCount: orderedResources.length,
-            sharedSkipped: sharedIds.size,
+            scopeFilter,
+            skipped: skippedIds.size,
           });
         } catch (graphError: unknown) {
           this.logger.warn('Graph-based deletion order failed, falling back to reverse order', {
             error: ensureError(graphError).message,
           });
-          // Fall back to flat reverse order
-          orderedResources = [...deploymentRecord.resources].reverse();
+          // Fall back to flat reverse order, still honoring the scope
+          // filter by excluding skipped resources.
+          orderedResources = [...deploymentRecord.resources]
+            .reverse()
+            .filter((r) => !skippedIds.has(r.id));
         }
+      } else if (skippedIds.size > 0) {
+        // No graph — filter out skipped resources from the flat list.
+        orderedResources = deploymentRecord.resources.filter((r) => !skippedIds.has(r.id));
       }
 
       const { rolledBackResources, errors } = await this.rollbackDeployedResources(
         orderedResources,
-        deploymentRecord.options
+        deploymentRecord.options,
+        { preOrdered: true }
       );
 
       const status =
         errors.length === 0 ? 'success' : rolledBackResources.length > 0 ? 'partial' : 'failed';
+
+      // Remove from in-memory state. The cluster is the authoritative
+      // backend for cross-process cleanup, so no additional teardown of
+      // a separate state store is needed.
+      this.deploymentState.delete(deploymentId);
 
       return {
         deploymentId,
@@ -1254,6 +1358,22 @@ export class DirectDeploymentEngine {
         ],
       };
     }
+  }
+
+  /**
+   * Look up a deployment by factory + instance name via cluster-side
+   * label discovery. Used by the direct factory's `deleteInstance` to
+   * clean up deployments created in a previous process.
+   *
+   * Returns `undefined` when no tagged resources match — either the
+   * instance was already cleaned up, was never deployed, or was
+   * deployed by a typekro version that did not tag resources.
+   */
+  async loadDeploymentByInstance(opts: {
+    factoryName: string;
+    instanceName: string;
+  }): Promise<DeploymentStateRecord | undefined> {
+    return discoverDeployedResourcesByInstance(this.k8sApi, opts);
   }
 
   /**

--- a/src/core/deployment/engine.ts
+++ b/src/core/deployment/engine.ts
@@ -1164,10 +1164,16 @@ export class DirectDeploymentEngine {
    */
   private async rollbackDeployedResources(
     deployedResources: DeployedResource[],
-    options: DeploymentOptions,
-    rollbackOpts?: { preOrdered?: boolean }
+    options: DeploymentOptions
   ): Promise<{ rolledBackResources: string[]; errors: DeploymentError[] }> {
-    return this.rollbackManager.rollbackDeployedResources(deployedResources, options, rollbackOpts);
+    return this.rollbackManager.rollbackDeployedResources(deployedResources, options);
+  }
+
+  private async rollbackOrderedResources(
+    deployedResources: DeployedResource[],
+    options: DeploymentOptions
+  ): Promise<{ rolledBackResources: string[]; errors: DeploymentError[] }> {
+    return this.rollbackManager.rollbackOrderedResources(deployedResources, options);
   }
 
   /**
@@ -1320,10 +1326,9 @@ export class DirectDeploymentEngine {
         orderedResources = deploymentRecord.resources.filter((r) => !skippedIds.has(r.id));
       }
 
-      const { rolledBackResources, errors } = await this.rollbackDeployedResources(
+      const { rolledBackResources, errors } = await this.rollbackOrderedResources(
         orderedResources,
-        deploymentRecord.options,
-        { preOrdered: true }
+        deploymentRecord.options
       );
 
       const status =

--- a/src/core/deployment/engine.ts
+++ b/src/core/deployment/engine.ts
@@ -1329,10 +1329,12 @@ export class DirectDeploymentEngine {
       const status =
         errors.length === 0 ? 'success' : rolledBackResources.length > 0 ? 'partial' : 'failed';
 
-      // Remove from in-memory state. The cluster is the authoritative
-      // backend for cross-process cleanup, so no additional teardown of
-      // a separate state store is needed.
-      this.deploymentState.delete(deploymentId);
+      // Remove from in-memory state if present. Discovered records have
+      // synthetic IDs (e.g., "discovered-<ts>") that were never in the
+      // map — the delete is a harmless no-op for those.
+      if (this.deploymentState.has(deploymentId)) {
+        this.deploymentState.delete(deploymentId);
+      }
 
       return {
         deploymentId,

--- a/src/core/deployment/engine.ts
+++ b/src/core/deployment/engine.ts
@@ -1227,7 +1227,7 @@ export class DirectDeploymentEngine {
    */
   async rollback(
     deploymentId: string,
-    opts: { scopes?: string[] } = {}
+    opts: { scopes?: string[]; includeUnscopedResources?: boolean } = {}
   ): Promise<RollbackResult> {
     const deploymentRecord = this.deploymentState.get(deploymentId);
     if (!deploymentRecord) {
@@ -1264,11 +1264,12 @@ export class DirectDeploymentEngine {
    */
   async rollbackRecord(
     deploymentRecord: DeploymentStateRecord,
-    opts: { scopes?: string[] } = {}
+    opts: { scopes?: string[]; includeUnscopedResources?: boolean } = {}
   ): Promise<RollbackResult> {
     const startTime = Date.now();
     const deploymentId = deploymentRecord.deploymentId;
     const scopeFilter = opts.scopes ?? [];
+    const includeUnscoped = opts.includeUnscopedResources !== false;
     try {
       // Determine which resources the caller's scope filter allows us
       // to delete. Resources outside the filter (shared/scoped) are
@@ -1277,7 +1278,7 @@ export class DirectDeploymentEngine {
       const skippedIds = new Set<string>();
       for (const r of deploymentRecord.resources) {
         const effectiveScopes = getEffectiveScopes(r.manifest);
-        if (!scopesMatchFilter(effectiveScopes, scopeFilter)) {
+        if (!scopesMatchFilter(effectiveScopes, scopeFilter, includeUnscoped)) {
           skippedIds.add(r.id);
         }
       }

--- a/src/core/deployment/engine.ts
+++ b/src/core/deployment/engine.ts
@@ -47,7 +47,7 @@ import { CRDManager } from './crd-manager.js';
 import { createDebugLoggerFromDeploymentOptions, type DebugLogger } from './debug-logger.js';
 import { discoverDeployedResourcesByInstance } from './deployment-state-discovery.js';
 import { createEventMonitor, type EventMonitor } from './event-monitor.js';
-import { getEffectiveScopes, shouldDeleteForScopes } from './resource-tagging.js';
+import { getEffectiveScopes, scopesMatchFilter } from './resource-tagging.js';
 import { ResourceReadinessChecker } from './readiness.js';
 import { ReadinessWaiter } from './readiness-waiter.js';
 import { ResourceApplier } from './resource-applier.js';
@@ -726,7 +726,7 @@ export class DirectDeploymentEngine {
       // `targetScopes` is undefined (the default), everything deploys.
       if (options.targetScopes !== undefined) {
         const resourceScopes = getEffectiveScopes(resource.manifest);
-        if (!shouldDeleteForScopes(resourceScopes, options.targetScopes)) {
+        if (!scopesMatchFilter(resourceScopes, options.targetScopes)) {
           resourceLogger.debug('Skipping resource: scope does not match targetScopes', {
             resourceScopes,
             targetScopes: options.targetScopes,
@@ -1271,7 +1271,7 @@ export class DirectDeploymentEngine {
       const skippedIds = new Set<string>();
       for (const r of deploymentRecord.resources) {
         const effectiveScopes = getEffectiveScopes(r.manifest);
-        if (!shouldDeleteForScopes(effectiveScopes, scopeFilter)) {
+        if (!scopesMatchFilter(effectiveScopes, scopeFilter)) {
           skippedIds.add(r.id);
         }
       }

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -14,7 +14,7 @@ import {
   DEFAULT_RGD_TIMEOUT,
 } from '../config/defaults.js';
 import { CEL_EXPRESSION_BRAND } from '../constants/brands.js';
-import { CRDInstanceError, ensureError, ResourceGraphFactoryError } from '../errors.js';
+import { CRDInstanceError, ensureError, ResourceGraphFactoryError, TypeKroError } from '../errors.js';
 import type { KubernetesClientProvider } from '../kubernetes/client-provider.js';
 import { createBunCompatibleKubernetesObjectApi } from '../kubernetes/index.js';
 import { getComponentLogger } from '../logging/index.js';
@@ -179,9 +179,11 @@ export class KroResourceFactoryImpl<
    */
   async deploy(spec: TSpec, opts?: { targetScopes?: string[] }): Promise<Enhanced<TSpec, TStatus>> {
     if (opts?.targetScopes !== undefined) {
-      this.logger.warn('KRO mode does not support scope-targeted deployment — targetScopes option ignored', {
-        targetScopes: opts.targetScopes,
-      });
+      throw new TypeKroError(
+        'Scope-targeted deployment is not supported in KRO mode. KRO manages resource lifecycle via its own controller. Use direct mode for scope-targeted deploys.',
+        'UNSUPPORTED_OPTION',
+        { targetScopes: opts.targetScopes, mode: 'kro' }
+      );
     }
     // Validate spec against ArkType schema
     validateSpec(spec, this.schemaDefinition, {
@@ -565,10 +567,11 @@ export class KroResourceFactoryImpl<
    */
   async deleteInstance(name: string, opts?: { scopes?: string[] }): Promise<void> {
     if (opts?.scopes?.length) {
-      this.logger.warn('KRO mode does not support scope-filtered deletion — scopes option ignored', {
-        instanceName: name,
-        scopes: opts.scopes,
-      });
+      throw new TypeKroError(
+        'Scope-filtered deletion is not supported in KRO mode. KRO manages resource lifecycle via its own controller. Use direct mode for scope-filtered deletes.',
+        'UNSUPPORTED_OPTION',
+        { scopes: opts.scopes, instanceName: name, mode: 'kro' }
+      );
     }
     const kubeConfig = this.getKubeConfig();
     const k8sApi = createBunCompatibleKubernetesObjectApi(kubeConfig);

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -177,7 +177,12 @@ export class KroResourceFactoryImpl<
   /**
    * Deploy a new instance by creating a custom resource
    */
-  async deploy(spec: TSpec, _opts?: { targetScopes?: string[] }): Promise<Enhanced<TSpec, TStatus>> {
+  async deploy(spec: TSpec, opts?: { targetScopes?: string[] }): Promise<Enhanced<TSpec, TStatus>> {
+    if (opts?.targetScopes !== undefined) {
+      this.logger.warn('KRO mode does not support scope-targeted deployment — targetScopes option ignored', {
+        targetScopes: opts.targetScopes,
+      });
+    }
     // Validate spec against ArkType schema
     validateSpec(spec, this.schemaDefinition, {
       kind: this.schemaDefinition.kind,
@@ -558,7 +563,13 @@ export class KroResourceFactoryImpl<
   /**
    * Delete a specific instance by name
    */
-  async deleteInstance(name: string, _opts?: { scopes?: string[] }): Promise<void> {
+  async deleteInstance(name: string, opts?: { scopes?: string[] }): Promise<void> {
+    if (opts?.scopes?.length) {
+      this.logger.warn('KRO mode does not support scope-filtered deletion — scopes option ignored', {
+        instanceName: name,
+        scopes: opts.scopes,
+      });
+    }
     const kubeConfig = this.getKubeConfig();
     const k8sApi = createBunCompatibleKubernetesObjectApi(kubeConfig);
 

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -177,7 +177,7 @@ export class KroResourceFactoryImpl<
   /**
    * Deploy a new instance by creating a custom resource
    */
-  async deploy(spec: TSpec): Promise<Enhanced<TSpec, TStatus>> {
+  async deploy(spec: TSpec, _opts?: { targetScopes?: string[] }): Promise<Enhanced<TSpec, TStatus>> {
     // Validate spec against ArkType schema
     validateSpec(spec, this.schemaDefinition, {
       kind: this.schemaDefinition.kind,
@@ -558,7 +558,7 @@ export class KroResourceFactoryImpl<
   /**
    * Delete a specific instance by name
    */
-  async deleteInstance(name: string): Promise<void> {
+  async deleteInstance(name: string, _opts?: { scopes?: string[] }): Promise<void> {
     const kubeConfig = this.getKubeConfig();
     const k8sApi = createBunCompatibleKubernetesObjectApi(kubeConfig);
 

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -565,7 +565,7 @@ export class KroResourceFactoryImpl<
   /**
    * Delete a specific instance by name
    */
-  async deleteInstance(name: string, opts?: { scopes?: string[] }): Promise<void> {
+  async deleteInstance(name: string, opts?: { scopes?: string[]; includeUnscopedResources?: boolean }): Promise<void> {
     if (opts?.scopes?.length) {
       throw new TypeKroError(
         'Scope-filtered deletion is not supported in KRO mode. KRO manages resource lifecycle via its own controller. Use direct mode for scope-filtered deletes.',

--- a/src/core/deployment/resource-applier.ts
+++ b/src/core/deployment/resource-applier.ts
@@ -20,7 +20,11 @@ import {
 } from '../config/defaults.js';
 import { ensureError } from '../errors.js';
 import type { TypeKroLogger } from '../logging/index.js';
-import { copyResourceMetadata, getReadinessEvaluator } from '../metadata/index.js';
+import {
+  copyResourceMetadata,
+  getMetadataField,
+  getReadinessEvaluator,
+} from '../metadata/index.js';
 import type { ReferenceResolver } from '../references/index.js';
 import type { DeploymentOptions, ResolutionContext } from '../types/deployment.js';
 import type {
@@ -39,6 +43,7 @@ import {
   isUnsupportedMediaTypeError,
   patchResourceWithCorrectContentType,
 } from './k8s-helpers.js';
+import { applyTypekroTags } from './resource-tagging.js';
 
 export class ResourceApplier {
   constructor(
@@ -150,6 +155,53 @@ export class ResourceApplier {
     copyResourceMetadata(resource, newResource);
 
     return newResource;
+  }
+
+  /**
+   * Apply typekro ownership metadata (labels + annotations) to a resource
+   * manifest right before it's serialized and sent to the cluster.
+   *
+   * No-op when the deployment isn't tagged with factoryName + instanceName
+   * — untagged deployments don't participate in cross-process discovery
+   * and would pollute their resources with partial ownership metadata.
+   *
+   * Merges WeakMap `scopes` and the legacy `lifecycle: 'shared'` alias
+   * into the effective scope annotation so that delete-time discovery
+   * can respect them.
+   */
+  applyOwnershipTags(
+    resource: KubernetesResource,
+    options: DeploymentOptions,
+    resourceId: string,
+    context: ResolutionContext
+  ): void {
+    const { factoryName, instanceName } = options;
+    if (!factoryName || !instanceName) return;
+
+    const deploymentId = context.deploymentId;
+    if (!deploymentId) return;
+
+    // Compute the effective scopes: explicit `scopes` metadata
+    // plus the `lifecycle: 'shared'` alias treated as ['shared'].
+    const scopes: string[] = [];
+    const fromMeta = getMetadataField(resource as object, 'scopes');
+    if (fromMeta) scopes.push(...fromMeta);
+    const legacy = getMetadataField(resource as object, 'lifecycle');
+    if (legacy === 'shared' && !scopes.includes('shared')) {
+      scopes.push('shared');
+    }
+
+    const dependencies = context.dependenciesForResource?.(resourceId) ?? [];
+
+    applyTypekroTags(resource, {
+      factoryName,
+      instanceName,
+      deploymentId,
+      factoryNamespace: options.namespace ?? context.namespace ?? 'default',
+      resourceId,
+      ...(scopes.length > 0 && { scopes }),
+      ...(dependencies.length > 0 && { dependencies }),
+    });
   }
 
   /**

--- a/src/core/deployment/resource-applier.ts
+++ b/src/core/deployment/resource-applier.ts
@@ -22,7 +22,6 @@ import { ensureError } from '../errors.js';
 import type { TypeKroLogger } from '../logging/index.js';
 import {
   copyResourceMetadata,
-  getMetadataField,
   getReadinessEvaluator,
 } from '../metadata/index.js';
 import type { ReferenceResolver } from '../references/index.js';
@@ -43,7 +42,7 @@ import {
   isUnsupportedMediaTypeError,
   patchResourceWithCorrectContentType,
 } from './k8s-helpers.js';
-import { applyTypekroTags } from './resource-tagging.js';
+import { applyTypekroTags, getEffectiveScopes } from './resource-tagging.js';
 
 export class ResourceApplier {
   constructor(
@@ -165,9 +164,9 @@ export class ResourceApplier {
    * — untagged deployments don't participate in cross-process discovery
    * and would pollute their resources with partial ownership metadata.
    *
-   * Merges WeakMap `scopes` and the legacy `lifecycle: 'shared'` alias
-   * into the effective scope annotation so that delete-time discovery
-   * can respect them.
+   * Uses `getEffectiveScopes` from the tagging module as the single
+   * source of truth for scope computation — avoids duplicating the
+   * WeakMap + annotation + legacy-alias merge logic.
    */
   applyOwnershipTags(
     resource: KubernetesResource,
@@ -181,16 +180,7 @@ export class ResourceApplier {
     const deploymentId = context.deploymentId;
     if (!deploymentId) return;
 
-    // Compute the effective scopes: explicit `scopes` metadata
-    // plus the `lifecycle: 'shared'` alias treated as ['shared'].
-    const scopes: string[] = [];
-    const fromMeta = getMetadataField(resource as object, 'scopes');
-    if (fromMeta) scopes.push(...fromMeta);
-    const legacy = getMetadataField(resource as object, 'lifecycle');
-    if (legacy === 'shared' && !scopes.includes('shared')) {
-      scopes.push('shared');
-    }
-
+    const scopes = getEffectiveScopes(resource);
     const dependencies = context.dependenciesForResource?.(resourceId) ?? [];
 
     applyTypekroTags(resource, {

--- a/src/core/deployment/resource-tagging.ts
+++ b/src/core/deployment/resource-tagging.ts
@@ -260,30 +260,35 @@ export function getEffectiveScopes(resource: KubernetesResource): string[] {
 }
 
 /**
- * Decide whether a resource should be deleted given a scope filter.
+ * Decide whether a resource matches a scope filter.
  *
- * Semantics:
- *   - Instance-private resources (empty effective scopes) are ALWAYS
- *     deleted, regardless of the filter. They belong exclusively to
- *     the instance being torn down.
- *   - Scoped resources are deleted ONLY IF the filter explicitly
- *     includes at least one of their scopes. This protects shared
- *     infrastructure from being nuked by a default `deleteInstance`
- *     call.
+ * Used by both the deploy path (`targetScopes`) and the delete path
+ * (`deleteInstance` scopes). The semantics are additive:
  *
- * Examples:
- *   scopesMatchFilter([],            []) === true   // instance-private, always delete
- *   scopesMatchFilter([],            ['cluster']) === true   // instance-private even if filter is non-empty
- *   scopesMatchFilter(['cluster'],   []) === false  // shared, default delete skips it
- *   scopesMatchFilter(['cluster'],   ['cluster']) === true   // shared, explicit opt-in
- *   scopesMatchFilter(['cluster'],   ['team:platform']) === false  // wrong scope
- *   scopesMatchFilter(['cluster', 'team:platform'], ['cluster']) === true  // any match
+ *   - **Unscoped** resources (empty effective scopes) match when
+ *     `includeUnscoped` is `true` (the default). Set to `false` to
+ *     exclude them — useful when you want to tear down only shared
+ *     infrastructure without touching instance-private resources.
+ *   - **Scoped** resources match when ANY of their scopes appear in
+ *     the `scopeFilter`. An empty filter means "no broader scopes
+ *     targeted" — only unscoped resources pass.
+ *
+ * Examples (default includeUnscoped=true):
+ *   scopesMatchFilter([],            [])            === true   // unscoped, included by default
+ *   scopesMatchFilter([],            ['cluster'])   === true   // unscoped, still included
+ *   scopesMatchFilter(['cluster'],   [])            === false  // scoped, not targeted
+ *   scopesMatchFilter(['cluster'],   ['cluster'])   === true   // scoped, targeted
+ *
+ * With includeUnscoped=false:
+ *   scopesMatchFilter([],            ['cluster'], false) === false  // unscoped excluded
+ *   scopesMatchFilter(['cluster'],   ['cluster'], false) === true   // scoped still matches
  */
 export function scopesMatchFilter(
   resourceScopes: string[],
-  scopeFilter: string[]
+  scopeFilter: string[],
+  includeUnscoped = true
 ): boolean {
-  if (resourceScopes.length === 0) return true;
+  if (resourceScopes.length === 0) return includeUnscoped;
   return resourceScopes.some((s) => scopeFilter.includes(s));
 }
 

--- a/src/core/deployment/resource-tagging.ts
+++ b/src/core/deployment/resource-tagging.ts
@@ -272,14 +272,14 @@ export function getEffectiveScopes(resource: KubernetesResource): string[] {
  *     call.
  *
  * Examples:
- *   shouldDeleteForScopes([],            []) === true   // instance-private, always delete
- *   shouldDeleteForScopes([],            ['cluster']) === true   // instance-private even if filter is non-empty
- *   shouldDeleteForScopes(['cluster'],   []) === false  // shared, default delete skips it
- *   shouldDeleteForScopes(['cluster'],   ['cluster']) === true   // shared, explicit opt-in
- *   shouldDeleteForScopes(['cluster'],   ['team:platform']) === false  // wrong scope
- *   shouldDeleteForScopes(['cluster', 'team:platform'], ['cluster']) === true  // any match
+ *   scopesMatchFilter([],            []) === true   // instance-private, always delete
+ *   scopesMatchFilter([],            ['cluster']) === true   // instance-private even if filter is non-empty
+ *   scopesMatchFilter(['cluster'],   []) === false  // shared, default delete skips it
+ *   scopesMatchFilter(['cluster'],   ['cluster']) === true   // shared, explicit opt-in
+ *   scopesMatchFilter(['cluster'],   ['team:platform']) === false  // wrong scope
+ *   scopesMatchFilter(['cluster', 'team:platform'], ['cluster']) === true  // any match
  */
-export function shouldDeleteForScopes(
+export function scopesMatchFilter(
   resourceScopes: string[],
   scopeFilter: string[]
 ): boolean {
@@ -336,9 +336,12 @@ function parseJsonStringArray(value: string | undefined): string[] {
  * that need collision resistance should use the annotation form.
  */
 export function sanitiseLabelValue(value: string): string {
-  return value
+  const sanitised = value
     .toLowerCase()
     .replace(/[^a-z0-9._-]/g, '-')
     .slice(0, 63)
     .replace(/^[-._]+|[-._]+$/g, '');
+  // An empty string is an invalid K8s label value. Fall back to a
+  // deterministic placeholder so selectors don't break.
+  return sanitised || 'unknown';
 }

--- a/src/core/deployment/resource-tagging.ts
+++ b/src/core/deployment/resource-tagging.ts
@@ -1,0 +1,344 @@
+/**
+ * Resource Tagging
+ *
+ * Applies typekro-ownership metadata to Kubernetes resources at deploy time
+ * as labels and annotations, and extracts it back at delete time. This is
+ * the core of typekro's label-based deployment-state backend: the cluster
+ * IS the state, no separate ConfigMap record is kept.
+ *
+ * ## What gets tagged
+ *
+ * **Labels** (selector-queryable, constrained to 63-char DNS-label values):
+ *   - `typekro.io/managed-by=typekro` — claims ownership; acts as a broad
+ *     filter for "find everything typekro has deployed"
+ *   - `typekro.io/factory-name=<sanitized>` — scopes a resource to one
+ *     factory identity
+ *   - `typekro.io/instance-name=<sanitized>` — scopes a resource to one
+ *     deployed instance within a factory
+ *
+ * **Annotations** (arbitrary strings, used for state that exceeds label
+ * constraints or isn't selector-queried):
+ *   - `typekro.io/deployment-id=<uuid>` — groups resources from a single
+ *     deployment call
+ *   - `typekro.io/resource-id=<node-id>` — original composition-local
+ *     resource id (may differ from `metadata.name` and isn't DNS-constrained)
+ *   - `typekro.io/factory-name=<raw>` — unsanitized factory name for display
+ *     and exact-match comparisons (labels may be truncated/sanitized)
+ *   - `typekro.io/instance-name=<raw>` — same, for instance name
+ *   - `typekro.io/factory-namespace=<ns>` — the factory's "home" namespace
+ *     (where the factory was invoked from). Used by cross-namespace
+ *     discovery to narrow queries.
+ *   - `typekro.io/scopes=<json-array>` — JSON-encoded list of scope names
+ *     this resource belongs to (e.g., `["cluster"]`). Empty/absent means
+ *     "instance-private." See {@link getEffectiveScopes}.
+ *   - `typekro.io/depends-on=<json-array>` — JSON-encoded list of
+ *     composition-local resource ids that THIS resource depends on. Used
+ *     by discovery to reconstruct the dependency graph for reverse-
+ *     topological deletion without needing the original composition source.
+ *
+ * ## Why this design
+ *
+ * A prior iteration stored the deployment record in a ConfigMap in the
+ * factory namespace. That worked for cross-process cleanup but had
+ * drawbacks: the ConfigMap could drift from reality (e.g., a resource
+ * deleted manually leaves a dangling record), required a bootstrap
+ * namespace for the record to live in, and made multi-consumer ownership
+ * of shared resources ambiguous.
+ *
+ * Storing the state directly on the resources makes the cluster self-
+ * describing: `kubectl get all -l typekro.io/factory-name=X` returns the
+ * full set. No external index to keep in sync. Shared resources can
+ * carry tags from multiple owners naturally.
+ */
+
+import { getMetadataField } from '../metadata/index.js';
+import type { KubernetesResource } from '../types/kubernetes.js';
+
+// ── Label keys ────────────────────────────────────────────────────────────
+
+/** Label set on every resource deployed by typekro. */
+export const MANAGED_BY_LABEL = 'typekro.io/managed-by';
+export const MANAGED_BY_VALUE = 'typekro';
+
+/** Label identifying the factory that deployed this resource. */
+export const FACTORY_NAME_LABEL = 'typekro.io/factory-name';
+
+/** Label identifying the instance within a factory. */
+export const INSTANCE_NAME_LABEL = 'typekro.io/instance-name';
+
+// ── Annotation keys ───────────────────────────────────────────────────────
+
+/** Annotation carrying the deployment run id. */
+export const DEPLOYMENT_ID_ANNOTATION = 'typekro.io/deployment-id';
+
+/** Annotation carrying the composition-local resource id (pre-sanitization). */
+export const RESOURCE_ID_ANNOTATION = 'typekro.io/resource-id';
+
+/** Annotation carrying the raw (unsanitized) factory name. */
+export const FACTORY_NAME_ANNOTATION = 'typekro.io/factory-name';
+
+/** Annotation carrying the raw (unsanitized) instance name. */
+export const INSTANCE_NAME_ANNOTATION = 'typekro.io/instance-name';
+
+/** Annotation carrying the factory's home namespace. */
+export const FACTORY_NAMESPACE_ANNOTATION = 'typekro.io/factory-namespace';
+
+/** Annotation carrying scope membership as a JSON array of strings. */
+export const SCOPES_ANNOTATION = 'typekro.io/scopes';
+
+/** Annotation carrying dependency ids as a JSON array of strings. */
+export const DEPENDS_ON_ANNOTATION = 'typekro.io/depends-on';
+
+// ── Tagging context and API ───────────────────────────────────────────────
+
+/**
+ * Everything needed to stamp a resource with its typekro ownership
+ * metadata at deploy time.
+ */
+export interface TagContext {
+  /** Factory identifier (raw, pre-sanitization). */
+  factoryName: string;
+  /** Instance identifier (raw, pre-sanitization). */
+  instanceName: string;
+  /** Deployment run id — usually the engine's generated `deployment-<ts>-<rand>`. */
+  deploymentId: string;
+  /** The factory's home namespace — where it was invoked from. */
+  factoryNamespace: string;
+  /** The composition-local resource id (graph node id). */
+  resourceId: string;
+  /**
+   * Scope names this resource belongs to. Empty or undefined means
+   * "instance-private — delete on deleteInstance by default."
+   */
+  scopes?: string[];
+  /**
+   * IDs of resources this resource depends on (from the dependency graph).
+   * Used for reverse-topological deletion reconstruction.
+   */
+  dependencies?: string[];
+}
+
+/**
+ * Apply typekro ownership metadata to a resource manifest. Mutates
+ * `manifest.metadata.labels` and `manifest.metadata.annotations` in place.
+ *
+ * Called from the deploy path right before the resource is serialized and
+ * sent to the cluster. The manifest at that point is a plain object (post
+ * reference-resolution and namespace-application), so in-place mutation is
+ * safe and avoids an extra clone.
+ *
+ * Existing user-set labels and annotations are preserved — only the
+ * `typekro.io/*` keys are added or overwritten.
+ */
+export function applyTypekroTags(manifest: KubernetesResource, ctx: TagContext): void {
+  if (!manifest.metadata) {
+    (manifest as unknown as { metadata: Record<string, unknown> }).metadata = {};
+  }
+  const metadata = manifest.metadata as unknown as {
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+
+  metadata.labels = { ...(metadata.labels ?? {}) };
+  metadata.annotations = { ...(metadata.annotations ?? {}) };
+
+  // Labels: sanitized, DNS-label-compatible
+  metadata.labels[MANAGED_BY_LABEL] = MANAGED_BY_VALUE;
+  metadata.labels[FACTORY_NAME_LABEL] = sanitiseLabelValue(ctx.factoryName);
+  metadata.labels[INSTANCE_NAME_LABEL] = sanitiseLabelValue(ctx.instanceName);
+
+  // Annotations: raw values + state that can't fit in labels
+  metadata.annotations[FACTORY_NAME_ANNOTATION] = ctx.factoryName;
+  metadata.annotations[INSTANCE_NAME_ANNOTATION] = ctx.instanceName;
+  metadata.annotations[FACTORY_NAMESPACE_ANNOTATION] = ctx.factoryNamespace;
+  metadata.annotations[DEPLOYMENT_ID_ANNOTATION] = ctx.deploymentId;
+  metadata.annotations[RESOURCE_ID_ANNOTATION] = ctx.resourceId;
+
+  if (ctx.scopes && ctx.scopes.length > 0) {
+    metadata.annotations[SCOPES_ANNOTATION] = JSON.stringify(ctx.scopes);
+  }
+  if (ctx.dependencies && ctx.dependencies.length > 0) {
+    metadata.annotations[DEPENDS_ON_ANNOTATION] = JSON.stringify(ctx.dependencies);
+  }
+}
+
+// ── Extraction (used by discovery / delete path) ──────────────────────────
+
+/**
+ * Parsed typekro ownership metadata extracted from a live resource's
+ * labels and annotations. Shape mirrors {@link TagContext} but with the
+ * nullable fields explicit, because labels/annotations may be missing
+ * (e.g., if a resource was tagged by an older typekro version).
+ */
+export interface ExtractedTags {
+  factoryName?: string;
+  instanceName?: string;
+  factoryNamespace?: string;
+  deploymentId?: string;
+  resourceId?: string;
+  scopes: string[];
+  dependencies: string[];
+}
+
+/**
+ * Extract typekro metadata from a live Kubernetes resource. The live
+ * resource is whatever the server returned from a list/read call —
+ * `metadata.labels` and `metadata.annotations` are plain records.
+ *
+ * Never throws: malformed annotations (bad JSON, wrong types) are
+ * silently ignored and return empty defaults. The caller should treat
+ * missing fields as "we don't know" rather than "the resource is
+ * un-owned," because this function is invoked on resources that matched
+ * a label selector upstream.
+ */
+export function extractTypekroTags(
+  resource: { metadata?: { labels?: Record<string, string>; annotations?: Record<string, string> } }
+): ExtractedTags {
+  const labels = resource.metadata?.labels ?? {};
+  const annotations = resource.metadata?.annotations ?? {};
+
+  // Prefer annotations for raw values (they aren't sanitized); fall
+  // back to labels so we still get a usable value when annotations are
+  // stripped by a downstream mutator.
+  const factoryName = annotations[FACTORY_NAME_ANNOTATION] ?? labels[FACTORY_NAME_LABEL];
+  const instanceName = annotations[INSTANCE_NAME_ANNOTATION] ?? labels[INSTANCE_NAME_LABEL];
+
+  return {
+    ...(factoryName !== undefined && { factoryName }),
+    ...(instanceName !== undefined && { instanceName }),
+    ...(annotations[FACTORY_NAMESPACE_ANNOTATION] !== undefined && {
+      factoryNamespace: annotations[FACTORY_NAMESPACE_ANNOTATION],
+    }),
+    ...(annotations[DEPLOYMENT_ID_ANNOTATION] !== undefined && {
+      deploymentId: annotations[DEPLOYMENT_ID_ANNOTATION],
+    }),
+    ...(annotations[RESOURCE_ID_ANNOTATION] !== undefined && {
+      resourceId: annotations[RESOURCE_ID_ANNOTATION],
+    }),
+    scopes: parseJsonStringArray(annotations[SCOPES_ANNOTATION]),
+    dependencies: parseJsonStringArray(annotations[DEPENDS_ON_ANNOTATION]),
+  };
+}
+
+/**
+ * Compute the effective scope set for a resource, merging three sources:
+ *
+ *   1. `typekro.io/scopes` annotation on the live manifest (the
+ *      canonical cluster-side source, used by cross-process delete).
+ *   2. WeakMap `scopes` metadata set via `setMetadataField` in-process
+ *      (used when the resource is still in memory and hasn't been
+ *      tagged on-cluster yet — e.g., during deploy).
+ *   3. The legacy `lifecycle: 'shared'` alias, which is equivalent to
+ *      `scopes: ['shared']`.
+ *
+ * Returns an empty array if the resource is "instance-private" (no
+ * scopes from any source).
+ */
+export function getEffectiveScopes(resource: KubernetesResource): string[] {
+  const scopes = new Set<string>();
+
+  // 1. Annotation (authoritative for on-cluster resources)
+  const annotation = resource.metadata?.annotations?.[SCOPES_ANNOTATION];
+  for (const s of parseJsonStringArray(annotation)) scopes.add(s);
+
+  // 2. WeakMap metadata (in-process deploy path)
+  const fromMeta = getMetadataField(resource as object, 'scopes');
+  if (fromMeta) {
+    for (const s of fromMeta) scopes.add(s);
+  }
+
+  // 3. Legacy lifecycle alias
+  const legacy = getMetadataField(resource as object, 'lifecycle');
+  if (legacy === 'shared') scopes.add('shared');
+
+  // 4. Annotation-based legacy: `typekro.io/lifecycle: shared` from any
+  //    pre-scopes deployment is also treated as `['shared']`.
+  const lifecycleAnn = resource.metadata?.annotations?.['typekro.io/lifecycle'];
+  if (lifecycleAnn === 'shared') scopes.add('shared');
+
+  return Array.from(scopes);
+}
+
+/**
+ * Decide whether a resource should be deleted given a scope filter.
+ *
+ * Semantics:
+ *   - Instance-private resources (empty effective scopes) are ALWAYS
+ *     deleted, regardless of the filter. They belong exclusively to
+ *     the instance being torn down.
+ *   - Scoped resources are deleted ONLY IF the filter explicitly
+ *     includes at least one of their scopes. This protects shared
+ *     infrastructure from being nuked by a default `deleteInstance`
+ *     call.
+ *
+ * Examples:
+ *   shouldDeleteForScopes([],            []) === true   // instance-private, always delete
+ *   shouldDeleteForScopes([],            ['cluster']) === true   // instance-private even if filter is non-empty
+ *   shouldDeleteForScopes(['cluster'],   []) === false  // shared, default delete skips it
+ *   shouldDeleteForScopes(['cluster'],   ['cluster']) === true   // shared, explicit opt-in
+ *   shouldDeleteForScopes(['cluster'],   ['team:platform']) === false  // wrong scope
+ *   shouldDeleteForScopes(['cluster', 'team:platform'], ['cluster']) === true  // any match
+ */
+export function shouldDeleteForScopes(
+  resourceScopes: string[],
+  scopeFilter: string[]
+): boolean {
+  if (resourceScopes.length === 0) return true;
+  return resourceScopes.some((s) => scopeFilter.includes(s));
+}
+
+// ── Label selector construction ───────────────────────────────────────────
+
+/**
+ * Build a label selector string for locating all resources belonging to
+ * a specific factory + instance. Used by the discovery path at delete
+ * time.
+ */
+export function buildFactoryInstanceSelector(opts: {
+  factoryName: string;
+  instanceName: string;
+}): string {
+  return [
+    `${MANAGED_BY_LABEL}=${MANAGED_BY_VALUE}`,
+    `${FACTORY_NAME_LABEL}=${sanitiseLabelValue(opts.factoryName)}`,
+    `${INSTANCE_NAME_LABEL}=${sanitiseLabelValue(opts.instanceName)}`,
+  ].join(',');
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Parse a JSON-encoded string array annotation. Returns an empty array
+ * on any parsing failure (missing, non-JSON, wrong shape) — this is
+ * intentional: a broken annotation should not crash the rollback path.
+ */
+function parseJsonStringArray(value: string | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed) && parsed.every((v) => typeof v === 'string')) {
+      return parsed as string[];
+    }
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Sanitise a string for use as a Kubernetes label value. Labels must be
+ * DNS-label-compatible (alphanumeric + `-`, `_`, `.`, max 63 chars) and
+ * must start+end with an alphanumeric. Replace anything else with `-`
+ * and truncate.
+ *
+ * Note: this is not collision-free — two factory names that differ only
+ * in disallowed characters will sanitise to the same value. Callers
+ * that need collision resistance should use the annotation form.
+ */
+export function sanitiseLabelValue(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, '-')
+    .slice(0, 63)
+    .replace(/^[-._]+|[-._]+$/g, '');
+}

--- a/src/core/deployment/rollback-manager.ts
+++ b/src/core/deployment/rollback-manager.ts
@@ -14,7 +14,7 @@ import {
 import { DeploymentTimeoutError, ensureError, TypeKroError } from '../errors.js';
 import { createBunCompatibleKubernetesObjectApi } from '../kubernetes/index.js';
 import { getComponentLogger } from '../logging/index.js';
-import { getMetadataField } from '../metadata/resource-metadata.js';
+import { getEffectiveScopes } from './resource-tagging.js';
 import type {
   DeployedResource,
   DeploymentError,
@@ -310,13 +310,21 @@ export class ResourceRollbackManager {
   }
 
   /**
-   * Rollback deployed resources by deleting them in reverse order.
-   * Skips resources that failed to deploy. Used by the deployment engine
-   * for rollback-on-failure during level-based deployment.
+   * Rollback deployed resources by deleting them.
+   *
+   * When called from `engine.rollbackRecord`, the resources are ALREADY
+   * in reverse-topological deletion order and scope filtering has ALREADY
+   * been applied. Pass `preOrdered: true` to skip the reverse + scope
+   * check so we don't double-reverse or double-filter.
+   *
+   * When called from the deploy-failure rollback path, resources are in
+   * deployment order and scope filtering hasn't been applied. The default
+   * (`preOrdered: false`) reverses and filters.
    */
   async rollbackDeployedResources(
     deployedResources: DeployedResource[],
-    options: DeploymentOptions
+    options: DeploymentOptions,
+    rollbackOpts?: { preOrdered?: boolean }
   ): Promise<{ rolledBackResources: string[]; errors: DeploymentError[] }> {
     this.emitDeploymentEvent(options, {
       type: 'rollback',
@@ -327,21 +335,30 @@ export class ResourceRollbackManager {
     const rolledBackResources: string[] = [];
     const errors: DeploymentError[] = [];
 
-    // Rollback in reverse order
-    const reversedResources = [...deployedResources].reverse();
+    const preOrdered = rollbackOpts?.preOrdered === true;
+    // When resources are pre-ordered (from rollbackRecord), trust the
+    // ordering and scope selection as-is. Otherwise reverse to get
+    // reverse-deployment order and apply scope filtering.
+    const resources = preOrdered
+      ? deployedResources
+      : [...deployedResources].reverse();
 
-    for (const resource of reversedResources) {
+    for (const resource of resources) {
       // Only try to rollback resources that were actually deployed (not failed)
       if (resource.status === 'failed') {
         continue; // Skip resources that failed to deploy
       }
 
-      // Skip shared resources — they survive instance deletion (e.g., HelmRepository in flux-system)
-      if (getMetadataField(resource.manifest, 'lifecycle') === 'shared') {
-        this.logger.debug('Skipping shared resource during rollback', {
+      // Skip scoped resources when NOT pre-ordered. When pre-ordered,
+      // scope filtering was already applied by the engine's
+      // rollbackRecord — don't re-filter or we'd silently drop
+      // scoped resources the caller explicitly targeted.
+      if (!preOrdered && getEffectiveScopes(resource.manifest).length > 0) {
+        this.logger.debug('Skipping scoped resource during rollback', {
           resourceId: resource.id,
           kind: resource.kind,
           name: resource.name,
+          scopes: getEffectiveScopes(resource.manifest),
         });
         continue;
       }
@@ -379,19 +396,15 @@ export class ResourceRollbackManager {
   }
 
   /**
-   * Delete a single deployed resource from the cluster and wait for deletion to complete.
+   * Delete a single deployed resource from the cluster and wait for
+   * deletion to complete.
+   *
+   * This method does NOT perform scope filtering — the caller (typically
+   * `engine.rollbackRecord`) is responsible for deciding which resources
+   * should be deleted. Filtering at this level would silently drop
+   * resources that the caller explicitly targeted for deletion.
    */
   async deleteDeployedResource(resource: DeployedResource): Promise<void> {
-    // Skip shared resources — they survive instance deletion
-    if (getMetadataField(resource.manifest, 'lifecycle') === 'shared') {
-      this.logger.debug('Skipping shared resource deletion', {
-        resourceId: resource.id,
-        kind: resource.kind,
-        name: resource.name,
-      });
-      return;
-    }
-
     const deleteLogger = this.logger.child({
       resourceId: resource.id,
       kind: resource.kind,

--- a/src/core/deployment/rollback-manager.ts
+++ b/src/core/deployment/rollback-manager.ts
@@ -334,12 +334,13 @@ export class ResourceRollbackManager {
     const filtered = [...deployedResources]
       .reverse()
       .filter((r) => {
-        if (getEffectiveScopes(r.manifest).length > 0) {
+        const scopes = getEffectiveScopes(r.manifest);
+        if (scopes.length > 0) {
           this.logger.debug('Skipping scoped resource during rollback', {
             resourceId: r.id,
             kind: r.kind,
             name: r.name,
-            scopes: getEffectiveScopes(r.manifest),
+            scopes,
           });
           return false;
         }

--- a/src/core/deployment/rollback-manager.ts
+++ b/src/core/deployment/rollback-manager.ts
@@ -310,21 +310,51 @@ export class ResourceRollbackManager {
   }
 
   /**
-   * Rollback deployed resources by deleting them.
-   *
-   * When called from `engine.rollbackRecord`, the resources are ALREADY
-   * in reverse-topological deletion order and scope filtering has ALREADY
-   * been applied. Pass `preOrdered: true` to skip the reverse + scope
-   * check so we don't double-reverse or double-filter.
-   *
-   * When called from the deploy-failure rollback path, resources are in
-   * deployment order and scope filtering hasn't been applied. The default
-   * (`preOrdered: false`) reverses and filters.
+   * Rollback resources that are already in the correct deletion order
+   * with scope filtering already applied. Used by `engine.rollbackRecord`
+   * which computes reverse-topological order and scope exclusions.
+   */
+  async rollbackOrderedResources(
+    deployedResources: DeployedResource[],
+    options: DeploymentOptions
+  ): Promise<{ rolledBackResources: string[]; errors: DeploymentError[] }> {
+    return this.deleteResourceList(deployedResources, options);
+  }
+
+  /**
+   * Rollback resources in reverse-deployment order, skipping scoped
+   * resources. Used by the deploy-failure auto-rollback path where
+   * resources are in deployment order and scope filtering hasn't been
+   * applied.
    */
   async rollbackDeployedResources(
     deployedResources: DeployedResource[],
-    options: DeploymentOptions,
-    rollbackOpts?: { preOrdered?: boolean }
+    options: DeploymentOptions
+  ): Promise<{ rolledBackResources: string[]; errors: DeploymentError[] }> {
+    const filtered = [...deployedResources]
+      .reverse()
+      .filter((r) => {
+        if (getEffectiveScopes(r.manifest).length > 0) {
+          this.logger.debug('Skipping scoped resource during rollback', {
+            resourceId: r.id,
+            kind: r.kind,
+            name: r.name,
+            scopes: getEffectiveScopes(r.manifest),
+          });
+          return false;
+        }
+        return true;
+      });
+    return this.deleteResourceList(filtered, options);
+  }
+
+  /**
+   * Core deletion loop — iterates the resource list in order, deleting
+   * each non-failed resource. Shared by both ordered and unordered paths.
+   */
+  private async deleteResourceList(
+    resources: DeployedResource[],
+    options: DeploymentOptions
   ): Promise<{ rolledBackResources: string[]; errors: DeploymentError[] }> {
     this.emitDeploymentEvent(options, {
       type: 'rollback',
@@ -335,33 +365,8 @@ export class ResourceRollbackManager {
     const rolledBackResources: string[] = [];
     const errors: DeploymentError[] = [];
 
-    const preOrdered = rollbackOpts?.preOrdered === true;
-    // When resources are pre-ordered (from rollbackRecord), trust the
-    // ordering and scope selection as-is. Otherwise reverse to get
-    // reverse-deployment order and apply scope filtering.
-    const resources = preOrdered
-      ? deployedResources
-      : [...deployedResources].reverse();
-
     for (const resource of resources) {
-      // Only try to rollback resources that were actually deployed (not failed)
-      if (resource.status === 'failed') {
-        continue; // Skip resources that failed to deploy
-      }
-
-      // Skip scoped resources when NOT pre-ordered. When pre-ordered,
-      // scope filtering was already applied by the engine's
-      // rollbackRecord — don't re-filter or we'd silently drop
-      // scoped resources the caller explicitly targeted.
-      if (!preOrdered && getEffectiveScopes(resource.manifest).length > 0) {
-        this.logger.debug('Skipping scoped resource during rollback', {
-          resourceId: resource.id,
-          kind: resource.kind,
-          name: resource.name,
-          scopes: getEffectiveScopes(resource.manifest),
-        });
-        continue;
-      }
+      if (resource.status === 'failed') continue;
 
       try {
         await this.k8sApi.delete({
@@ -375,7 +380,6 @@ export class ResourceRollbackManager {
 
         rolledBackResources.push(`${resource.kind}/${resource.name}`);
       } catch (error: unknown) {
-        // Log and collect errors for individual resource deletion failures
         this.logger.warn('Failed to delete resource during rollback', {
           error: ensureError(error),
           resourceId: resource.id,

--- a/src/core/deployment/strategies/base-strategy.ts
+++ b/src/core/deployment/strategies/base-strategy.ts
@@ -41,6 +41,8 @@ export abstract class BaseDeploymentStrategy<
 > implements DeploymentStrategy<TSpec, TStatus>
 {
   protected readonly logger = getComponentLogger('deployment-strategy');
+  /** Set by the factory before deploy() when the caller passes targetScopes. */
+  private _targetScopes: string[] | undefined = undefined;
 
   constructor(
     protected factoryName: string,
@@ -50,6 +52,18 @@ export abstract class BaseDeploymentStrategy<
     protected resourceKeys?: Record<string, KubernetesResource>,
     protected factoryOptions: FactoryOptions = {}
   ) {}
+
+  /** Set scope filter for the next deploy call, then auto-clears. */
+  setTargetScopes(scopes: string[]): void {
+    this._targetScopes = scopes;
+  }
+
+  /** Consume and clear the targetScopes. */
+  protected consumeTargetScopes(): string[] | undefined {
+    const scopes = this._targetScopes;
+    this._targetScopes = undefined;
+    return scopes;
+  }
 
   /**
    * Template method for deployment - defines the common flow

--- a/src/core/deployment/strategies/base-strategy.ts
+++ b/src/core/deployment/strategies/base-strategy.ts
@@ -25,11 +25,16 @@ import { createEnhancedMetadata, generateInstanceName, validateSpec } from '../s
 /**
  * Base deployment strategy interface
  */
+/** Options threaded from `factory.deploy(spec, opts)` to the strategy. */
+export interface DeployStrategyOptions {
+  targetScopes?: string[];
+}
+
 export interface DeploymentStrategy<
   TSpec extends KroCompatibleType,
   TStatus extends KroCompatibleType,
 > {
-  deploy(spec: TSpec): Promise<Enhanced<TSpec, TStatus>>;
+  deploy(spec: TSpec, opts?: DeployStrategyOptions): Promise<Enhanced<TSpec, TStatus>>;
 }
 
 /**
@@ -41,8 +46,6 @@ export abstract class BaseDeploymentStrategy<
 > implements DeploymentStrategy<TSpec, TStatus>
 {
   protected readonly logger = getComponentLogger('deployment-strategy');
-  /** Set by the factory before deploy() when the caller passes targetScopes. */
-  private _targetScopes: string[] | undefined = undefined;
 
   constructor(
     protected factoryName: string,
@@ -53,22 +56,13 @@ export abstract class BaseDeploymentStrategy<
     protected factoryOptions: FactoryOptions = {}
   ) {}
 
-  /** Set scope filter for the next deploy call, then auto-clears. */
-  setTargetScopes(scopes: string[]): void {
-    this._targetScopes = scopes;
-  }
-
-  /** Consume and clear the targetScopes. */
-  protected consumeTargetScopes(): string[] | undefined {
-    const scopes = this._targetScopes;
-    this._targetScopes = undefined;
-    return scopes;
-  }
-
   /**
    * Template method for deployment - defines the common flow
    */
-  async deploy(spec: TSpec): Promise<Enhanced<TSpec, TStatus>> {
+  async deploy(
+    spec: TSpec,
+    opts?: DeployStrategyOptions
+  ): Promise<Enhanced<TSpec, TStatus>> {
     this.logger.debug('Base strategy deploy called', {
       factoryName: this.factoryName,
       hasStatusBuilder: !!this.statusBuilder,
@@ -87,7 +81,7 @@ export abstract class BaseDeploymentStrategy<
     });
 
     // Step 3: Execute strategy-specific deployment
-    const deploymentResult = await this.executeDeployment(spec, instanceName);
+    const deploymentResult = await this.executeDeployment(spec, instanceName, opts);
 
     // Step 4: Create Enhanced proxy (common to all strategies)
     return await this.createEnhancedProxy(spec, instanceName, deploymentResult);
@@ -98,7 +92,8 @@ export abstract class BaseDeploymentStrategy<
    */
   protected abstract executeDeployment(
     spec: TSpec,
-    instanceName: string
+    instanceName: string,
+    opts?: DeployStrategyOptions
   ): Promise<DeploymentResult>;
 
   /**

--- a/src/core/deployment/strategies/direct-strategy.ts
+++ b/src/core/deployment/strategies/direct-strategy.ts
@@ -50,17 +50,22 @@ export class DirectDeploymentStrategy<
     super(factoryName, namespace, schemaDefinition, statusBuilder, resourceKeys, factoryOptions);
   }
 
-  protected async executeDeployment(spec: TSpec, _instanceName: string): Promise<DeploymentResult> {
+  protected async executeDeployment(spec: TSpec, instanceName: string): Promise<DeploymentResult> {
     try {
       // Create resource graph for this instance
       const resourceGraph = this.resourceResolver.createResourceGraphForInstance(spec);
 
-      // Create deployment options
-      const deploymentOptions = createDeploymentOptions(
-        this.factoryOptions,
-        this.namespace,
-        'direct'
-      );
+      // Create deployment options. Tag the options with factoryName +
+      // instanceName so the engine stamps every resource with ownership
+      // labels — this enables cross-process cleanup via
+      // `factory.deleteInstance` from a later bun process.
+      const targetScopes = this.consumeTargetScopes();
+      const deploymentOptions = {
+        ...createDeploymentOptions(this.factoryOptions, this.namespace, 'direct'),
+        factoryName: this.factoryName,
+        instanceName,
+        ...(targetScopes !== undefined && { targetScopes }),
+      };
 
       // Pass closures to deployment engine for level-based execution
       const closures = this.factoryOptions.closures || {};

--- a/src/core/deployment/strategies/direct-strategy.ts
+++ b/src/core/deployment/strategies/direct-strategy.ts
@@ -50,7 +50,11 @@ export class DirectDeploymentStrategy<
     super(factoryName, namespace, schemaDefinition, statusBuilder, resourceKeys, factoryOptions);
   }
 
-  protected async executeDeployment(spec: TSpec, instanceName: string): Promise<DeploymentResult> {
+  protected async executeDeployment(
+    spec: TSpec,
+    instanceName: string,
+    opts?: import('./base-strategy.js').DeployStrategyOptions
+  ): Promise<DeploymentResult> {
     try {
       // Create resource graph for this instance
       const resourceGraph = this.resourceResolver.createResourceGraphForInstance(spec);
@@ -59,12 +63,11 @@ export class DirectDeploymentStrategy<
       // instanceName so the engine stamps every resource with ownership
       // labels — this enables cross-process cleanup via
       // `factory.deleteInstance` from a later bun process.
-      const targetScopes = this.consumeTargetScopes();
       const deploymentOptions = {
         ...createDeploymentOptions(this.factoryOptions, this.namespace, 'direct'),
         factoryName: this.factoryName,
         instanceName,
-        ...(targetScopes !== undefined && { targetScopes }),
+        ...(opts?.targetScopes !== undefined && { targetScopes: opts.targetScopes }),
       };
 
       // Pass closures to deployment engine for level-based execution

--- a/src/core/metadata/resource-metadata.ts
+++ b/src/core/metadata/resource-metadata.ts
@@ -45,8 +45,30 @@ export interface ResourceMetadata {
   templateOverrides?: Array<{ propertyPath: string; celExpression: string }>;
   /** Kubernetes scope — 'cluster' for cluster-scoped resources (Namespace, ClusterRole, etc.) */
   scope?: 'namespaced' | 'cluster';
-  /** Resource lifecycle — 'shared' resources survive instance deletion (e.g., HelmRepository in flux-system) */
+  /**
+   * Deprecated alias for `scopes`. `lifecycle: 'shared'` is equivalent to
+   * `scopes: ['shared']`. New code should use `scopes` directly.
+   */
   lifecycle?: 'managed' | 'shared';
+  /**
+   * Deletion scopes this resource belongs to. Used by `factory.deleteInstance`
+   * to limit blast radius:
+   *
+   * - Empty / undefined → resource is "instance-private" and is deleted by
+   *   default when its owning instance is torn down.
+   * - Non-empty → resource also belongs to these broader lifecycles. On
+   *   delete, it is *only* removed if the caller explicitly targets one of
+   *   its scopes (via `deleteInstance(name, { scopes: [...] })`).
+   *
+   * Scope names are free-form strings; common conventions are `'cluster'`
+   * for cluster-wide singletons (e.g., operators installed by a bootstrap),
+   * `'team:<name>'` for team-shared infra, etc.
+   *
+   * Also serialized at deploy time into the `typekro.io/scopes` annotation
+   * on the live cluster object so that cross-process deletion can recover
+   * the scopes without access to the original composition.
+   */
+  scopes?: string[];
 }
 
 /** Keys of ResourceMetadata that are valid metadata field names */

--- a/src/core/types/deployment.ts
+++ b/src/core/types/deployment.ts
@@ -674,7 +674,7 @@ export interface ResourceFactory<
 
   // Instance management
   getInstances(): Promise<Enhanced<TSpec, TStatus>[]>;
-  deleteInstance(name: string, opts?: { scopes?: string[] }): Promise<void>;
+  deleteInstance(name: string, opts?: { scopes?: string[]; includeUnscopedResources?: boolean }): Promise<void>;
   getStatus(): Promise<FactoryStatus>;
 
   // Metadata

--- a/src/core/types/deployment.ts
+++ b/src/core/types/deployment.ts
@@ -259,7 +259,7 @@ export interface DeploymentOptions extends BaseDeploymentConfig {
    * are silently skipped — not an error, just not part of this deploy.
    *
    * Matching uses the same rule as delete-side scope filtering
-   * ({@link shouldDeleteForScopes}):
+   * ({@link scopesMatchFilter}):
    *
    * - Instance-private resources (empty scopes) are deployed when the
    *   filter is `[]` (empty) — meaning "target instance scope."

--- a/src/core/types/deployment.ts
+++ b/src/core/types/deployment.ts
@@ -232,6 +232,57 @@ export interface DeploymentOptions extends BaseDeploymentConfig {
    * @default Uses built-in defaults for each operation type
    */
   httpTimeouts?: HttpTimeoutConfig;
+
+  /**
+   * Factory identifier used to tag deployed resources with typekro
+   * ownership metadata. When both `factoryName` and `instanceName` are
+   * set, every resource applied by this deployment is stamped with
+   * `typekro.io/factory-name` and `typekro.io/instance-name` labels
+   * (plus matching annotations + deployment-id + depends-on for graph
+   * reconstruction). This makes cross-process cleanup possible:
+   * `factory.deleteInstance(name)` from a later bun process discovers
+   * the resources by label selector and performs reverse-topological
+   * deletion without needing the in-memory deployment state.
+   *
+   * Without these fields, resources are not tagged and cross-process
+   * cleanup is unavailable — same-process cleanup via the engine's
+   * in-memory map continues to work.
+   */
+  factoryName?: string;
+
+  /** Instance identifier — see `factoryName`. */
+  instanceName?: string;
+
+  /**
+   * Scope-targeted deployment. When set, only resources whose effective
+   * scopes match this filter are deployed. Resources outside the filter
+   * are silently skipped — not an error, just not part of this deploy.
+   *
+   * Matching uses the same rule as delete-side scope filtering
+   * ({@link shouldDeleteForScopes}):
+   *
+   * - Instance-private resources (empty scopes) are deployed when the
+   *   filter is `[]` (empty) — meaning "target instance scope."
+   * - Scoped resources (e.g., `['cluster']`) are deployed when the
+   *   filter contains at least one of their scopes.
+   *
+   * When `targetScopes` is **undefined** (the default), ALL resources
+   * deploy regardless of scope — backwards-compatible "deploy
+   * everything" behavior.
+   *
+   * @example
+   * ```ts
+   * // Deploy only cluster-scoped resources (operators)
+   * await factory.deploy(spec, { targetScopes: ['cluster'] });
+   *
+   * // Deploy only instance-private resources (app + database)
+   * await factory.deploy(spec, { targetScopes: [] });
+   *
+   * // Deploy everything (default)
+   * await factory.deploy(spec);
+   * ```
+   */
+  targetScopes?: string[];
 }
 
 export interface AlchemyDeploymentOptions extends BaseDeploymentConfig {
@@ -619,11 +670,11 @@ export interface ResourceFactory<
   TStatus extends KroCompatibleType,
 > {
   // Core deployment - single method handles all cases
-  deploy(spec: TSpec): Promise<Enhanced<TSpec, TStatus>>;
+  deploy(spec: TSpec, opts?: { targetScopes?: string[] }): Promise<Enhanced<TSpec, TStatus>>;
 
   // Instance management
   getInstances(): Promise<Enhanced<TSpec, TStatus>[]>;
-  deleteInstance(name: string): Promise<void>;
+  deleteInstance(name: string, opts?: { scopes?: string[] }): Promise<void>;
   getStatus(): Promise<FactoryStatus>;
 
   // Metadata
@@ -745,4 +796,11 @@ export interface ResolutionContext {
   deploymentId?: string;
   resourceKeyMapping?: Map<string, unknown>;
   schema?: { spec?: unknown; status?: unknown };
+  /**
+   * Function returning the composition-local dependency ids for a given
+   * resource id. Populated by the engine before deploy so the tagging
+   * step can record per-resource `depends-on` annotations without
+   * reaching back into the graph.
+   */
+  dependenciesForResource?: (resourceId: string) => string[];
 }

--- a/src/factories/cnpg/compositions/cnpg-bootstrap.ts
+++ b/src/factories/cnpg/compositions/cnpg-bootstrap.ts
@@ -1,5 +1,6 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
+import { setMetadataField } from '../../../core/metadata/index.js';
 import { Cel } from '../../../core/references/cel.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
 import { cnpgHelmRelease, cnpgHelmRepository } from '../resources/helm.js';
@@ -49,6 +50,12 @@ export const cnpgBootstrap = kubernetesComposition(
   (spec: CnpgBootstrapConfig) => {
     const resolvedNamespace = spec.namespace || 'cnpg-system';
     const resolvedVersion = spec.version || '0.23.0';
+    // Default to shared-lifecycle: the operator is cluster-scoped
+    // infrastructure and should survive individual consumer instance
+    // deletions. Users can opt out by passing `shared: false` when
+    // they want a dedicated per-instance operator (isolation, version
+    // testing, multi-tenancy).
+    const isShared = spec.shared !== false;
 
     // Map config to Helm values
     const helmValues = mapCnpgConfigToHelmValues({
@@ -89,6 +96,19 @@ export const cnpgBootstrap = kubernetesComposition(
       repositoryName: 'cnpg-repo',
       id: 'cnpgHelmRelease',
     });
+
+    // Tag all resources with 'cluster' scope so factory-level
+    // deleteInstance leaves the operator install intact for other
+    // consumers. Callers can explicitly tear down shared infra with
+    // `deleteInstance(name, { scopes: ['cluster'] })`. The
+    // HelmRepository in flux-system is ALWAYS shared (per rule #23)
+    // because multiple compositions legitimately reference the same
+    // chart repo — we tag it here too for clarity.
+    if (isShared) {
+      setMetadataField(_cnpgNamespace, 'scopes', ['cluster']);
+      setMetadataField(_helmRepository, 'scopes', ['cluster']);
+      setMetadataField(_helmRelease, 'scopes', ['cluster']);
+    }
 
     // Status derived from HelmRelease conditions.
     // Flux HelmRelease v2 uses conditions with type='Ready' for readiness.

--- a/src/factories/cnpg/types.ts
+++ b/src/factories/cnpg/types.ts
@@ -115,6 +115,17 @@ export const CnpgBootstrapConfigSchema = type({
   },
   /** Additional Helm values for user overrides. */
   'customValues?': 'Record<string, unknown>',
+  /**
+   * Whether the operator install should be treated as shared cluster
+   * infrastructure (default: `true`). When `true`, the Namespace,
+   * HelmRepository, and HelmRelease are tagged with
+   * `scopes: ['cluster']` so `factory.deleteInstance()` will NOT
+   * remove them — multiple consumers (e.g., many `webAppWithProcessing`
+   * deployments) can converge on the same operator install. Set to
+   * `false` for dedicated per-instance operators (e.g., isolated
+   * multi-tenancy or version testing).
+   */
+  'shared?': 'boolean',
 });
 
 /** Configuration for installing the CloudNativePG operator via Helm. */

--- a/src/factories/inngest/resources/helm.ts
+++ b/src/factories/inngest/resources/helm.ts
@@ -61,7 +61,7 @@ export function inngestHelmRepository(
   // HelmRepositories in flux-system are shared cluster-level resources.
   // They should survive instance deletion — multiple compositions can
   // reference the same repo.
-  setMetadataField(repo, 'lifecycle', 'shared');
+  setMetadataField(repo, 'scopes', ['cluster']);
 
   return repo;
 }

--- a/src/factories/valkey/compositions/valkey-bootstrap.ts
+++ b/src/factories/valkey/compositions/valkey-bootstrap.ts
@@ -1,5 +1,6 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
+import { setMetadataField } from '../../../core/metadata/index.js';
 import { Cel } from '../../../core/references/cel.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
 import {
@@ -64,6 +65,10 @@ export const valkeyBootstrap = kubernetesComposition(
     const resolvedNamespace = spec.namespace || 'valkey-operator-system';
     const resolvedVersion = spec.version || DEFAULT_VALKEY_VERSION;
     const appVersion = stripChartSuffix(resolvedVersion);
+    // Default to shared-lifecycle so multiple consumers (e.g., many
+    // `webAppWithProcessing` deployments) converge on a single operator
+    // install. Users can opt out by passing `shared: false`.
+    const isShared = spec.shared !== false;
 
     const helmValues = mapValkeyConfigToHelmValues({
       ...spec,
@@ -104,6 +109,16 @@ export const valkeyBootstrap = kubernetesComposition(
       repositoryName: DEFAULT_VALKEY_REPO_NAME,
       id: 'valkeyHelmRelease',
     });
+
+    // Tag all resources with 'cluster' scope so factory-level
+    // deleteInstance leaves the operator install intact. Callers can
+    // opt in to tearing down shared infra with
+    // `deleteInstance(name, { scopes: ['cluster'] })`.
+    if (isShared) {
+      setMetadataField(_valkeyNamespace, 'scopes', ['cluster']);
+      setMetadataField(_helmRepository, 'scopes', ['cluster']);
+      setMetadataField(_helmRelease, 'scopes', ['cluster']);
+    }
 
     // Status derived from HelmRelease conditions.
     return {

--- a/src/factories/valkey/types.ts
+++ b/src/factories/valkey/types.ts
@@ -50,6 +50,16 @@ export const ValkeyBootstrapConfigSchema = type({
   'version?': 'string',
   /** Additional Helm values for user overrides. */
   'customValues?': 'Record<string, unknown>',
+  /**
+   * Whether the operator install should be treated as shared cluster
+   * infrastructure (default: `true`). When `true`, the Namespace,
+   * HelmRepository, and HelmRelease are tagged with
+   * `scopes: ['cluster']` so `factory.deleteInstance()` will NOT
+   * remove them — multiple consumers can converge on the same
+   * operator install. Set to `false` for dedicated per-instance
+   * operators.
+   */
+  'shared?': 'boolean',
 });
 
 /** Configuration for installing the Hyperspike Valkey operator via Helm. */

--- a/src/factories/webapp/compositions/web-app-with-processing.ts
+++ b/src/factories/webapp/compositions/web-app-with-processing.ts
@@ -1,8 +1,10 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { cnpgBootstrap } from '../../cnpg/compositions/cnpg-bootstrap.js';
 import { cluster } from '../../cnpg/resources/cluster.js';
 import { pooler } from '../../cnpg/resources/pooler.js';
 import { inngestBootstrap } from '../../inngest/compositions/inngest-bootstrap.js';
 import { simple } from '../../simple/index.js';
+import { valkeyBootstrap } from '../../valkey/compositions/valkey-bootstrap.js';
 import { valkey } from '../../valkey/resources/valkey.js';
 import {
   type WebAppWithProcessingConfig,
@@ -13,11 +15,28 @@ import {
 /**
  * Full-Stack Web Application with Background Processing
  *
- * Deploys a complete application stack:
- * 1. **PostgreSQL** (via CNPG) — cluster + PgBouncer pooler
- * 2. **Valkey** cache cluster
- * 3. **Inngest** workflow engine (with external DB/cache, not bundled)
- * 4. **Application** Deployment + Service
+ * Deploys a complete, self-contained application stack. The composition
+ * installs its own operators AND the application resources managed by
+ * those operators — callers don't need to pre-install anything other
+ * than the TypeKro runtime (Flux + KRO) on the target cluster.
+ *
+ * **Operators** (installed by nested bootstraps):
+ * 1. **CloudNativePG operator** (via `cnpgBootstrap`) — manages the
+ *    PostgreSQL cluster. Installs into `cnpg-system` by default.
+ * 2. **Hyperspike Valkey operator** (via `valkeyBootstrap`) — manages
+ *    the Valkey cache cluster. Installs into `valkey-operator-system`
+ *    by default.
+ * 3. **Inngest** (via `inngestBootstrap`) — the workflow engine itself
+ *    is installed via a Helm release alongside the app. Bundled
+ *    Postgres/Redis are disabled; Inngest uses the CNPG and Valkey
+ *    instances from this composition.
+ *
+ * **Application resources** (created in the app namespace, managed by
+ * the operators above):
+ * 1. **PostgreSQL cluster** (CNPG `Cluster`) + PgBouncer `Pooler`
+ * 2. **Valkey cache cluster** (Hyperspike `Valkey` CR) + explicit
+ *    ClusterIP Service (KRO prunes unowned Services otherwise)
+ * 3. **Application** `Deployment` + `Service`
  *
  * All connection strings are automatically wired into the app's environment:
  * - `DATABASE_URL` — points to the PgBouncer pooler
@@ -29,6 +48,12 @@ import {
  * - Inngest references `cache.metadata.name` for the redis URI → deploys after Valkey
  * - Inngest references `database.status.writeService` for the postgres URI → deploys after CNPG
  * - App references service names derived from resource names → deploys after all infra
+ *
+ * Operator install settings can be overridden per-deployment via
+ * `spec.cnpgOperator` and `spec.valkeyOperator` — e.g., to pin chart
+ * versions or change the install namespace. Both fields are optional;
+ * defaults install the latest pinned version into each operator's
+ * system namespace.
  *
  * @example
  * ```typescript
@@ -62,6 +87,9 @@ import {
  *     signingKey: 'deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567',
  *     sdkUrl: ['http://my-app:3000/api/inngest'],
  *   },
+ *   // Operators install with sensible defaults; override only if
+ *   // you need a specific chart version or custom install namespace.
+ *   cnpgOperator: { version: '0.23.0' },
  * });
  * ```
  */
@@ -79,6 +107,41 @@ export const webAppWithProcessing = kubernetesComposition(
     const inngestReplicas = spec.processing.replicas ?? 1;
     const dbName = spec.database.database ?? spec.name;
     const dbOwner = spec.database.owner ?? 'app';
+
+    // ── Operator bootstraps ────────────────────────────────────────────
+    //
+    // Install the CNPG and Valkey operators as part of the composition
+    // so consumers get a fully self-contained stack. The bootstraps run
+    // in their own system namespaces (not the app namespace) and install
+    // cluster-scoped operators; the later `cluster()`/`valkey()` calls
+    // create instances in the app namespace managed by those operators.
+    //
+    // **Shared-singleton default.** Operators are cluster-scoped
+    // infrastructure — one install per cluster serves every consumer.
+    // The nested bootstraps use fixed names (`cnpg-operator`,
+    // `valkey-operator`) in fixed system namespaces and are marked
+    // `scopes: ['cluster']`, so multiple `webAppWithProcessing`
+    // deployments on the same cluster converge on the same operator
+    // install and `factory.deleteInstance()` on any one consumer
+    // leaves the operator intact for the others.
+    //
+    // Users who need a dedicated per-instance operator (multi-tenancy,
+    // version testing, isolated failure domains) can override any
+    // combination of fields via `spec.cnpgOperator` / `spec.valkeyOperator` —
+    // e.g., `{ name: 'testapp-cnpg', namespace: 'testapp-cnpg-system', shared: false }`.
+    // The spread puts user overrides AFTER the defaults so they win.
+    const _cnpg = cnpgBootstrap({
+      name: 'cnpg-operator',
+      namespace: 'cnpg-system',
+      installCRDs: true,
+      ...spec.cnpgOperator,
+    });
+
+    const _valkeyOp = valkeyBootstrap({
+      name: 'valkey-operator',
+      namespace: 'valkey-operator-system',
+      ...spec.valkeyOperator,
+    });
 
     // ── PostgreSQL (CNPG) ──────────────────────────────────────────────
 

--- a/src/factories/webapp/types.ts
+++ b/src/factories/webapp/types.ts
@@ -12,6 +12,8 @@
  */
 
 import { type } from 'arktype';
+import { CnpgBootstrapConfigSchema } from '../cnpg/types.js';
+import { ValkeyBootstrapConfigSchema } from '../valkey/types.js';
 
 // ============================================================================
 // Config Schemas (source of truth) + Inferred Types
@@ -74,6 +76,37 @@ export const WebAppWithProcessingConfigSchema = type({
     /** Number of Inngest server replicas (default: 1). */
     'replicas?': 'number',
   },
+  /**
+   * CloudNativePG operator install settings. The composition nests
+   * `cnpgBootstrap` so the operator installs automatically alongside
+   * the app stack.
+   *
+   * The schema embeds the full `CnpgBootstrapConfigSchema` made
+   * partial (every field optional) so every field the underlying
+   * bootstrap supports is available here without duplication:
+   * `name`, `namespace`, `version`, `installCRDs`, `replicaCount`,
+   * `monitoring`, `resources`, `customValues`, `shared`.
+   *
+   * Defaults applied by the composition when omitted:
+   *   name: 'cnpg-operator'
+   *   namespace: 'cnpg-system'
+   *   shared: true (singleton — survives instance deletion)
+   *
+   * The defaults make the operator a **shared cluster-level singleton**:
+   * multiple `webAppWithProcessing` instances (and any other composition
+   * that nests `cnpgBootstrap`) converge on the same install. Override
+   * `name`/`namespace` + set `shared: false` to deploy a dedicated
+   * per-instance operator (isolation, version testing, multi-tenancy).
+   */
+  'cnpgOperator?': CnpgBootstrapConfigSchema.partial(),
+  /**
+   * Hyperspike Valkey operator install settings. Same shared-singleton
+   * pattern as `cnpgOperator`. Defaults:
+   *   name: 'valkey-operator'
+   *   namespace: 'valkey-operator-system'
+   *   shared: true
+   */
+  'valkeyOperator?': ValkeyBootstrapConfigSchema.partial(),
 });
 
 /** Inferred config type — no separate interface needed. */

--- a/test/unit/deployment-state-discovery.test.ts
+++ b/test/unit/deployment-state-discovery.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for deployment-state-discovery.ts — pure functions that
+ * reconstruct a DeploymentStateRecord from tagged cluster resources.
+ */
+
+import { describe, expect, it } from 'bun:test';
+// We can't import the private functions directly, so we test through
+// the public API by constructing fake resources and calling
+// discoverDeployedResourcesByInstance with a mock k8sApi.
+import { discoverDeployedResourcesByInstance } from '../../src/core/deployment/deployment-state-discovery.js';
+import type { GvkTarget } from '../../src/core/deployment/deployment-state-discovery.js';
+import {
+  DEPENDS_ON_ANNOTATION,
+  DEPLOYMENT_ID_ANNOTATION,
+  FACTORY_NAME_ANNOTATION,
+  FACTORY_NAME_LABEL,
+  FACTORY_NAMESPACE_ANNOTATION,
+  INSTANCE_NAME_ANNOTATION,
+  INSTANCE_NAME_LABEL,
+  MANAGED_BY_LABEL,
+  MANAGED_BY_VALUE,
+  RESOURCE_ID_ANNOTATION,
+  SCOPES_ANNOTATION,
+} from '../../src/core/deployment/resource-tagging.js';
+
+/** Build a fake tagged K8s resource as it would appear from a list call. */
+function makeTaggedResource(opts: {
+  apiVersion: string;
+  kind: string;
+  name: string;
+  namespace?: string;
+  factoryName: string;
+  instanceName: string;
+  deploymentId: string;
+  resourceId: string;
+  scopes?: string[];
+  dependencies?: string[];
+  creationTimestamp?: Date;
+}) {
+  return {
+    apiVersion: opts.apiVersion,
+    kind: opts.kind,
+    metadata: {
+      name: opts.name,
+      namespace: opts.namespace ?? 'default',
+      creationTimestamp: opts.creationTimestamp ?? new Date('2026-04-05T00:00:00Z'),
+      labels: {
+        [MANAGED_BY_LABEL]: MANAGED_BY_VALUE,
+        [FACTORY_NAME_LABEL]: opts.factoryName,
+        [INSTANCE_NAME_LABEL]: opts.instanceName,
+      },
+      annotations: {
+        [FACTORY_NAME_ANNOTATION]: opts.factoryName,
+        [INSTANCE_NAME_ANNOTATION]: opts.instanceName,
+        [DEPLOYMENT_ID_ANNOTATION]: opts.deploymentId,
+        [RESOURCE_ID_ANNOTATION]: opts.resourceId,
+        [FACTORY_NAMESPACE_ANNOTATION]: 'factory-ns',
+        ...(opts.scopes?.length && { [SCOPES_ANNOTATION]: JSON.stringify(opts.scopes) }),
+        ...(opts.dependencies?.length && { [DEPENDS_ON_ANNOTATION]: JSON.stringify(opts.dependencies) }),
+      },
+    },
+  };
+}
+
+/**
+ * Create a mock KubernetesObjectApi that returns a fixed list of
+ * resources for any list call whose labelSelector matches the factory.
+ */
+function makeFakeK8sApi(resources: ReturnType<typeof makeTaggedResource>[]) {
+  return {
+    list: async (
+      _apiVersion: string,
+      _kind: string,
+      _namespace?: string,
+      _pretty?: string,
+      _exact?: boolean,
+      _exportt?: boolean,
+      _fieldSelector?: string,
+      labelSelector?: string
+    ) => {
+      // Only return resources when the selector matches our factory
+      if (labelSelector?.includes('my-factory')) {
+        // Filter by kind to simulate per-GVK list calls
+        const matching = resources.filter(
+          (r) => r.apiVersion === _apiVersion && r.kind === _kind
+        );
+        return { items: matching };
+      }
+      return { items: [] };
+    },
+  } as any;
+}
+
+describe('discoverDeployedResourcesByInstance', () => {
+  it('returns undefined when no resources match', async () => {
+    const api = makeFakeK8sApi([]);
+    const result = await discoverDeployedResourcesByInstance(api, {
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      knownGvks: [{ apiVersion: 'v1', kind: 'ConfigMap', namespaced: true }],
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('discovers resources and builds a record', async () => {
+    const db = makeTaggedResource({
+      apiVersion: 'postgresql.cnpg.io/v1',
+      kind: 'Cluster',
+      name: 'database',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'database',
+    });
+    const app = makeTaggedResource({
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      name: 'my-app',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'app',
+      dependencies: ['database'],
+    });
+
+    const knownGvks: GvkTarget[] = [
+      { apiVersion: 'postgresql.cnpg.io/v1', kind: 'Cluster', namespaced: true },
+      { apiVersion: 'apps/v1', kind: 'Deployment', namespaced: true },
+    ];
+
+    const api = makeFakeK8sApi([db, app]);
+    const result = await discoverDeployedResourcesByInstance(api, {
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      knownGvks,
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.resources).toHaveLength(2);
+    expect(result!.resources.map((r) => r.id).sort()).toEqual(['app', 'database']);
+    expect(result!.deploymentId).toBe('dep-1');
+  });
+
+  it('reconstructs dependency graph from annotations', async () => {
+    const db = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'db',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'database',
+    });
+    const pooler = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'pooler',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'pooler',
+      dependencies: ['database'],
+    });
+    const app = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'app',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'app',
+      dependencies: ['pooler'],
+    });
+
+    const api = makeFakeK8sApi([db, pooler, app]);
+    const result = await discoverDeployedResourcesByInstance(api, {
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      knownGvks: [{ apiVersion: 'v1', kind: 'ConfigMap', namespaced: true }],
+    });
+
+    expect(result).toBeDefined();
+    const graph = result!.dependencyGraph;
+    expect(graph.getDependencies('pooler')).toEqual(['database']);
+    expect(graph.getDependencies('app')).toEqual(['pooler']);
+    expect(graph.getDependencies('database')).toEqual([]);
+  });
+
+  it('silently drops dangling dependency edges', async () => {
+    const app = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'app',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'app',
+      dependencies: ['deleted-resource'],
+    });
+
+    const api = makeFakeK8sApi([app]);
+    const result = await discoverDeployedResourcesByInstance(api, {
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      knownGvks: [{ apiVersion: 'v1', kind: 'ConfigMap', namespaced: true }],
+    });
+
+    expect(result).toBeDefined();
+    // 'deleted-resource' doesn't exist, so no edge added, no crash
+    expect(result!.dependencyGraph.getDependencies('app')).toEqual([]);
+  });
+
+  it('skips resources without resource-id annotation', async () => {
+    const good = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'good',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'good',
+    });
+    // Resource with no resource-id — simulate by removing annotation
+    const bad = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'bad',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'bad',
+    });
+    delete (bad.metadata.annotations as any)[RESOURCE_ID_ANNOTATION];
+
+    const api = makeFakeK8sApi([good, bad]);
+    const result = await discoverDeployedResourcesByInstance(api, {
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      knownGvks: [{ apiVersion: 'v1', kind: 'ConfigMap', namespaced: true }],
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.resources).toHaveLength(1);
+    expect(result!.resources[0]!.id).toBe('good');
+  });
+
+  it('preserves scopes annotation on discovered resources', async () => {
+    const operator = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'operator',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'operator',
+      scopes: ['cluster'],
+    });
+
+    const api = makeFakeK8sApi([operator]);
+    const result = await discoverDeployedResourcesByInstance(api, {
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      knownGvks: [{ apiVersion: 'v1', kind: 'ConfigMap', namespaced: true }],
+    });
+
+    expect(result).toBeDefined();
+    const manifest = result!.resources[0]!.manifest;
+    const scopes = manifest.metadata?.annotations?.[SCOPES_ANNOTATION];
+    expect(scopes).toBe('["cluster"]');
+  });
+
+  it('deduplicates resources seen at multiple GVK versions', async () => {
+    const resource = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'dedup-test',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'dedup',
+    });
+
+    // Same resource returned by two "versions" of the GVK
+    const api = makeFakeK8sApi([resource]);
+    const result = await discoverDeployedResourcesByInstance(api, {
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      knownGvks: [
+        { apiVersion: 'v1', kind: 'ConfigMap', namespaced: true },
+        { apiVersion: 'v1', kind: 'ConfigMap', namespaced: true },
+      ],
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.resources).toHaveLength(1);
+  });
+});

--- a/test/unit/deployment-state-discovery.test.ts
+++ b/test/unit/deployment-state-discovery.test.ts
@@ -329,4 +329,56 @@ describe('discoverDeployedResourcesByInstance', () => {
     expect(result!.resources).toHaveLength(2);
     expect(result!.resources.map((r) => r.id).sort()).toEqual(['widgetV1', 'widgetV2']);
   });
+
+  it('rejects resources from a different factory with a colliding sanitized label', async () => {
+    // Both "my@factory" and "my#factory" sanitize to "my-factory" in labels.
+    // The label selector returns resources from BOTH factories, but the
+    // annotation post-filter should reject the one with the wrong raw name.
+    const mine = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'mine',
+      factoryName: 'my@factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'mine',
+    });
+    const theirs = makeTaggedResource({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      name: 'theirs',
+      factoryName: 'my#factory', // different raw name, same sanitized label
+      instanceName: 'my-instance',
+      deploymentId: 'dep-2',
+      resourceId: 'theirs',
+    });
+
+    // Mock API returns BOTH (label selector can't distinguish them)
+    const api = {
+      list: async (
+        _apiVersion: string,
+        _kind: string,
+        _namespace?: string,
+        _pretty?: string,
+        _exact?: boolean,
+        _exportt?: boolean,
+        _fieldSelector?: string,
+        _labelSelector?: string
+      ) => {
+        if (_kind === 'ConfigMap') return { items: [mine, theirs] };
+        return { items: [] };
+      },
+    } as any;
+
+    const result = await discoverDeployedResourcesByInstance(api, {
+      factoryName: 'my@factory',
+      instanceName: 'my-instance',
+      knownGvks: [{ apiVersion: 'v1', kind: 'ConfigMap', namespaced: true }],
+    });
+
+    expect(result).toBeDefined();
+    // Only 'mine' should be included — 'theirs' has a different raw factoryName
+    expect(result!.resources).toHaveLength(1);
+    expect(result!.resources[0]!.id).toBe('mine');
+  });
 });

--- a/test/unit/deployment-state-discovery.test.ts
+++ b/test/unit/deployment-state-discovery.test.ts
@@ -294,4 +294,39 @@ describe('discoverDeployedResourcesByInstance', () => {
     expect(result).toBeDefined();
     expect(result!.resources).toHaveLength(1);
   });
+
+  it('keeps resources with same kind+name but different apiVersion', async () => {
+    const v1 = makeTaggedResource({
+      apiVersion: 'example.io/v1',
+      kind: 'Widget',
+      name: 'my-widget',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'widgetV1',
+    });
+    const v2 = makeTaggedResource({
+      apiVersion: 'example.io/v2',
+      kind: 'Widget',
+      name: 'my-widget',
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      deploymentId: 'dep-1',
+      resourceId: 'widgetV2',
+    });
+
+    const api = makeFakeK8sApi([v1, v2]);
+    const result = await discoverDeployedResourcesByInstance(api, {
+      factoryName: 'my-factory',
+      instanceName: 'my-instance',
+      knownGvks: [
+        { apiVersion: 'example.io/v1', kind: 'Widget', namespaced: true },
+        { apiVersion: 'example.io/v2', kind: 'Widget', namespaced: true },
+      ],
+    });
+
+    expect(result).toBeDefined();
+    expect(result!.resources).toHaveLength(2);
+    expect(result!.resources.map((r) => r.id).sort()).toEqual(['widgetV1', 'widgetV2']);
+  });
 });

--- a/test/unit/resource-tagging.test.ts
+++ b/test/unit/resource-tagging.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Unit tests for the label-based deployment state backend.
+ *
+ * Covers:
+ *   - applyTypekroTags: label + annotation stamping
+ *   - extractTypekroTags: round-trip extraction from a live resource
+ *   - getEffectiveScopes: merges annotation, WeakMap, and legacy sources
+ *   - shouldDeleteForScopes: scope-filter matching matrix
+ *   - buildFactoryInstanceSelector: label selector construction
+ *   - sanitiseLabelValue: DNS-label sanitisation
+ *
+ * Discovery module (deployment-state-discovery.ts) — graph reconstruction
+ * from per-resource annotations — is exercised by integration tests that
+ * deploy to a real cluster and then call `factory.deleteInstance` from a
+ * fresh factory instance.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { setMetadataField } from '../../src/core/metadata/index.js';
+import type { KubernetesResource } from '../../src/core/types/kubernetes.js';
+import {
+  applyTypekroTags,
+  buildFactoryInstanceSelector,
+  DEPLOYMENT_ID_ANNOTATION,
+  DEPENDS_ON_ANNOTATION,
+  extractTypekroTags,
+  FACTORY_NAME_ANNOTATION,
+  FACTORY_NAME_LABEL,
+  FACTORY_NAMESPACE_ANNOTATION,
+  getEffectiveScopes,
+  INSTANCE_NAME_ANNOTATION,
+  INSTANCE_NAME_LABEL,
+  MANAGED_BY_LABEL,
+  MANAGED_BY_VALUE,
+  RESOURCE_ID_ANNOTATION,
+  sanitiseLabelValue,
+  SCOPES_ANNOTATION,
+  shouldDeleteForScopes,
+  type TagContext,
+} from '../../src/core/deployment/resource-tagging.js';
+
+// ── applyTypekroTags ──────────────────────────────────────────────────────
+
+describe('applyTypekroTags', () => {
+  function makeManifest(): KubernetesResource {
+    return {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: 'my-app',
+        namespace: 'default',
+      },
+    };
+  }
+
+  function makeCtx(overrides?: Partial<TagContext>): TagContext {
+    return {
+      factoryName: 'webapp',
+      instanceName: 'testapp',
+      deploymentId: 'deploy-1',
+      factoryNamespace: 'factory-ns',
+      resourceId: 'appDeployment',
+      ...overrides,
+    };
+  }
+
+  it('sets managed-by, factory-name, and instance-name labels', () => {
+    const manifest = makeManifest();
+    applyTypekroTags(manifest, makeCtx());
+    const labels = (manifest.metadata as any).labels;
+    expect(labels[MANAGED_BY_LABEL]).toBe(MANAGED_BY_VALUE);
+    expect(labels[FACTORY_NAME_LABEL]).toBe('webapp');
+    expect(labels[INSTANCE_NAME_LABEL]).toBe('testapp');
+  });
+
+  it('sets deployment-id, resource-id, and factory-namespace annotations', () => {
+    const manifest = makeManifest();
+    applyTypekroTags(manifest, makeCtx());
+    const annotations = (manifest.metadata as any).annotations;
+    expect(annotations[DEPLOYMENT_ID_ANNOTATION]).toBe('deploy-1');
+    expect(annotations[RESOURCE_ID_ANNOTATION]).toBe('appDeployment');
+    expect(annotations[FACTORY_NAMESPACE_ANNOTATION]).toBe('factory-ns');
+  });
+
+  it('sets scopes annotation when provided', () => {
+    const manifest = makeManifest();
+    applyTypekroTags(manifest, makeCtx({ scopes: ['cluster'] }));
+    const ann = (manifest.metadata as any).annotations[SCOPES_ANNOTATION];
+    expect(JSON.parse(ann)).toEqual(['cluster']);
+  });
+
+  it('omits scopes annotation when scopes is empty', () => {
+    const manifest = makeManifest();
+    applyTypekroTags(manifest, makeCtx({ scopes: [] }));
+    expect((manifest.metadata as any).annotations[SCOPES_ANNOTATION]).toBeUndefined();
+  });
+
+  it('sets depends-on annotation when provided', () => {
+    const manifest = makeManifest();
+    applyTypekroTags(manifest, makeCtx({ dependencies: ['database', 'cache'] }));
+    const ann = (manifest.metadata as any).annotations[DEPENDS_ON_ANNOTATION];
+    expect(JSON.parse(ann)).toEqual(['database', 'cache']);
+  });
+
+  it('preserves existing user labels and annotations', () => {
+    const manifest = makeManifest();
+    (manifest.metadata as any).labels = { 'app.kubernetes.io/name': 'my-app' };
+    (manifest.metadata as any).annotations = { 'my.org/version': '1.0' };
+    applyTypekroTags(manifest, makeCtx());
+    expect((manifest.metadata as any).labels['app.kubernetes.io/name']).toBe('my-app');
+    expect((manifest.metadata as any).annotations['my.org/version']).toBe('1.0');
+  });
+
+  it('creates metadata if missing', () => {
+    const manifest = { apiVersion: 'v1', kind: 'ConfigMap' } as KubernetesResource;
+    applyTypekroTags(manifest, makeCtx());
+    expect((manifest.metadata as any).labels[MANAGED_BY_LABEL]).toBe(MANAGED_BY_VALUE);
+  });
+
+  it('stores raw factory/instance names as annotations', () => {
+    const manifest = makeManifest();
+    applyTypekroTags(manifest, makeCtx({ factoryName: 'My/Factory', instanceName: 'Test:App' }));
+    const ann = (manifest.metadata as any).annotations;
+    expect(ann[FACTORY_NAME_ANNOTATION]).toBe('My/Factory');
+    expect(ann[INSTANCE_NAME_ANNOTATION]).toBe('Test:App');
+    // Labels are sanitized
+    const labels = (manifest.metadata as any).labels;
+    expect(labels[FACTORY_NAME_LABEL]).toBe('my-factory');
+    expect(labels[INSTANCE_NAME_LABEL]).toBe('test-app');
+  });
+});
+
+// ── extractTypekroTags ────────────────────────────────────────────────────
+
+describe('extractTypekroTags', () => {
+  it('extracts all fields from a fully-tagged resource', () => {
+    const resource = {
+      metadata: {
+        labels: {
+          [MANAGED_BY_LABEL]: MANAGED_BY_VALUE,
+          [FACTORY_NAME_LABEL]: 'webapp',
+          [INSTANCE_NAME_LABEL]: 'testapp',
+        },
+        annotations: {
+          [FACTORY_NAME_ANNOTATION]: 'webapp',
+          [INSTANCE_NAME_ANNOTATION]: 'testapp',
+          [DEPLOYMENT_ID_ANNOTATION]: 'deploy-1',
+          [RESOURCE_ID_ANNOTATION]: 'appDeployment',
+          [FACTORY_NAMESPACE_ANNOTATION]: 'factory-ns',
+          [SCOPES_ANNOTATION]: '["cluster"]',
+          [DEPENDS_ON_ANNOTATION]: '["database","cache"]',
+        },
+      },
+    };
+    const tags = extractTypekroTags(resource);
+    expect(tags.factoryName).toBe('webapp');
+    expect(tags.instanceName).toBe('testapp');
+    expect(tags.deploymentId).toBe('deploy-1');
+    expect(tags.resourceId).toBe('appDeployment');
+    expect(tags.factoryNamespace).toBe('factory-ns');
+    expect(tags.scopes).toEqual(['cluster']);
+    expect(tags.dependencies).toEqual(['database', 'cache']);
+  });
+
+  it('returns empty arrays for missing scopes and dependencies', () => {
+    const resource = { metadata: { labels: {}, annotations: {} } };
+    const tags = extractTypekroTags(resource);
+    expect(tags.scopes).toEqual([]);
+    expect(tags.dependencies).toEqual([]);
+  });
+
+  it('tolerates malformed JSON in annotations', () => {
+    const resource = {
+      metadata: {
+        annotations: {
+          [SCOPES_ANNOTATION]: 'not-json',
+          [DEPENDS_ON_ANNOTATION]: '{bad}',
+        },
+      },
+    };
+    const tags = extractTypekroTags(resource);
+    expect(tags.scopes).toEqual([]);
+    expect(tags.dependencies).toEqual([]);
+  });
+
+  it('falls back to labels when annotations are missing', () => {
+    const resource = {
+      metadata: {
+        labels: {
+          [FACTORY_NAME_LABEL]: 'webapp',
+          [INSTANCE_NAME_LABEL]: 'testapp',
+        },
+      },
+    };
+    const tags = extractTypekroTags(resource);
+    expect(tags.factoryName).toBe('webapp');
+    expect(tags.instanceName).toBe('testapp');
+  });
+});
+
+// ── getEffectiveScopes ────────────────────────────────────────────────────
+
+describe('getEffectiveScopes', () => {
+  it('returns annotation scopes', () => {
+    const manifest = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { annotations: { [SCOPES_ANNOTATION]: '["cluster"]' } },
+    } as KubernetesResource;
+    expect(getEffectiveScopes(manifest)).toEqual(['cluster']);
+  });
+
+  it('returns WeakMap scopes metadata', () => {
+    const manifest = { apiVersion: 'v1', kind: 'ConfigMap', metadata: {} } as KubernetesResource;
+    setMetadataField(manifest, 'scopes', ['team:platform']);
+    expect(getEffectiveScopes(manifest)).toEqual(['team:platform']);
+  });
+
+  it('treats lifecycle: shared as scopes: ["shared"]', () => {
+    const manifest = { apiVersion: 'v1', kind: 'ConfigMap', metadata: {} } as KubernetesResource;
+    setMetadataField(manifest, 'lifecycle', 'shared');
+    expect(getEffectiveScopes(manifest)).toEqual(['shared']);
+  });
+
+  it('returns typekro.io/lifecycle annotation as ["shared"]', () => {
+    const manifest = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { annotations: { 'typekro.io/lifecycle': 'shared' } },
+    } as KubernetesResource;
+    expect(getEffectiveScopes(manifest)).toEqual(['shared']);
+  });
+
+  it('merges all sources without duplicates', () => {
+    const manifest = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { annotations: { [SCOPES_ANNOTATION]: '["cluster"]' } },
+    } as KubernetesResource;
+    setMetadataField(manifest, 'scopes', ['cluster', 'team:ops']);
+    setMetadataField(manifest, 'lifecycle', 'shared');
+    const scopes = getEffectiveScopes(manifest);
+    expect(scopes).toContain('cluster');
+    expect(scopes).toContain('team:ops');
+    expect(scopes).toContain('shared');
+    // 'cluster' should not appear twice
+    expect(scopes.filter((s) => s === 'cluster')).toHaveLength(1);
+  });
+
+  it('returns empty array for unscoped resources', () => {
+    const manifest = { apiVersion: 'v1', kind: 'ConfigMap', metadata: {} } as KubernetesResource;
+    expect(getEffectiveScopes(manifest)).toEqual([]);
+  });
+});
+
+// ── shouldDeleteForScopes ─────────────────────────────────────────────────
+
+describe('shouldDeleteForScopes', () => {
+  it('always deletes instance-private resources (empty scopes)', () => {
+    expect(shouldDeleteForScopes([], [])).toBe(true);
+    expect(shouldDeleteForScopes([], ['cluster'])).toBe(true);
+  });
+
+  it('skips scoped resources when filter is empty (default delete)', () => {
+    expect(shouldDeleteForScopes(['cluster'], [])).toBe(false);
+    expect(shouldDeleteForScopes(['shared'], [])).toBe(false);
+  });
+
+  it('deletes scoped resources when filter matches', () => {
+    expect(shouldDeleteForScopes(['cluster'], ['cluster'])).toBe(true);
+    expect(shouldDeleteForScopes(['cluster', 'team:ops'], ['cluster'])).toBe(true);
+    expect(shouldDeleteForScopes(['team:ops'], ['team:ops'])).toBe(true);
+  });
+
+  it('skips scoped resources when filter does not match', () => {
+    expect(shouldDeleteForScopes(['cluster'], ['team:ops'])).toBe(false);
+    expect(shouldDeleteForScopes(['team:frontend'], ['team:backend'])).toBe(false);
+  });
+
+  it('matches when any scope intersects the filter', () => {
+    expect(shouldDeleteForScopes(['cluster', 'team:ops'], ['team:ops'])).toBe(true);
+  });
+});
+
+// ── buildFactoryInstanceSelector ──────────────────────────────────────────
+
+describe('buildFactoryInstanceSelector', () => {
+  it('builds a label selector with managed-by, factory, and instance', () => {
+    const selector = buildFactoryInstanceSelector({
+      factoryName: 'webapp',
+      instanceName: 'testapp',
+    });
+    expect(selector).toContain(`${MANAGED_BY_LABEL}=${MANAGED_BY_VALUE}`);
+    expect(selector).toContain(`${FACTORY_NAME_LABEL}=webapp`);
+    expect(selector).toContain(`${INSTANCE_NAME_LABEL}=testapp`);
+  });
+
+  it('sanitizes factory and instance names', () => {
+    const selector = buildFactoryInstanceSelector({
+      factoryName: 'My/Factory',
+      instanceName: 'Test:App',
+    });
+    expect(selector).toContain(`${FACTORY_NAME_LABEL}=my-factory`);
+    expect(selector).toContain(`${INSTANCE_NAME_LABEL}=test-app`);
+  });
+});
+
+// ── sanitiseLabelValue ────────────────────────────────────────────────────
+
+describe('sanitiseLabelValue', () => {
+  it('lowercases and replaces non-DNS characters', () => {
+    expect(sanitiseLabelValue('My/Factory:Name')).toBe('my-factory-name');
+  });
+
+  it('truncates to 63 characters', () => {
+    const long = 'a'.repeat(100);
+    expect(sanitiseLabelValue(long).length).toBeLessThanOrEqual(63);
+  });
+
+  it('strips leading and trailing special chars', () => {
+    expect(sanitiseLabelValue('--hello--')).toBe('hello');
+  });
+
+  it('handles empty string', () => {
+    expect(sanitiseLabelValue('')).toBe('');
+  });
+});
+
+// ── Round-trip: tag → extract → verify ────────────────────────────────────
+
+describe('Tag round-trip', () => {
+  it('round-trips all fields through tag and extract', () => {
+    const manifest = {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: { name: 'my-svc', namespace: 'default' },
+    } as KubernetesResource;
+
+    applyTypekroTags(manifest, {
+      factoryName: 'webapp',
+      instanceName: 'testapp',
+      deploymentId: 'deploy-1',
+      factoryNamespace: 'factory-ns',
+      resourceId: 'mySvc',
+      scopes: ['cluster', 'team:platform'],
+      dependencies: ['database', 'cache'],
+    });
+
+    const tags = extractTypekroTags(manifest as any);
+    expect(tags.factoryName).toBe('webapp');
+    expect(tags.instanceName).toBe('testapp');
+    expect(tags.deploymentId).toBe('deploy-1');
+    expect(tags.resourceId).toBe('mySvc');
+    expect(tags.factoryNamespace).toBe('factory-ns');
+    expect(tags.scopes).toEqual(['cluster', 'team:platform']);
+    expect(tags.dependencies).toEqual(['database', 'cache']);
+  });
+});

--- a/test/unit/resource-tagging.test.ts
+++ b/test/unit/resource-tagging.test.ts
@@ -5,7 +5,7 @@
  *   - applyTypekroTags: label + annotation stamping
  *   - extractTypekroTags: round-trip extraction from a live resource
  *   - getEffectiveScopes: merges annotation, WeakMap, and legacy sources
- *   - shouldDeleteForScopes: scope-filter matching matrix
+ *   - scopesMatchFilter: scope-filter matching matrix
  *   - buildFactoryInstanceSelector: label selector construction
  *   - sanitiseLabelValue: DNS-label sanitisation
  *
@@ -35,7 +35,7 @@ import {
   RESOURCE_ID_ANNOTATION,
   sanitiseLabelValue,
   SCOPES_ANNOTATION,
-  shouldDeleteForScopes,
+  scopesMatchFilter,
   type TagContext,
 } from '../../src/core/deployment/resource-tagging.js';
 
@@ -253,32 +253,32 @@ describe('getEffectiveScopes', () => {
   });
 });
 
-// ── shouldDeleteForScopes ─────────────────────────────────────────────────
+// ── scopesMatchFilter ─────────────────────────────────────────────────
 
-describe('shouldDeleteForScopes', () => {
+describe('scopesMatchFilter', () => {
   it('always deletes instance-private resources (empty scopes)', () => {
-    expect(shouldDeleteForScopes([], [])).toBe(true);
-    expect(shouldDeleteForScopes([], ['cluster'])).toBe(true);
+    expect(scopesMatchFilter([], [])).toBe(true);
+    expect(scopesMatchFilter([], ['cluster'])).toBe(true);
   });
 
   it('skips scoped resources when filter is empty (default delete)', () => {
-    expect(shouldDeleteForScopes(['cluster'], [])).toBe(false);
-    expect(shouldDeleteForScopes(['shared'], [])).toBe(false);
+    expect(scopesMatchFilter(['cluster'], [])).toBe(false);
+    expect(scopesMatchFilter(['shared'], [])).toBe(false);
   });
 
   it('deletes scoped resources when filter matches', () => {
-    expect(shouldDeleteForScopes(['cluster'], ['cluster'])).toBe(true);
-    expect(shouldDeleteForScopes(['cluster', 'team:ops'], ['cluster'])).toBe(true);
-    expect(shouldDeleteForScopes(['team:ops'], ['team:ops'])).toBe(true);
+    expect(scopesMatchFilter(['cluster'], ['cluster'])).toBe(true);
+    expect(scopesMatchFilter(['cluster', 'team:ops'], ['cluster'])).toBe(true);
+    expect(scopesMatchFilter(['team:ops'], ['team:ops'])).toBe(true);
   });
 
   it('skips scoped resources when filter does not match', () => {
-    expect(shouldDeleteForScopes(['cluster'], ['team:ops'])).toBe(false);
-    expect(shouldDeleteForScopes(['team:frontend'], ['team:backend'])).toBe(false);
+    expect(scopesMatchFilter(['cluster'], ['team:ops'])).toBe(false);
+    expect(scopesMatchFilter(['team:frontend'], ['team:backend'])).toBe(false);
   });
 
   it('matches when any scope intersects the filter', () => {
-    expect(shouldDeleteForScopes(['cluster', 'team:ops'], ['team:ops'])).toBe(true);
+    expect(scopesMatchFilter(['cluster', 'team:ops'], ['team:ops'])).toBe(true);
   });
 });
 
@@ -321,8 +321,13 @@ describe('sanitiseLabelValue', () => {
     expect(sanitiseLabelValue('--hello--')).toBe('hello');
   });
 
-  it('handles empty string', () => {
-    expect(sanitiseLabelValue('')).toBe('');
+  it('returns "unknown" for empty string (invalid K8s label value)', () => {
+    expect(sanitiseLabelValue('')).toBe('unknown');
+  });
+
+  it('returns "unknown" for all-special-chars input', () => {
+    expect(sanitiseLabelValue('---')).toBe('unknown');
+    expect(sanitiseLabelValue('...')).toBe('unknown');
   });
 });
 

--- a/test/unit/resource-tagging.test.ts
+++ b/test/unit/resource-tagging.test.ts
@@ -280,6 +280,15 @@ describe('scopesMatchFilter', () => {
   it('matches when any scope intersects the filter', () => {
     expect(scopesMatchFilter(['cluster', 'team:ops'], ['team:ops'])).toBe(true);
   });
+
+  it('excludes unscoped resources when includeUnscoped is false', () => {
+    expect(scopesMatchFilter([], ['cluster'], false)).toBe(false);
+    expect(scopesMatchFilter([], [], false)).toBe(false);
+  });
+
+  it('still matches scoped resources when includeUnscoped is false', () => {
+    expect(scopesMatchFilter(['cluster'], ['cluster'], false)).toBe(true);
+  });
 });
 
 // ── buildFactoryInstanceSelector ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Cross-process cleanup works**: `factory.deleteInstance(name)` from a different process discovers resources by cluster-side labels and performs graph-based reverse-topological deletion — no ConfigMap state backend needed
- **Scoped resource lifecycle**: Resources can belong to scopes (e.g., `['cluster']`) that protect them from default deletion. `deleteInstance(name, { scopes: ['cluster'] })` explicitly targets broader scopes
- **Symmetric deploy/delete**: `deploy(spec, { targetScopes: ['cluster'] })` deploys only cluster-scoped resources; `deploy(spec, { targetScopes: [] })` deploys only instance-private ones
- **Webapp composition self-contained**: Nests `cnpgBootstrap` and `valkeyBootstrap` alongside `inngestBootstrap` with shared-singleton defaults

## Design

Every resource deployed by typekro is stamped with ownership labels (`typekro.io/managed-by`, `factory-name`, `instance-name`) and annotations (`deployment-id`, `resource-id`, `scopes`, `depends-on`). On delete, the engine queries by label selector, discovers all resources, reconstructs the dependency graph from per-resource `depends-on` annotations, and deletes in reverse-topological order.

No separate state backend (ConfigMap, database) exists. The cluster IS the state.

### Scope filtering

| Resource scopes | Delete filter | Result |
|---|---|---|
| `[]` (instance-private) | `[]` (default) | **Deleted** |
| `['cluster']` | `[]` (default) | **Skipped** |
| `['cluster']` | `['cluster']` | **Deleted** |
| `['cluster', 'team:ops']` | `['team:ops']` | **Deleted** |

## Key files

| File | Change |
|---|---|
| `resource-tagging.ts` | **New** — labels/annotations + scope filtering |
| `deployment-state-discovery.ts` | **New** — GVR enumeration + label-selector discovery + graph reconstruction |
| `engine.ts` | Wired tagging into deploy, scope-filtered rollback, `targetScopes` deploy filter |
| `resource-applier.ts` | `applyOwnershipTags` before cluster apply |
| `rollback-manager.ts` | `preOrdered` flag to avoid double-reverse + double-filter |
| `direct-factory.ts` | `deleteInstance(name, { scopes? })` with discovery fallback |
| `resource-metadata.ts` | Added `scopes?: string[]` field |
| `cnpg-bootstrap.ts`, `valkey-bootstrap.ts`, `inngest/helm.ts` | Migrated from `lifecycle: 'shared'` to `scopes: ['cluster']` |
| `web-app-with-processing.ts` | Nests cnpg + valkey bootstraps |

## Test plan

- [x] 3724 unit tests pass (30 new in `resource-tagging.test.ts`)
- [x] Typecheck clean
- [x] No circular dependencies
- [x] SearXNG integration: 3/3 pass (unit, direct, KRO)
- [x] Webapp direct-mode integration: 2/2 pass
- [ ] Webapp KRO-mode: blocked by pre-existing stuck CRD (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)