### PR TITLE
fix: bind live status map methods during nested re-execution

### DIFF
--- a/src/core/composition/imperative.ts
+++ b/src/core/composition/imperative.ts
@@ -95,9 +95,13 @@ function createNestedReExecutionLiveStatusMap(
   });
 
   return new Proxy(parentLiveStatusMap, {
-    get(target, prop, receiver) {
+    get(target, prop) {
       if (prop !== 'get' && prop !== 'has') {
-        return Reflect.get(target, prop, receiver);
+        const value = Reflect.get(target, prop, target);
+        // Map prototype methods perform brand checks against their receiver.
+        // Bind them to the real Map so nested re-execution can safely call
+        // methods like keys() on this proxy-backed live status map.
+        return typeof value === 'function' ? value.bind(target) : value;
       }
 
       return (resourceId: string) => {

--- a/test/unit/nested-composition-direct-mode.test.ts
+++ b/test/unit/nested-composition-direct-mode.test.ts
@@ -654,6 +654,95 @@ describe('Nested Composition Direct Mode', () => {
       expect(status?.innerUrl).toBe('http://myapp-inner.test-ns.svc:80');
       expect(status?.innerUrl).not.toContain('__KUBERNETES_REF_');
     });
+
+    it('direct factory reExecuteWithLiveStatus supports three-level nested compositions', () => {
+      const leafComposition = kubernetesComposition(
+        {
+          name: 'leaf',
+          kind: 'Leaf',
+          spec: type({ name: 'string' }),
+          status: type({ ready: 'boolean', endpoint: 'string' }),
+        },
+        (spec) => {
+          const deployment = simple.Deployment({
+            name: spec.name,
+            image: 'nginx:alpine',
+            id: 'leafDeployment',
+          });
+
+          return {
+            ready: deployment.status.readyReplicas >= 1,
+            endpoint: `http://${spec.name}:80`,
+          };
+        }
+      );
+
+      const middleComposition = kubernetesComposition(
+        {
+          name: 'middle',
+          kind: 'Middle',
+          spec: type({ name: 'string' }),
+          status: type({ ready: 'boolean', endpoint: 'string' }),
+        },
+        (spec) => {
+          const leaf = leafComposition({ name: `${spec.name}-leaf` });
+          const deployment = simple.Deployment({
+            name: `${spec.name}-middle`,
+            image: 'nginx:alpine',
+            env: { LEAF_ENDPOINT: leaf.status.endpoint },
+            id: 'middleDeployment',
+          });
+
+          return {
+            ready: leaf.status.ready && deployment.status.readyReplicas >= 1,
+            endpoint: leaf.status.endpoint,
+          };
+        }
+      );
+
+      const threeLevelComposition = kubernetesComposition(
+        {
+          name: 'three-level',
+          kind: 'ThreeLevel',
+          spec: type({ name: 'string' }),
+          status: type({ ready: 'boolean', endpoint: 'string' }),
+        },
+        (spec) => {
+          const middle = middleComposition({ name: spec.name });
+          const deployment = simple.Deployment({
+            name: `${spec.name}-outer`,
+            image: 'nginx:alpine',
+            env: { MIDDLE_ENDPOINT: middle.status.endpoint },
+            id: 'outerDeployment',
+          });
+
+          return {
+            ready: middle.status.ready && deployment.status.readyReplicas >= 1,
+            endpoint: middle.status.endpoint,
+          };
+        }
+      );
+
+      interface DirectFactoryWithReExecution {
+        reExecuteWithLiveStatus(
+          spec: { name: string },
+          liveStatusMap: Map<string, Record<string, unknown>>,
+        ): { ready: boolean; endpoint: string } | null;
+      }
+
+      const factory = threeLevelComposition.factory('direct', { namespace: 'test-ns' }) as unknown as DirectFactoryWithReExecution;
+      const status = factory.reExecuteWithLiveStatus(
+        { name: 'myapp' },
+        new Map([
+          ['middle1Leaf1', { readyReplicas: 1 }],
+          ['middle1MiddleDeployment', { readyReplicas: 1 }],
+          ['outerDeployment', { readyReplicas: 1 }],
+        ]),
+      );
+
+      expect(status).not.toBeNull();
+      expect(status?.ready).toBe(true);
+    });
   });
 
   describe('Bug #3: discovery stamps kind/apiVersion on list items', () => {


### PR DESCRIPTION
## Summary
- Bind non-overridden `Map` methods returned by the nested live-status proxy to the real backing `Map`.
- Add a three-level nested composition regression for direct-mode `reExecuteWithLiveStatus`.

## Bug
During CollectorBills dogfooding, direct-mode re-execution failed for deeper nested TypeKro compositions with:

```text
Map operation called on non-Map object
```

The failing path was nested live-status re-execution. TypeKro wraps the parent `liveStatusMap` in a proxy so nested compositions can resolve local resource IDs against merged parent IDs. That proxy overrides `get` and `has`, but other `Map` methods such as `keys()` were returned directly.

Native `Map` prototype methods perform receiver brand checks. When a deeper nested composition called `parentLiveStatusMap.keys()` on the proxy, the receiver was the proxy instead of the actual `Map`, so Bun threw before TypeKro could synthesize live status.

## Fix
For properties other than the overridden `get` and `has`, the proxy now reads from the real target and binds function values back to the real `Map` target. This preserves normal `Map` behavior while keeping the existing nested ID resolution logic for `get` and `has`.

## Verification
- `bun test --timeout 10000 test/unit/nested-composition-direct-mode.test.ts`
- `bunx biome lint src/core/composition/imperative.ts test/unit/nested-composition-direct-mode.test.ts`
- `bun run typecheck:tests`
- `bun run build:lib`