### PR TITLE
Add Dagster integration

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -93,6 +93,7 @@ export default withMermaid(
               { text: 'APISix', link: '/api/apisix/' },
               { text: 'External-DNS', link: '/api/external-dns/' },
               { text: 'Inngest', link: '/api/inngest/' },
+              { text: 'Dagster OSS', link: '/api/dagster/' },
               { text: 'Ory', link: '/api/ory/' },
               { text: 'Pebble', link: '/api/pebble/' },
               { text: 'SearXNG', link: '/api/searxng/' },

--- a/docs/advanced/integration-skill.md
+++ b/docs/advanced/integration-skill.md
@@ -16,9 +16,34 @@ Before generating an integration, gather:
 3. **Helm chart details** — record repository URL, chart name, Helm type, and default version. For OCI repositories, Flux constructs `{repo_url}/{chart_name}:{version}`, so verify the path and pass `type: 'oci'` to the HelmRepository. Check the exact tag format from GitHub releases (e.g., `v0.0.61-chart` vs `0.23.0`).
 4. **Readiness semantics** — how each resource reports readiness (conditions, phase, top-level boolean, custom).
 5. **Upstream ownership boundary** — identify the official operator, Helm chart, CRDs, and helper controllers. Prefer official upstream components over custom TypeKro controllers or bespoke charts unless the user explicitly asks for custom infrastructure.
-6. **Dependency contract** — list every dependency as `managed` or `external`: databases, Secrets, routes, object storage, email, DNS, TLS, cloud IAM, and sample upstreams. For managed dependencies, identify the exact generated resource names and keys consumed by Helm values (for example CNPG `*-db-app` Secret key `uri`).
+6. **Dependency contract** — list every dependency as `managed` or `external`: databases, Secrets, routes, object storage, email, DNS, TLS, cloud IAM, and sample upstreams. For managed dependencies, identify the exact generated resource names and keys consumed by Helm values (for example CNPG `*-db-app` Secret key `uri`). For security-sensitive inputs, decide whether the integration requires explicit secret material, an external `secretKeyRef`, or an explicit generation mode; never silently invent hidden secret state.
 7. **Baseline local requirements** — define what must work in local/CI without external DNS, TLS, SMTP, cloud credentials, or ingress controllers. Optional integrations should be opt-in, not required for the baseline.
-8. **Direct and KRO mode expectations** — decide which resources can exist in direct-only YAML and which must be valid in a graph-native RGD. Optional CRDs absent from common test clusters must not make the RGD inactive.
+8. **Direct and KRO mode expectations** — decide which resources can exist in direct-only YAML and which must be valid in a graph-native RGD. Optional CRDs absent from common test clusters must not make the RGD inactive. If direct mode supports a disabled/no-op instance, verify KRO status can also avoid omitted resources; otherwise document the option as direct-mode only and tell KRO users to omit the instance.
+
+## Integration Author Mental Model
+
+TypeKro integrations are not generic SDK wrappers. They are graph-aware resource compositions that must
+work in three execution shapes: direct deploy, KRO ResourceGraphDefinition generation, and plain YAML
+generation. Most sharp edges come from forgetting which values are concrete TypeScript data and which
+values are runtime graph references.
+
+Keep these boundaries explicit:
+
+- **Typed convenience fields** are for common, validated, field-selectable configuration. Model fields
+  structurally when the composition or mapper reads nested paths such as `schema.spec.webserver.image`.
+- **`values` is the raw Helm passthrough** for full chart compatibility. Raw chart areas that are only
+  forwarded do not need exhaustive TypeScript modeling.
+- **Do not infer Helm chart child resources.** If TypeKro owns a HelmRelease, status should usually be
+  derived from the HelmRelease and HelmRepository, not from Deployments, Pods, Jobs, or Secrets created
+  by the chart.
+- **Graph-aware values are first-class values.** Kubernetes refs, CEL expressions, schema proxy paths,
+  and values-merge expressions must be preserved, not cloned into plain JSON, stringified, or coerced.
+- **KRO schema visibility is intentional.** If generated YAML field-selects a path, ArkType must expose
+  that path structurally. If a field is truly opaque raw passthrough, do not field-select inside it.
+
+For Helm-chart integrations, the main design decision is not "how can we model the whole chart?" It is
+"which chart paths need TypeKro validation, defaults, references, or status-safe access?" Model those
+paths. Leave the rest to `values`.
 
 ## Generation Prompt
 
@@ -81,7 +106,7 @@ export const MyBootstrapConfigSchema = type({
   name: 'string',
   'namespace?': 'string',
   'version?': 'string',
-  'customValues?': 'Record<string, unknown>',
+  'values?': 'Record<string, unknown>',
   // ... operator-specific fields
 });
 export type MyBootstrapConfig = typeof MyBootstrapConfigSchema.infer;
@@ -126,6 +151,10 @@ export interface MyResourceStatus {
 - Nested objects: inline `{ field: 'string', 'optional?': 'number' }`
 
 **Defaults rule:** If a field has a default, make it optional in both the interface and schema, and apply the default in the factory. Never have a required type with a `?? default` in the factory — the type and runtime must agree.
+
+**Schema invariants:** Encode user-facing invariants in ArkType schemas whenever possible. Use `.narrow()` for conditional rules that cannot be represented as a simple shape, such as "enabled instances require either `server.secret_key` or `secretKeyRef`". Keep the base object schema shape intact so KRO SimpleSchema generation can still discover fields. Use factory-specific runtime guards only for mode-specific constraints the shared schema cannot express, such as a direct-only `enabled: false` option that is unsafe in KRO status.
+
+**Secret-source rule:** If the app requires a stable secret, require explicit material or a ref in the schema. Valid options are usually `server.secret_key`/`secretKey` to create a Kubernetes Secret, or `secretKeyRef` to use an existing Secret. Do not generate random values inside a composition, during `toYaml()`, or during RGD serialization; composition functions are re-executed and graph rendering must be deterministic. If a future integration adds generation, make it an explicit deploy-time mode that creates/reuses a persisted Secret before applying the graph and only reports the Secret ref, never the secret value.
 
 **CRD field names:** ⚠️ ArkType schema field names MUST match the CRD's OpenAPI schema field names exactly. KRO validates CEL paths against the CRD's schema — mismatches cause the RGD to be rejected as `Inactive`. Check the CRD: `kubectl get crd {name} -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties}'`. For example, CNPG uses `storageClass` (not `storageClassName`).
 
@@ -226,9 +255,9 @@ export function mapMyConfigToHelmValues(config: MyBootstrapConfig): Record<strin
     key2: config.operatorConfig?.key2,
   };
 
-  // Deep merge customValues last — recursive, prototype-safe
-  if (config.customValues) {
-    deepMerge(values, config.customValues);
+  // Deep merge user-provided Helm values last — recursive, prototype-safe.
+  if (config.values) {
+    deepMerge(values, config.values);
   }
 
   return values;
@@ -257,13 +286,66 @@ const repo = myHelmRepository({ ... });
 setMetadataField(repo, 'lifecycle', 'shared');
 ```
 
-**Custom values merge:** The helm-values-mapper uses recursive deep merge for `customValues`. Plain objects merge key-by-key at arbitrary depth. Arrays and primitives replace. Prototype pollution is guarded (`__proto__`, `constructor`, `prototype` keys are skipped).
+**Helm values passthrough:** Use `values` as the primary user-facing passthrough API for chart values. Avoid parallel knobs like `customValues`, `extraValues`, `literalOnly`, or `directOnly` unless you have a concrete compatibility reason. The helm-values-mapper uses recursive deep merge for `values`: plain objects merge key-by-key at arbitrary depth; arrays and primitives replace; prototype pollution is guarded (`__proto__`, `constructor`, `prototype` keys are skipped). Add regression tests that prove framework/runtime values survive whole-map graph merges.
+
+**Typed fields vs raw values:** Typed convenience fields and raw `values` have different jobs:
+- Add typed fields for chart paths that are common, safety-sensitive, cross-resource referenced, or
+  need validation before deploy/YAML generation.
+- Keep unusual or fast-changing chart areas in `values`; do not chase the entire upstream `values.yaml`
+  unless the user explicitly asks for a complete typed surface.
+- If typed config and raw `values` target the same chart path, raw `values` should merge last so users
+  can intentionally override defaults.
+- Arrays should normally replace rather than concatenate. Concatenation usually surprises chart users
+  and can duplicate containers, env vars, volumes, or deployment entries.
+
+**KRO schema visibility rule:** If the mapper or composition reads `spec.some.path`, the ArkType schema
+must expose `some.path` as a structured object. Do not use broad `object` or `Record<string, unknown>`
+for a value you later field-select in KRO-generated YAML. Opaque objects are fine only when they are
+passed through wholesale.
+
+Example: if the mapper needs `schema.spec.webserver.image.repository`, model at least:
+
+```typescript
+const imageSchemaShape = {
+  repository: 'string',
+  'tag?': 'string',
+  'pullPolicy?': '"Always" | "IfNotPresent" | "Never"',
+} as const;
+
+export const MyBootstrapConfigSchema = type({
+  name: 'string',
+  'webserver?': {
+    'image?': imageSchemaShape,
+    'replicaCount?': 'number',
+  },
+  'values?': 'Record<string, unknown>',
+});
+```
+
+If KRO rejects an RGD with an error like `type 'string' does not support field selection`, look for a
+generated expression that selects through an opaque schema field. Fix the schema shape or stop selecting
+inside that raw field.
+
+**Graph-aware values merge rule:** Treat Kubernetes refs, CEL expressions, schema proxy values, and
+values-merge expressions as runtime values, not JSON. Do not use JSON cloning, object spreading as a
+deep clone, or string interpolation that can produce `[object Object]`. When raw values overlay typed
+values in KRO mode, preserve typed graph-aware fields at sibling paths. For example, a raw
+`values.dagsterWebserver.service.type` override must not erase a typed graph-aware
+`webserver.image.repository` that selects from `schema.spec.webserver.image.repository`.
+
+Good regression assertions for graph-aware Helm values:
+- Generated RGD YAML contains expected `schema.spec.*` paths for typed fields.
+- Generated RGD YAML contains `json.unmarshal(json.marshal(schema.spec.values))` or the expected merge
+  expression for raw passthrough.
+- Generated YAML does not contain raw markers such as `__KUBERNETES_REF_`, internal schema keys,
+  `[object Object]`, or `undefined`.
+- Unit mapper tests prove refs/CEL survive inside nested raw `values`.
 
 **Dependency-source resolution:** If the integration wires managed infrastructure into Helm charts, keep dependency resolution explicit and test it thoroughly:
 - Managed dependencies should reference the actual producer's output, not a guessed placeholder. For CNPG app databases, use the generated application Secret/key (`*-db-app`, key `uri`) when the chart needs a DSN with credentials.
 - External dependencies should accept Secret refs or literal URLs only where production-safe.
 - Values mappers must validate unresolved dependencies early with structured errors.
-- Do not pass raw schema proxies, raw `values`, or raw `customValues` into graph fallback values if the chart requires concrete strings or nested config. Build a graph-safe fallback config and let the mapper emit deterministic defaults.
+- Do not pass raw schema proxies or raw `values` into graph fallback values if the chart requires concrete strings or nested config. Build a graph-safe fallback config and let the mapper emit deterministic defaults. Preserve user/runtime `values` in the final graph merge; do not drop whole-map values while constructing graph-safe fallbacks.
 - Add tests that inspect generated RGD YAML for the exact Secret names/keys and required chart defaults.
 
 **For OCI registries**, pass `type: 'oci'` to `helmRepository()`:
@@ -355,8 +437,9 @@ return {
 **Platform compositions with nested stacks:** If a composition creates managed infrastructure and then calls a nested integration stack:
 - Keep the infrastructure ownership in the platform composition and pass dependencies through typed dependency sources.
 - Rebuild status field-by-field from nested status handles. Do not pass a nested `status` object wholesale into the parent status; KRO may serialize nested object references into invalid expressions.
-- KRO graph fallback should contain only graph-safe values. Strip raw `values`, `customValues`, Secret value sources, and optional service config that can become `omit()` where Helm requires a concrete string.
+- KRO graph fallback should contain only graph-safe values. Strip raw `values`, Secret value sources, and optional service config that can become `omit()` where Helm requires a concrete string. Preserve user/runtime `values` in the final merge path so graph-safe fallbacks do not erase chart passthrough values.
 - Omit optional CRDs from the RGD when the CRD may not exist in baseline clusters. It is fine for concrete direct-mode YAML to include optional resources gated by a concrete spec flag.
+- KRO status may only reference resources that are present for every schema-valid KRO instance. If a resource is conditionally omitted, either make the status field independent of that resource, split direct-only behavior from KRO behavior, or reject that KRO instance shape with a clear factory-specific error.
 - Do not create a `Namespace` resource in a KRO graph for the same namespace that contains the KRO instance. Create test namespaces outside the graph, deploy the instance into them, then delete those namespaces after `deleteInstance`.
 
 **Barrel exports (`index.ts`):** Each directory needs a barrel export:
@@ -378,9 +461,11 @@ export type { MyConfig, MyStatus } from './types.js';
 
 **Unit tests** — for helm:
 - HelmRepository with defaults (verify URL, namespace, type)
-- HelmRelease with defaults and custom values
-- `sanitizeHelmValues`: plain values survive intact (strings, numbers, booleans, nested objects, arrays), empty input returns defined object. ⚠️ This is consistently flagged in reviews — always include these tests.
+- HelmRelease with defaults and user-provided `values`
 - mapConfigToHelmValues with various inputs (including verifying bootstrap-only fields like `name`/`namespace`/`version` are NOT passed through)
+- Raw `values` merge last while preserving typed values at unrelated sibling paths
+- Refs and CEL expressions survive inside nested Helm values and generated RGD YAML
+- Graph-aware arrays pass through directly when they are schema refs; concrete arrays still get defaults or replacement semantics as intended
 - Version override test must assert the actual version value, not just other fields
 - getHelmValueWarnings (if any)
 
@@ -399,11 +484,12 @@ export type { MyConfig, MyStatus } from './types.js';
 - ⚠️ Run with parallel kubectl monitoring via a background Bash command (not a subagent — subagents can't run Bash). Monitor HelmRepository, HelmRelease, HelmChart, and pods every 15s to catch OCI pull errors, CrashLoopBackOff, or SourceNotReady early.
 - Do not materialize command strings, logs, generated YAML snapshots, or debugging output into repo files unless the user explicitly asks for a committed artifact. Use temp paths outside the workspace for long-running logs.
 
-**Deep merge for customValues:**
+**Deep merge for values:**
 - Test one-level deep merge (existing keys preserved)
 - Test two-level deep merge (nested objects merged recursively)
 - Test array replacement (not concatenation)
 - Test primitive override
+- Test whole-map graph merges so user/runtime chart values survive KRO serialization and final resource emission
 
 #### Step 7: Documentation
 
@@ -460,20 +546,24 @@ Then verify each item:
 - [ ] Phase uses simple two-state ternary (no nested `.exists()`)
 - [ ] `failed` uses separate single `.exists()` expression
 - [ ] Status type exactly matches what the CEL actually produces
+- [ ] KRO status references only resources that exist for every schema-valid KRO instance; direct-only disabled/no-op paths are documented or rejected in KRO mode
 - [ ] `version` is documented as deploy-time, not runtime
 - [ ] Labels use app version (stripped of `-chart` suffix if needed)
 
 **Helm:**
-- [ ] `sanitizeHelmValues` uses `isKubernetesRef`/`isCelExpression` type guards
+- [ ] If the integration implements `sanitizeHelmValues` directly, it uses `isKubernetesRef`/`isCelExpression` type guards. If it delegates to `helmRelease()`, no local sanitizer is needed.
 - [ ] OCI registries have `type: 'oci'` on HelmRepository
 - [ ] Chart version tag format verified from operator's GitHub releases
 - [ ] Cross-namespace HelmRepositories (flux-system) marked `lifecycle: 'shared'`
-- [ ] `customValues` deep merge tested at 2+ levels of nesting
+- [ ] `values` deep merge tested at 2+ levels of nesting, including a graph-mode whole-map merge regression
 - [ ] Values mapper excludes bootstrap-only fields (`name`, `namespace`, `version`) from Helm output
+- [ ] Typed fields that are field-selected in KRO YAML have structured ArkType schema paths, not opaque `object` fields
+- [ ] Raw `values` merge last while preserving graph-aware typed sibling fields in KRO mode
 
 **Integration:**
 - [ ] Integration test covers both `'kro'` and `'direct'` factory modes
 - [ ] Config types are inferred from ArkType schemas (`typeof Schema.infer`), not hand-written interfaces
+- [ ] Schema-level invariants reject invalid enabled configs early (for example missing secret sources) without relying only on late composition errors
 - [ ] Live e2e proves both direct and KRO modes for dependency-managing stacks
 - [ ] Generated in-cluster HelmRelease values reference the expected managed Secrets and concrete chart defaults
 - [ ] KRO RGD reaches `Active True`, KRO instance reaches ready, and cleanup via `deleteInstance` completes
@@ -489,8 +579,8 @@ Then verify each item:
 **Tests:**
 - [ ] Every readiness state has a unit test
 - [ ] Integration test asserts every field declared by the status schema, not just `ready`
-- [ ] Helm unit tests verify defaults, custom values, readiness evaluators
-- [ ] `sanitizeHelmValues` tests construct mock branded objects with `Symbol.for('TypeKro.KubernetesRef')` and `Symbol.for('TypeKro.CelExpression')` and verify they are STRIPPED (not just that plain values pass through). KubernetesRef mocks need both `resourceId` and `fieldPath` string properties.
+- [ ] Helm unit tests verify defaults, user-provided `values`, readiness evaluators
+- [ ] If a local `sanitizeHelmValues` exists, tests construct mock branded objects with `Symbol.for('TypeKro.KubernetesRef')` and `Symbol.for('TypeKro.CelExpression')` and assert the intended behavior. If using `helmRelease()`, tests should instead verify refs/CEL are preserved through nested Helm values.
 - [ ] Values mapper test verifies bootstrap-only fields (`name`, `namespace`, `version`) are NOT in output
 - [ ] Version override test asserts the actual version value, not just other fields
 - [ ] No `exactOptionalPropertyTypes` violations (no `replicaCount: undefined` — use conditional spreads)
@@ -502,6 +592,7 @@ Then verify each item:
 
 **Docs & exports:**
 - [ ] API reference page exists with readiness table and limitations noted
+- [ ] Direct-only options are explicitly labeled; docs do not promise KRO behavior for instance shapes the KRO factory rejects
 - [ ] Sidebar nav entry added (alphabetical order)
 - [ ] `package.json` export added
 - [ ] JSDoc on all public APIs with `@example`
@@ -551,7 +642,7 @@ git diff master...HEAD -- src/ # review all source changes
 ### Common Mistakes to Avoid
 
 1. **ArkType schema drift** — The #1 issue across both CNPG and Valkey PRs. Go field-by-field. Extract shared schema shapes for types used in multiple places.
-2. **Raw property checks in sanitizeHelmValues** — Use `isKubernetesRef()`/`isCelExpression()`.
+2. **Raw property checks in sanitizer code** — If you implement local Helm-value sanitization, use `isKubernetesRef()`/`isCelExpression()` instead of raw property checks. Prefer delegating to `helmRelease()` when possible so refs/CEL are preserved by the existing Helm machinery.
 3. **String types for enums** — Use union types (`'Exists' | 'Equal'`).
 4. **Missing `id` parameter** — Every resource in a composition MUST have `id: 'camelCase'`.
 5. **Forgetting docs/exports** — Docs page, sidebar entry, package.json export.
@@ -560,13 +651,13 @@ git diff master...HEAD -- src/ # review all source changes
 8. **DRY violation with constants** — Import `DEFAULT_FLUX_NAMESPACE` from core. Extract repo name/version/URL as exported constants.
 9. **Status type wider than CEL expression** — Type must match runtime output.
 10. **Missing `conditions` on status types** — If using condition-based evaluator, status needs `conditions?`.
-11. **sanitizeHelmValues drops more than proxies** — Document that custom values must be JSON-serializable.
+11. **Sanitizer logic drops graph-aware values** — Document the intended behavior. Some integrations need to strip proxy markers before concrete YAML; HelmRelease values generally need to preserve refs/CEL so KRO can resolve them at reconcile time.
 12. **Incomplete nested schemas** — Each nested schema reference is independent.
 13. **Nested CEL ternaries** — Only simple two-state ternaries work. Use `failed` boolean for failure detection. See [#48](https://github.com/yehudacohen/typekro/issues/48).
 14. **OCI Helm repositories** — Need `type: 'oci'`, have no status field, version tag format varies per operator.
 15. **String literal coupling** — After writing, grep for any string that appears in both a factory default and a composition. Extract as a constant.
 16. **Chart version in labels** — `app.kubernetes.io/version` should be the app version, not the chart tag. Strip `-chart` suffix.
-17. **Missing `sanitizeHelmValues` tests** — Every review flags this. Always test that plain values survive and proxy objects are stripped. This is the safety barrier between the magic proxy and Helm YAML.
+17. **Testing the wrong Helm-value boundary** — If using `helmRelease()`, do not add a redundant local sanitizer just to satisfy a pattern. Test the actual boundary: defaults, raw `values`, mapper output, nested refs/CEL preservation, and generated RGD YAML. Only test `sanitizeHelmValues` directly when the integration owns sanitizer code.
 18. **JSDoc version prefix mismatch** — If `DEFAULT_VERSION = '0.3.1'`, don't write `@default 'v0.3.1'` in JSDoc. Users copy from docs and pass the wrong value.
 19. **Spreading the magic proxy in compositions** — `{ ...spec }` doesn't work for nested proxy objects. Access fields explicitly: `{ name: spec.name, inngest: spec.inngest }`. Use `Object.assign` with conditional spreads for optional fields to satisfy `exactOptionalPropertyTypes`.
 20. **Hex key format for Inngest** — `eventKey` and `signingKey` must be hex strings. Test keys like `'test-key'` will crash the container. Use `'deadbeef0123456789abcdef01234567'` in tests.
@@ -602,10 +693,19 @@ git diff master...HEAD -- src/ # review all source changes
     **Prefer writing compositions as if they're plain JavaScript — if a pattern doesn't work, report it as a framework gap rather than reaching for `Cel.expr(...)` / `Cel.conditional(...)` / `Cel.has(...)` as a workaround. The explicit helpers are escape hatches for edge cases, not the default way to express conditionals.** Some things are still hard JS language limits (you can't intercept `??` on a proxy because JS evaluates it eagerly), but the framework covers the overwhelming majority of use cases and improves over time. When you hit a gap, file an issue linking to https://github.com/yehudacohen/typekro/issues/57 (AST-based analysis rewrite) and document the workaround inline.
 33. **Fix framework limitations at the framework level** — Related to rule #32: if a composition needs an ugly workaround (`isKubernetesRef(spec.x) ? ... : ...` to detect KRO mode, explicit `Cel.conditional(...)` blocks, private imports of internal helpers), treat it as a FRAMEWORK BUG and fix the framework instead. Workarounds buried in compositions become invisible to future maintainers and proliferate; framework-level fixes benefit every downstream composition. The `if (!spec.x)`-driven differential capture that now ships in TypeKro was originally an ad-hoc `Cel.not(Cel.has(spec.x))` construct in the SearXNG composition — when the author insisted on native-TypeScript ergonomics, the framework grew the capability, and the composition became ~30 lines shorter.
 34. **Optional-field overrides in differential capture are scoped to "tested" fields only** — The `processCompositionBodyAnalysis` hybrid-spec re-execution only overrides optional fields that appear in an `if`-condition or equivalent test (extracted from the AST analyzer's `includeWhen` expressions). Fields accessed unconditionally (e.g., `spec.server?.secret_key` inside a `stringData: { secret_key: ... }` object) are left as proxy references so their values flow through correctly in the captured resources. When adding a new conditional pattern, make sure the field you're testing appears in a way the `conditionToCel` bare-reference pattern recognises (`schema.spec.X` or `!schema.spec.X`); compound conditions (`spec.x && spec.y`) don't currently get extracted, so the override set will be empty and the branch capture will silently fail. Tracked in https://github.com/yehudacohen/typekro/issues/57.
-35. **KRO graph fallback values must not carry optional schema-proxy service config into Helm values** — For Helm values that require concrete defaults (for example Ory Kratos `identity.schemas[].id` and `selfservice.default_browser_return_url`), build a graph-safe fallback config that strips raw `values`, `customValues`, Secret sources, and optional service overrides. Let the mapper emit deterministic defaults, and assert the generated RGD contains those defaults. Optional proxy branches can produce `omit()` expressions in places the chart expects concrete strings.
+35. **KRO graph fallback values must not carry optional schema-proxy service config into Helm values** — For Helm values that require concrete defaults (for example Ory Kratos `identity.schemas[].id` and `selfservice.default_browser_return_url`), build a graph-safe fallback config that strips raw `values`, Secret sources, and optional service overrides. Let the mapper emit deterministic defaults, preserve user/runtime `values` in the final merge path, and assert the generated RGD contains those defaults. Optional proxy branches can produce `omit()` expressions in places the chart expects concrete strings.
 36. **Nested `id` is valid resource config, not always TypeKro metadata** — Resource factories use top-level `id` as the graph node identifier, but Helm values and CRD specs may also contain legitimate nested `id` fields. Serializer/reference-processing code must only remove hidden TypeKro metadata such as `__resourceId`; do not globally drop every key named `id`. Add regression assertions when an integration relies on nested ids.
 37. **Managed operator credentials should reference the operator-generated Secret, not a hand-written placeholder** — If a database operator like CNPG creates application credentials, point consuming Helm values at the generated Secret/key (for CNPG app users, commonly `*-db-app` and key `uri`). A placeholder DSN Secret without the generated password may pass YAML tests but will fail live migrations with database authentication errors.
 38. **Do not trust local RGD YAML alone for KRO integrations** — Local YAML proves serialization, but not KRO expression evaluation, Flux handoff, generated Secret availability, or chart runtime validation. For stacks that create dependencies and HelmReleases, inspect the live HelmRelease after KRO creates it and verify the final `spec.values` matches expectations.
 39. **Status passthrough must be field-by-field** — Passing nested status objects from a child stack into a parent status can serialize to invalid or unevaluable KRO expressions. Rebuild parent status one field at a time from child handles: booleans, phase, component map entries, endpoint strings, and version.
 40. **Optional CRDs must not poison baseline KRO mode** — If APISIX, ACK, cert-manager, or another optional CRD is not part of the baseline, do not emit those resources in graph-native RGD generation. Gate them on concrete direct-mode specs or require explicit user setup. Status must match what the graph actually owns; if KRO mode omits APISIX route resources, route infrastructure should report unmanaged/false rather than implying managed routes exist.
 41. **Artifact hygiene matters during integration work** — Long e2e logs belong in temp directories, not the repo. Do not create backup files, generated command artifacts, checked-in debug YAML, or alternate implementation files. If a generated artifact is useful, document the command that reproduces it instead of committing the generated output.
+42. **Schema-first invariants beat late factory surprises** — If an enabled integration cannot run without a field (for example a SearXNG secret source), enforce that invariant in the ArkType schema with `.narrow()` or a precise union. Keep mode-specific guards only for constraints the shared schema cannot express, such as direct-only `enabled: false` behavior that KRO status cannot support.
+43. **KRO status must match KRO-owned resources** — Do not let status reference a resource that can be omitted by `includeWhen`. If direct mode can return a static disabled status but KRO status is tied to a Deployment/HelmRelease, reject disabled KRO instances or remove the status dependency. KRO users can omit an instance; a broken reconciler status is worse than an explicit error.
+44. **Secret generation must be explicit and persistent** — Do not call `Math.random()`, `crypto.randomUUID()`, or similar inside a composition or YAML render to create secret material. Kubernetes can persist a Secret, but the composition/RGD renderer cannot safely implement "generate once if missing" without a deploy-time controller step. Require `secretKeyRef` or explicit secret material, or add a clearly named deploy-time generation mode that creates/reuses the Secret before graph reconciliation.
+45. **`values` is the Helm passthrough API** — Prefer `values` for raw chart passthrough and deep merge it last. Avoid new user-facing knobs like `customValues`, `extraValues`, `literal-only`, or `direct-only` to work around serialization issues. Fix framework merge/serialization bugs or keep graph-safe fallbacks internal instead.
+46. **Opaque schemas cannot be field-selected in KRO** — `Record<string, unknown>` and broad `object` fields are fine for raw passthrough, but not for paths the mapper reads. If generated YAML uses `schema.spec.webserver.image.repository`, the ArkType schema must structurally expose `webserver.image.repository`.
+47. **Raw values overlays can erase typed graph-aware fields** — When typed config and raw `values` target the same chart section, make sure partial raw overlays do not replace the entire typed graph-aware object. Preserve typed sibling fields such as images, Secret refs, and pod config while still letting raw values merge last.
+48. **Graph-aware arrays are not always concrete arrays** — A schema ref to an array is a runtime value. Do not wrap it in another array or call `.map()` on it unless you first know it is a concrete array. Concrete arrays can receive defaults item-by-item; graph-aware array refs should usually pass through directly.
+49. **Skipped live deploy is not acceptance for deployment integrations** — YAML and unit tests are necessary but insufficient when the integration claims a full deploy path. Use architecture-compatible images, local image builders, or explicit pullable images and prove direct/KRO readiness when the acceptance scenario requires it.
+50. **Stale generated KRO definitions can hide schema fixes** — If a live KRO test keeps reporting old schema behavior after the source changed, check whether an old ResourceGraphDefinition or generated CRD is still present. Prefer normal cleanup, but for tests that intentionally recreate the same RGD name, reset stale definitions in setup and document why.

--- a/docs/api/dagster/index.md
+++ b/docs/api/dagster/index.md
@@ -1,0 +1,427 @@
+---
+title: Dagster
+description: Deploy Dagster OSS to Kubernetes with TypeKro using the official Dagster Helm chart.
+---
+
+# Dagster
+
+TypeKro's Dagster integration deploys Dagster OSS through the official Dagster Helm chart.
+It creates the Kubernetes Namespace, Flux HelmRepository, and Flux HelmRelease needed to run
+Dagster, while leaving chart-generated webserver, daemon, user-code, run-worker, PostgreSQL,
+Redis, RabbitMQ, ingress, and pod resources owned by Helm and Flux.
+
+```ts
+import {
+  dagsterBootstrap,
+  dagsterHelmRelease,
+  dagsterHelmRepository,
+  mapDagsterConfigToHelmValues,
+} from 'typekro/dagster';
+```
+
+## What Gets Created
+
+`dagsterBootstrap` creates three TypeKro-owned resources:
+
+- A `Namespace` for the Dagster deployment namespace.
+- A Flux `HelmRepository` for `https://dagster-io.github.io/helm`.
+- A Flux `HelmRelease` for chart `dagster`, default version `1.13.8`.
+
+The bootstrap status is derived from owned Flux resources only. Component booleans such as
+`webserver`, `daemon`, and `userDeployments` mean the owning HelmRelease is ready, not that
+TypeKro inspected chart-generated Deployments or Pods.
+
+## Minimal Bootstrap
+
+```ts
+import { dagsterBootstrap } from 'typekro/dagster';
+
+const factory = dagsterBootstrap.factory('kro', {
+  namespace: 'dagster',
+});
+
+await factory.deploy({
+  name: 'analytics',
+  namespace: 'dagster',
+  userDeployments: {
+    enabled: true,
+    deployments: [
+      {
+        name: 'analytics-repo',
+        image: {
+          repository: 'ghcr.io/acme/dagster-analytics',
+          tag: '2026.06.01',
+        },
+        codeServerArgs: ['-m', 'analytics.definitions'],
+      },
+    ],
+  },
+});
+```
+
+Use `dagsterApiGrpcArgs` instead of `codeServerArgs` when your image starts a gRPC server with
+`dagster api grpc`. Typed user deployments must set exactly one of those fields. If omitted,
+TypeKro defaults the user-code port to `3030` and image pull policy to `IfNotPresent`.
+
+## Direct, KRO, And YAML Workflows
+
+Use direct mode for immediate apply/read/delete operations:
+
+```ts
+const direct = dagsterBootstrap.factory('direct', {
+  namespace: 'dagster',
+});
+
+await direct.deploy({
+  name: 'analytics',
+  namespace: 'dagster',
+  userDeployments: {
+    enabled: true,
+    deployments: [
+      {
+        name: 'analytics-repo',
+        image: { repository: 'ghcr.io/acme/dagster-analytics', tag: '2026.06.01' },
+        dagsterApiGrpcArgs: ['-m', 'analytics.grpc'],
+      },
+    ],
+  },
+});
+```
+
+Use YAML generation for GitOps:
+
+```ts
+const rgdYaml = dagsterBootstrap.toYaml();
+```
+
+Generated ResourceGraphDefinition YAML does not read the cluster. Raw `values` are serialized as
+runtime graph-aware Helm values, so schema refs and CEL values are preserved instead of being
+stringified.
+
+## Low-Level Helm Wrappers
+
+Use low-level wrappers when you want to compose your own resource graph:
+
+```ts
+const repo = dagsterHelmRepository({
+  id: 'dagsterHelmRepository',
+});
+
+const release = dagsterHelmRelease({
+  id: 'dagsterHelmRelease',
+  name: 'analytics',
+  namespace: 'dagster',
+  values: mapDagsterConfigToHelmValues({
+    name: 'analytics',
+    userDeployments: {
+      enabled: true,
+      deployments: [
+        {
+          name: 'analytics-repo',
+          image: { repository: 'ghcr.io/acme/dagster-analytics', tag: '2026.06.01' },
+          codeServerArgs: ['-m', 'analytics.definitions'],
+        },
+      ],
+    },
+  }),
+});
+```
+
+Defaults:
+
+- Repository URL: `https://dagster-io.github.io/helm`
+- Repository name: `dagster`
+- Chart name: `dagster`
+- Chart version: `1.13.8`
+- Repository namespace: `flux-system`
+
+## Typed Configuration
+
+Common chart areas have typed convenience fields:
+
+```ts
+await factory.deploy({
+  name: 'analytics',
+  namespace: 'dagster',
+  serviceAccountName: 'dagster-runtime',
+  rbacEnabled: true,
+  imagePullSecrets: [{ name: 'dagster-registry' }],
+  webserver: {
+    replicaCount: 2,
+    pathPrefix: '/dagster',
+    service: { type: 'ClusterIP', port: 8080 },
+    logFormat: 'json',
+  },
+  daemon: {
+    enabled: true,
+    runRetries: { enabled: true, maxRetries: 2 },
+    runMonitoring: { enabled: true },
+  },
+  userDeployments: {
+    enabled: true,
+    deployments: [
+      {
+        name: 'analytics-repo',
+        image: { repository: 'ghcr.io/acme/dagster-analytics', tag: '2026.06.01' },
+        codeServerArgs: ['-m', 'analytics.definitions'],
+        envSecrets: [{ name: 'analytics-dagster-env' }],
+        resources: { requests: { cpu: '250m', memory: '512Mi' } },
+      },
+    ],
+  },
+  runLauncher: {
+    type: 'K8sRunLauncher',
+    k8sRunLauncher: {
+      jobNamespace: 'dagster-runs',
+      envSecrets: [{ name: 'dagster-run-env' }],
+    },
+  },
+  computeLogManager: {
+    type: 'S3ComputeLogManager',
+    config: { bucket: 'dagster-compute-logs', prefix: 'runs' },
+  },
+});
+```
+
+Typed fields cover the common chart surface for webserver, daemon, user deployments, PostgreSQL,
+run launcher, scheduler, compute logs, Flower, ingress, RabbitMQ, Redis, image pull Secrets,
+RBAC, and global chart settings.
+
+## Raw Values Passthrough
+
+Use `values` for official chart fields not modeled as typed convenience config. Raw `values` merge
+last, so they can override typed fields when needed.
+
+```ts
+await factory.deploy({
+  name: 'analytics',
+  namespace: 'dagster',
+  userDeployments: {
+    enabled: true,
+    deployments: [
+      {
+        name: 'analytics-repo',
+        image: { repository: 'ghcr.io/acme/dagster-analytics', tag: '2026.06.01' },
+        codeServerArgs: ['-m', 'analytics.definitions'],
+      },
+    ],
+  },
+  values: {
+    busybox: { image: { repository: 'busybox', tag: '1.36' } },
+    dagsterWebserver: { replicaCount: 3 },
+    extraManifests: [],
+  },
+});
+```
+
+Plain objects merge recursively. Arrays replace earlier arrays. Primitive raw values override typed
+values. Kubernetes refs, CEL expressions, and TypeKro values-merge expressions are preserved. In KRO
+mode, partial raw `dagsterWebserver` or `dagsterDaemon` overrides preserve typed image settings such
+as architecture-compatible validation images while still applying the raw chart fields last.
+
+## External PostgreSQL And Secrets
+
+For production, prefer externally managed Secrets and external PostgreSQL databases. TypeKro does
+not generate hidden credentials.
+
+```ts
+await factory.deploy({
+  name: 'analytics',
+  namespace: 'dagster',
+  userDeployments: {
+    enabled: true,
+    deployments: [
+      {
+        name: 'analytics-repo',
+        image: { repository: 'ghcr.io/acme/dagster-analytics', tag: '2026.06.01' },
+        codeServerArgs: ['-m', 'analytics.definitions'],
+      },
+    ],
+  },
+  postgresql: {
+    enabled: false,
+    host: 'dagster-postgres.postgres.svc.cluster.local',
+    username: 'dagster',
+    database: 'dagster',
+    passwordSecretName: 'dagster-postgres',
+    servicePort: 5432,
+  },
+});
+```
+
+This maps to chart PostgreSQL values such as `postgresql.postgresqlHost`,
+`postgresql.postgresqlUsername`, `postgresql.postgresqlDatabase`, and
+`global.postgresqlSecretName`. When `passwordSecretName` is set, the mapper sets
+`generatePostgresqlPasswordSecret: false`.
+
+Literal passwords are accepted only when explicitly supplied by the caller and are intended for
+local development. Production configs should reference Secrets through chart-supported Secret
+fields, `envSecrets`, `imagePullSecrets`, or raw `values`.
+
+## Celery Run Launcher
+
+Celery mode requires a broker/backend path. Configure RabbitMQ, Redis, an existing Celery config
+Secret, or raw chart values.
+
+```ts
+await factory.deploy({
+  name: 'analytics',
+  namespace: 'dagster',
+  global: {
+    celeryConfigSecretName: 'dagster-celery-config',
+  },
+  runLauncher: {
+    type: 'CeleryK8sRunLauncher',
+    celeryK8sRunLauncher: {
+      workerQueues: [{ name: 'default', replicaCount: 2 }],
+    },
+  },
+  rabbitmq: {
+    enabled: true,
+    servicePort: 5672,
+    values: { persistence: { enabled: true } },
+  },
+  userDeployments: {
+    enabled: true,
+    deployments: [
+      {
+        name: 'analytics-repo',
+        image: { repository: 'ghcr.io/acme/dagster-analytics', tag: '2026.06.01' },
+        codeServerArgs: ['-m', 'analytics.definitions'],
+      },
+    ],
+  },
+});
+```
+
+If `global.celeryConfigSecretName` is set, TypeKro sets `generateCeleryConfigSecret: false`.
+RabbitMQ and Redis `values` merge into their official chart blocks; they do not appear as nested
+`.values` keys.
+
+## Ingress
+
+```ts
+await factory.deploy({
+  name: 'analytics',
+  namespace: 'dagster',
+  ingress: {
+    enabled: true,
+    ingressClassName: 'nginx',
+    dagsterWebserver: {
+      host: 'dagster.example.com',
+      path: '/',
+      tls: { enabled: true, secretName: 'dagster-tls' },
+    },
+  },
+  userDeployments: {
+    enabled: true,
+    deployments: [
+      {
+        name: 'analytics-repo',
+        image: { repository: 'ghcr.io/acme/dagster-analytics', tag: '2026.06.01' },
+        codeServerArgs: ['-m', 'analytics.definitions'],
+      },
+    ],
+  },
+});
+```
+
+You must provide the ingress controller, DNS, and TLS Secret or cert-manager policy appropriate for
+your cluster.
+
+## Validation
+
+TypeKro validates common impossible or unsafe typed configurations before deploy or YAML generation:
+
+- A typed user-code deployment must set exactly one of `dagsterApiGrpcArgs` or `codeServerArgs`.
+- `CeleryK8sRunLauncher` requires RabbitMQ, Redis, an existing Celery Secret, or raw Celery values.
+- External PostgreSQL typed config with `enabled: false` requires `host` or raw PostgreSQL values.
+
+Validation failures throw `DagsterConfigurationError`, a structured `TypeKroError` with safe issue
+metadata. Error messages do not include secret values.
+
+## Operations
+
+Recommended rollout checks:
+
+- Inspect the TypeKro instance status for `ready`, `phase`, and `failed`.
+- Inspect the Flux HelmRepository and HelmRelease Ready conditions.
+- Inspect Flux controller logs for chart fetch, install, and upgrade failures.
+- Inspect chart-generated pods for webserver, daemon, user-code, run workers, and step workers.
+- Inspect PostgreSQL, Redis, RabbitMQ, ingress, DNS, TLS, and object-storage dependencies owned by
+your platform.
+
+Recommended alerts:
+
+- HelmRelease Ready is false or not ready longer than the expected rollout window.
+- Dagster daemon is unavailable while schedules or sensors should run.
+- User-code deployment pods are unavailable or restarting.
+- PostgreSQL, Redis, RabbitMQ, image pull, or ingress failures appear in pod events.
+
+## Troubleshooting
+
+Start from TypeKro status, then move to Flux and chart-generated resources:
+
+```sh
+kubectl get helmrepository -n flux-system
+kubectl get helmrelease -n dagster
+kubectl describe helmrelease -n dagster analytics
+kubectl get pods -n dagster
+```
+
+Common issues:
+
+- Image pull failures: verify the configured image tag, registry access, and `imagePullSecrets`.
+- Database failures: verify `postgresql.host`, Secret name/key, database name, and network policy.
+- Celery failures: verify run launcher type, RabbitMQ/Redis settings, and Celery Secret wiring.
+- User-code load failures: inspect user-code pod logs and gRPC/code-server arguments.
+- KRO-only image or pod config failures: verify partial raw `values.dagsterWebserver` or
+  `values.dagsterDaemon` overrides are not replacing typed image settings you need for the cluster
+  architecture.
+- Ingress failures: verify ingress class, DNS, TLS Secret, and controller logs.
+- Upgrade failures: inspect HelmRelease conditions, then roll back by changing `version` or `values`.
+
+## Live Validation
+
+The integration test can prove the direct-mode path reaches HelmRelease `Ready=True` when a live
+cluster has Flux Helm CRDs/controllers and a Dagster image that matches the cluster architecture.
+
+For arm64 local clusters, build the checked-in validation fixture image through TypeKro's
+container builder:
+
+```ts
+import { buildContainer } from 'typekro/containers';
+
+await buildContainer({
+  context: 'test/integration/dagster/fixtures/arm64-validation',
+  imageName: 'typekro-dagster-validation',
+  tag: '1.13.8',
+  platform: 'linux/arm64',
+  registry: { type: 'orbstack' },
+  timeout: 900000,
+});
+```
+
+Then run the live test:
+
+```sh
+bun test test/integration/dagster/bootstrap-composition.test.ts --timeout 900000
+```
+
+The test also auto-detects `typekro-dagster-validation:1.13.8` on arm64 when it is available in the
+local Docker image store. If the image is absent and Docker is available, the test builds it with
+TypeKro's `buildContainer` helper before deploying. For remote clusters, push that fixture to a
+registry the cluster can pull and set `DAGSTER_TEST_VALIDATION_IMAGE` to the registry reference.
+Direct `docker build` is not required for the local validation path.
+
+On amd64 clusters, the official Dagster example image can be used for user code. To override both
+the user-code and Dagster system images explicitly, set `DAGSTER_TEST_USER_CODE_IMAGE` and
+`DAGSTER_TEST_DAGSTER_IMAGE` to architecture-compatible, pullable images before running the test.
+
+## Next Steps
+
+- Build and push a Dagster project image that contains your definitions.
+- Decide whether to use bundled PostgreSQL or an external managed PostgreSQL service.
+- Create required Secrets for database credentials, image pulls, Celery, and object storage.
+- Add ingress, TLS, compute log storage, and run launcher configuration for production.
+- Generate YAML with `dagsterBootstrap.toYaml()` for GitOps or use a direct factory for local tests.

--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
       "import": "./dist/factories/inngest/index.js",
       "types": "./dist/factories/inngest/index.d.ts"
     },
+    "./dagster": {
+      "import": "./dist/factories/dagster/index.js",
+      "types": "./dist/factories/dagster/index.d.ts"
+    },
     "./pebble": {
       "import": "./dist/factories/pebble/index.js",
       "types": "./dist/factories/pebble/index.d.ts"
@@ -109,6 +113,7 @@
     "test:watch": "bun test --watch --timeout 10000 $(find test -name '*.test.ts' | grep -v integration)",
     "test:all": "bun run test && bun run test:integration:all",
     "test:integration": "./scripts/run-integration-tests.sh",
+    "test:integration:dagster": "bun test test/integration/dagster/bootstrap-composition.test.ts --timeout 900000",
     "test:integration:required": "REQUIRE_CLUSTER_TESTS=true ./scripts/run-integration-tests.sh",
     "test:integration:debug": "DEBUG_MODE=true ./scripts/run-integration-tests.sh",
     "typecheck": "bun run typecheck:lib && bun run typecheck:examples && bun run typecheck:tests",

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -1453,6 +1453,11 @@ export class KroResourceFactoryImpl<
    */
   toYaml(spec?: TSpec): string {
     if (spec) {
+      validateSpec(spec, this.schemaDefinition, {
+        kind: this.schemaDefinition.kind,
+        name: this.name,
+      });
+
       // Generate CRD instance YAML
       const instanceName = generateInstanceName(spec, this.name);
       const customResource = this.createCustomResourceInstance(instanceName, spec);

--- a/src/factories/dagster/compositions/dagster-bootstrap.ts
+++ b/src/factories/dagster/compositions/dagster-bootstrap.ts
@@ -1,0 +1,131 @@
+import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
+import { Cel } from '../../../core/references/cel.js';
+import { namespace } from '../../kubernetes/core/namespace.js';
+import {
+  DEFAULT_DAGSTER_REPO_NAME,
+  DEFAULT_DAGSTER_VERSION,
+  dagsterHelmRelease,
+  dagsterHelmRepository,
+} from '../resources/helm.js';
+import {
+  type DagsterBootstrapConfig,
+  DagsterBootstrapConfigSchema,
+  DagsterBootstrapStatusSchema,
+} from '../types.js';
+import { mapDagsterConfigToHelmValues } from '../utils/helm-values-mapper.js';
+
+type DagsterBootstrapSchemaConfig = typeof DagsterBootstrapConfigSchema.infer;
+
+/**
+ * High-level Dagster bootstrap composition.
+ *
+ * Creates the target Namespace, official Dagster HelmRepository, and Dagster
+ * HelmRelease. Status is derived only from owned Flux Helm resources.
+ */
+export const dagsterBootstrap = kubernetesComposition(
+  {
+    name: 'dagster-bootstrap',
+    kind: 'DagsterBootstrap',
+    spec: DagsterBootstrapConfigSchema,
+    status: DagsterBootstrapStatusSchema,
+  },
+  (spec) => {
+    const resolvedNamespace = spec.namespace || 'dagster';
+    const resolvedVersion = spec.version || DEFAULT_DAGSTER_VERSION;
+    const repositoryName = spec.repositoryName || DEFAULT_DAGSTER_REPO_NAME;
+    const repositoryNamespace = spec.repositoryNamespace || DEFAULT_FLUX_NAMESPACE;
+    const helmValues = buildHelmValues(spec);
+
+    const _dagsterNamespace = namespace({
+      metadata: {
+        name: resolvedNamespace,
+        labels: {
+          'app.kubernetes.io/name': 'dagster',
+          'app.kubernetes.io/instance': spec.name,
+          'app.kubernetes.io/version': resolvedVersion,
+          'app.kubernetes.io/managed-by': 'typekro',
+        },
+      },
+      id: 'dagsterNamespace',
+    });
+
+    const _dagsterHelmRepository = dagsterHelmRepository({
+      name: repositoryName,
+      namespace: repositoryNamespace,
+      id: 'dagsterHelmRepository',
+    });
+
+    const _dagsterHelmRelease = dagsterHelmRelease({
+      name: spec.name,
+      namespace: resolvedNamespace,
+      version: resolvedVersion,
+      repositoryName,
+      repositoryNamespace,
+      values: helmValues,
+      id: 'dagsterHelmRelease',
+    });
+
+    const helmRepositoryReady = Cel.expr<boolean>(
+      _dagsterHelmRepository.status.conditions,
+      '.exists(c, c.type == "Ready" && c.status == "True")'
+    );
+    const helmReleaseReady = Cel.expr<boolean>(
+      _dagsterHelmRelease.status.conditions,
+      '.exists(c, c.type == "Ready" && c.status == "True")'
+    );
+
+    return {
+      ready: helmReleaseReady,
+      phase: Cel.expr<'Ready' | 'Installing' | 'Failed'>(
+        'dagsterHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "False") ' +
+          '? "Failed" : dagsterHelmRelease.status.conditions.exists(c, c.type == "Ready" && ' +
+          'c.status == "True") ? "Ready" : "Installing"'
+      ),
+      failed: Cel.expr<boolean>(
+        _dagsterHelmRelease.status.conditions,
+        '.exists(c, c.type == "Ready" && c.status == "False")'
+      ),
+      version: resolvedVersion,
+      components: {
+        helmRepository: helmRepositoryReady,
+        helmRelease: helmReleaseReady,
+        webserver: helmReleaseReady,
+        daemon: helmReleaseReady,
+        userDeployments: helmReleaseReady,
+      },
+    };
+  }
+);
+
+function buildHelmValues(spec: DagsterBootstrapSchemaConfig) {
+  return mapDagsterConfigToHelmValues(buildMapperConfig(spec));
+}
+
+function buildMapperConfig(spec: DagsterBootstrapSchemaConfig): DagsterBootstrapConfig {
+  return Object.assign(
+    { name: spec.name },
+    spec.namespace !== undefined && { namespace: spec.namespace },
+    spec.version !== undefined && { version: spec.version },
+    spec.repositoryName !== undefined && { repositoryName: spec.repositoryName },
+    spec.repositoryNamespace !== undefined && { repositoryNamespace: spec.repositoryNamespace },
+    spec.serviceAccountName !== undefined && { serviceAccountName: spec.serviceAccountName },
+    spec.nameOverride !== undefined && { nameOverride: spec.nameOverride },
+    spec.fullnameOverride !== undefined && { fullnameOverride: spec.fullnameOverride },
+    spec.rbacEnabled !== undefined && { rbacEnabled: spec.rbacEnabled },
+    spec.imagePullSecrets !== undefined && { imagePullSecrets: spec.imagePullSecrets },
+    spec.webserver !== undefined && { webserver: spec.webserver },
+    spec.daemon !== undefined && { daemon: spec.daemon },
+    spec.userDeployments !== undefined && { userDeployments: spec.userDeployments },
+    spec.postgresql !== undefined && { postgresql: spec.postgresql },
+    spec.runLauncher !== undefined && { runLauncher: spec.runLauncher },
+    spec.scheduler !== undefined && { scheduler: spec.scheduler },
+    spec.computeLogManager !== undefined && { computeLogManager: spec.computeLogManager },
+    spec.ingress !== undefined && { ingress: spec.ingress },
+    spec.flower !== undefined && { flower: spec.flower },
+    spec.rabbitmq !== undefined && { rabbitmq: spec.rabbitmq },
+    spec.redis !== undefined && { redis: spec.redis },
+    spec.global !== undefined && { global: spec.global },
+    spec.values !== undefined && { values: spec.values }
+  ) as DagsterBootstrapConfig;
+}

--- a/src/factories/dagster/compositions/index.ts
+++ b/src/factories/dagster/compositions/index.ts
@@ -1,0 +1,1 @@
+export * from './dagster-bootstrap.js';

--- a/src/factories/dagster/index.ts
+++ b/src/factories/dagster/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Dagster Integration for TypeKro.
+ *
+ * Provides type-safe deployment primitives for Dagster OSS on Kubernetes via
+ * the official Dagster Helm chart.
+ *
+ * ## Resources
+ * - `dagsterHelmRepository()` - official Dagster Helm chart repository
+ * - `dagsterHelmRelease()` - Dagster deployment via Flux HelmRelease
+ *
+ * ## Compositions
+ * - `dagsterBootstrap` - complete Dagster deployment using Namespace, HelmRepository, and HelmRelease
+ *
+ * @example
+ * ```typescript
+ * import { dagsterBootstrap } from 'typekro/dagster';
+ *
+ * const factory = dagsterBootstrap.factory('kro', {
+ *   namespace: 'dagster',
+ * });
+ * ```
+ *
+ * @see https://dagster.io/
+ * @see https://github.com/dagster-io/dagster/tree/master/helm/dagster
+ * @module
+ */
+export * from './compositions/index.js';
+export * from './resources/index.js';
+export * from './types.js';
+export * from './utils/index.js';

--- a/src/factories/dagster/resources/helm.ts
+++ b/src/factories/dagster/resources/helm.ts
@@ -1,0 +1,88 @@
+/**
+ * Dagster Helm resource factories.
+ *
+ * These wrappers apply official Dagster chart defaults while delegating resource
+ * construction and graph-aware Helm values serialization to TypeKro's generic
+ * Flux Helm factories.
+ */
+
+import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
+import { setMetadataField } from '../../../core/metadata/resource-metadata.js';
+import type { Composable, Enhanced } from '../../../core/types/index.js';
+import {
+  createHelmRepositoryReadinessEvaluator,
+  helmRepository,
+  type HelmRepositorySpec,
+  type HelmRepositoryStatus,
+} from '../../helm/helm-repository.js';
+import { helmRelease } from '../../helm/helm-release.js';
+import { createLabeledHelmReleaseEvaluator } from '../../helm/readiness-evaluators.js';
+import type { HelmReleaseSpec, HelmReleaseStatus } from '../../helm/types.js';
+import type {
+  DagsterHelmReleaseConfig,
+  DagsterHelmRepositoryConfig,
+  DagsterHelmValues,
+} from '../types.js';
+
+/** Default official Dagster Helm repository URL. */
+export const DEFAULT_DAGSTER_REPO_URL = 'https://dagster-io.github.io/helm';
+
+/** Default Flux HelmRepository name for the official Dagster chart. */
+export const DEFAULT_DAGSTER_REPO_NAME = 'dagster';
+
+/** Default official Dagster Helm chart version selected by the approved plan. */
+export const DEFAULT_DAGSTER_VERSION = '1.13.8';
+
+/**
+ * Create a Flux HelmRepository for the official Dagster Helm chart repository.
+ *
+ * @param config - Repository configuration with Dagster defaults
+ * @returns Enhanced HelmRepository resource
+ */
+export function dagsterHelmRepository(
+  config: Composable<DagsterHelmRepositoryConfig>
+): Enhanced<HelmRepositorySpec, HelmRepositoryStatus> {
+  const repo = helmRepository({
+    name: config.name || DEFAULT_DAGSTER_REPO_NAME,
+    namespace: config.namespace || DEFAULT_FLUX_NAMESPACE,
+    url: config.url || DEFAULT_DAGSTER_REPO_URL,
+    interval: config.interval || '5m',
+    ...(config.id && { id: config.id }),
+  }).withReadinessEvaluator(
+    createHelmRepositoryReadinessEvaluator('Dagster')
+  ) as Enhanced<HelmRepositorySpec, HelmRepositoryStatus>;
+
+  setMetadataField(repo, 'scopes', ['cluster']);
+
+  return repo;
+}
+
+/**
+ * Create a Flux HelmRelease for Dagster using the official chart defaults.
+ *
+ * @param config - Release configuration with Dagster defaults
+ * @returns Enhanced HelmRelease resource
+ */
+export function dagsterHelmRelease(
+  config: Composable<DagsterHelmReleaseConfig>
+): Enhanced<HelmReleaseSpec<DagsterHelmValues>, HelmReleaseStatus> {
+  return helmRelease<DagsterHelmValues>({
+    name: config.name,
+    namespace: config.namespace || config.name,
+    chart: {
+      repository: DEFAULT_DAGSTER_REPO_URL,
+      name: 'dagster',
+      version: config.version || DEFAULT_DAGSTER_VERSION,
+    },
+    sourceRef: {
+      name: config.repositoryName || DEFAULT_DAGSTER_REPO_NAME,
+      namespace: config.repositoryNamespace || DEFAULT_FLUX_NAMESPACE,
+      kind: 'HelmRepository',
+    },
+    ...(config.values !== undefined && { values: config.values }),
+    ...(config.id && { id: config.id }),
+  }).withReadinessEvaluator(createLabeledHelmReleaseEvaluator('Dagster')) as Enhanced<
+    HelmReleaseSpec<DagsterHelmValues>,
+    HelmReleaseStatus
+  >;
+}

--- a/src/factories/dagster/resources/index.ts
+++ b/src/factories/dagster/resources/index.ts
@@ -1,0 +1,1 @@
+export * from './helm.js';

--- a/src/factories/dagster/types.ts
+++ b/src/factories/dagster/types.ts
@@ -1,0 +1,1240 @@
+/**
+ * Public Dagster integration contracts.
+ *
+ * This module defines the TypeKro-facing configuration, status, error, chart value,
+ * and factory signatures for deploying Dagster OSS through the official Dagster Helm
+ * chart. Implementation files must conform to these contracts.
+ *
+ * Interface decision: expose typed convenience fields for common Dagster deployment
+ * configuration and use `values` as the single raw official chart passthrough surface.
+ * The rejected alternatives were a raw-values-only wrapper, which would not provide
+ * enough validation for common unsafe configurations, and an exhaustive chart model,
+ * which would be brittle as the upstream chart evolves.
+ *
+ * Scenario preserved from planning: a TypeKro user brings a Dagster project image,
+ * configures user-code server args, PostgreSQL, run launcher, ingress, and raw chart
+ * `values`, then deploys directly or generates KRO/YAML while status is derived from
+ * the owned HelmRelease. All captured planning requirements REQ-001 through REQ-014
+ * remain included in this contract; no interface requirement is intentionally deferred
+ * or weakened.
+ *
+ * Lifecycle/CRUD decision: this package does not introduce a separate persisted data
+ * entity or database table. Create/read/update/delete lifecycle is inherited from
+ * TypeKro resource factories: create/update through deploy/apply, read through status
+ * hydration, and delete through `deleteInstance` where supported by the selected mode.
+ */
+
+import { type } from 'arktype';
+import type { ValuesMergeExpression } from '../../core/aspects/values-merge.js';
+import type { TypeKroError } from '../../core/errors.js';
+import type {
+  Composable,
+  DirectResourceFactory,
+  Enhanced,
+  KroResourceFactory,
+  PublicFactoryOptions,
+} from '../../core/types/index.js';
+import type {
+  TypeKroChartValue,
+  TypeKroValueTree,
+  TypeKroValueTreeObject,
+} from '../../core/types/common.js';
+import type { HelmRepositorySpec, HelmRepositoryStatus } from '../helm/helm-repository.js';
+import type { HelmReleaseSpec, HelmReleaseStatus } from '../helm/types.js';
+
+/** Default official Dagster Helm repository URL. */
+export type DagsterDefaultHelmRepositoryUrl = 'https://dagster-io.github.io/helm';
+
+/** Default official Dagster Helm chart name. */
+export type DagsterDefaultChartName = 'dagster';
+
+/** Default chart version selected by the approved plan. */
+export type DagsterDefaultChartVersion = '1.13.8';
+
+/** Supported Dagster bootstrap phases exposed through TypeKro status. */
+export type DagsterBootstrapPhase = 'Ready' | 'Installing' | 'Failed';
+
+/** Supported image pull policies used by Dagster chart image fields. */
+export type DagsterImagePullPolicy = 'Always' | 'IfNotPresent' | 'Never';
+
+/** Supported run launcher names in the Dagster Helm chart. */
+export type DagsterRunLauncherType =
+  | 'K8sRunLauncher'
+  | 'CeleryK8sRunLauncher'
+  | 'CustomRunLauncher';
+
+/** Supported scheduler names in the Dagster Helm chart. */
+export type DagsterSchedulerType = 'DagsterDaemonScheduler' | 'CustomScheduler';
+
+/** Supported compute log manager names documented by Dagster OSS. */
+export type DagsterComputeLogManagerType =
+  | 'NoOpComputeLogManager'
+  | 'AzureBlobComputeLogManager'
+  | 'GCSComputeLogManager'
+  | 'S3ComputeLogManager'
+  | 'LocalComputeLogManager'
+  | 'CustomComputeLogManager';
+
+/** Supported workload identity auth providers in the Dagster chart PostgreSQL config. */
+export type DagsterPostgresqlAuthProviderType = 'azure_wif' | 'gcp_wif' | 'aws_wif';
+
+/** Error codes thrown by Dagster validation and values mapping. */
+export type DagsterConfigurationErrorCode =
+  | 'DAGSTER_INVALID_CONFIG'
+  | 'DAGSTER_REQUIRED_CONFIG_MISSING'
+  | 'DAGSTER_UNSAFE_SECRET_CONFIG'
+  | 'DAGSTER_UNSUPPORTED_KRO_CONFIG';
+
+/** Error codes for Dagster resource factory and lifecycle operations. */
+export type DagsterOperationErrorCode =
+  | DagsterConfigurationErrorCode
+  | 'DAGSTER_RESOURCE_APPLY_FAILED'
+  | 'DAGSTER_RESOURCE_DELETE_FAILED'
+  | 'DAGSTER_RESOURCE_READ_FAILED'
+  | 'DAGSTER_RESOURCE_RECONCILE_FAILED';
+
+/** Dagster components referenced by validation, lifecycle, and operational contracts. */
+export type DagsterComponentName =
+  | 'helmRepository'
+  | 'helmRelease'
+  | 'webserver'
+  | 'daemon'
+  | 'userDeployments'
+  | 'postgresql'
+  | 'runLauncher'
+  | 'scheduler'
+  | 'computeLogManager'
+  | 'ingress'
+  | 'flower'
+  | 'rabbitmq'
+  | 'redis';
+
+/** Operational event categories emitted by Dagster diagnostics without secret values. */
+export type DagsterOperationalEventType =
+  | 'helmRepositoryNotReady'
+  | 'helmReleaseNotReady'
+  | 'configurationValidationFailed'
+  | 'databaseConfigurationInvalid'
+  | 'brokerConfigurationInvalid'
+  | 'userCodeDeploymentInvalid'
+  | 'ingressConfigurationInvalid';
+
+/** Health check names exposed by Dagster status and tests. */
+export type DagsterHealthCheckName =
+  | 'helmRepositoryReady'
+  | 'helmReleaseReady'
+  | 'webserverReady'
+  | 'daemonReady'
+  | 'userDeploymentsReady';
+
+/** Metrics signal names exposed by Dagster chart and convenience config. */
+export type DagsterMetricSignalName =
+  | 'dagsterHelmReleaseReady'
+  | 'dagsterWebserverReplicasConfigured'
+  | 'dagsterDaemonEnabled'
+  | 'dagsterUserDeploymentsConfigured'
+  | 'dagsterCeleryWorkersConfigured'
+  | 'dagsterFlowerEnabled';
+
+/** Shared ArkType schema shape for Kubernetes resource requirements. */
+const resourceRequirementsSchemaShape = {
+  'requests?': { 'cpu?': 'string', 'memory?': 'string' },
+  'limits?': { 'cpu?': 'string', 'memory?': 'string' },
+} as const;
+
+/** Shared ArkType schema shape for Kubernetes tolerations. */
+const tolerationSchemaShape = {
+  'key?': 'string',
+  'operator?': '"Exists" | "Equal"',
+  'value?': 'string',
+  'effect?': '"NoSchedule" | "PreferNoSchedule" | "NoExecute"',
+  'tolerationSeconds?': 'number',
+} as const;
+
+/** Shared ArkType schema shape for Kubernetes-style environment entries. */
+const envVarSchema = type({
+  name: 'string',
+  'value?': 'string',
+  'valueFrom?': 'Record<string, unknown>',
+});
+
+/** Shared ArkType schema shape for ConfigMap/Secret env source refs. */
+const namedRefSchema = type({ name: 'string' });
+
+/** Shared ArkType schema shape for container image configuration. */
+const imageSchemaShape = {
+  repository: 'string',
+  'tag?': 'string',
+  'pullPolicy?': '"Always" | "IfNotPresent" | "Never"',
+} as const;
+
+/** Shared ArkType schema shape for values that intentionally pass chart-compatible objects. */
+const objectMapSchema = type('object');
+
+/** Shared ArkType schema shape for arrays of chart-compatible objects. */
+const objectMapArraySchema = objectMapSchema.array();
+
+const podConfigSchemaShape = {
+  'labels?': 'Record<string, string>',
+  'nodeSelector?': 'Record<string, string>',
+  'affinity?': objectMapSchema,
+  'tolerations?': type(tolerationSchemaShape).array(),
+  'resources?': resourceRequirementsSchemaShape,
+  'podSecurityContext?': objectMapSchema,
+  'securityContext?': objectMapSchema,
+  'volumes?': objectMapArraySchema,
+  'volumeMounts?': objectMapArraySchema,
+  'env?': envVarSchema.array(),
+  'envConfigMaps?': namedRefSchema.array(),
+  'envSecrets?': namedRefSchema.array(),
+} as const;
+
+const webserverSchemaShape = {
+  ...podConfigSchemaShape,
+  'replicaCount?': 'number',
+  'image?': imageSchemaShape,
+  'service?': {
+    'type?': 'string',
+    'port?': 'number',
+    'annotations?': 'Record<string, string>',
+  },
+  'pathPrefix?': 'string',
+  'enableReadOnly?': 'boolean',
+  'logFormat?': '"colored" | "json" | "rich"',
+  'logLevel?': 'string',
+  'workspace?': {
+    'enabled?': 'boolean',
+    'servers?': type({ host: 'string', port: 'number', 'name?': 'string' }).array(),
+    'externalConfigmap?': 'string',
+  },
+  'readinessProbe?': objectMapSchema,
+  'livenessProbe?': objectMapSchema,
+  'startupProbe?': objectMapSchema,
+} as const;
+
+const daemonSchemaShape = {
+  ...podConfigSchemaShape,
+  'enabled?': 'boolean',
+  'image?': imageSchemaShape,
+  'heartbeatTolerance?': 'number',
+  'logFormat?': '"colored" | "json" | "rich"',
+  'runCoordinator?': {
+    'enabled?': 'boolean',
+    'type?': '"QueuedRunCoordinator" | "CustomRunCoordinator"',
+    'config?': objectMapSchema,
+  },
+  'runMonitoring?': objectMapSchema,
+  'runRetries?': objectMapSchema,
+  'sensors?': objectMapSchema,
+  'schedules?': objectMapSchema,
+} as const;
+
+const userDeploymentSchema = type({
+  name: 'string',
+  image: imageSchemaShape,
+  'dagsterApiGrpcArgs?': 'string[]',
+  'codeServerArgs?': 'string[]',
+  'port?': 'number',
+  'replicaCount?': 'number',
+  'includeConfigInLaunchedRuns?': { 'enabled?': 'boolean' },
+  'env?': envVarSchema.array(),
+  'envConfigMaps?': namedRefSchema.array(),
+  'envSecrets?': namedRefSchema.array(),
+  'labels?': 'Record<string, string>',
+  'annotations?': 'Record<string, string>',
+  'nodeSelector?': 'Record<string, string>',
+  'affinity?': objectMapSchema,
+  'tolerations?': type(tolerationSchemaShape).array(),
+  'podSecurityContext?': objectMapSchema,
+  'securityContext?': objectMapSchema,
+  'resources?': resourceRequirementsSchemaShape,
+  'volumes?': objectMapArraySchema,
+  'volumeMounts?': objectMapArraySchema,
+  'initContainers?': objectMapArraySchema,
+  'sidecarContainers?': objectMapArraySchema,
+  'readinessProbe?': objectMapSchema,
+  'livenessProbe?': objectMapSchema,
+  'startupProbe?': objectMapSchema,
+  'deploymentStrategy?': objectMapSchema,
+  'service?': { 'annotations?': 'Record<string, string>' },
+});
+
+const userDeploymentsSchemaShape = {
+  'enabled?': 'boolean',
+  'enableSubchart?': 'boolean',
+  'imagePullSecrets?': namedRefSchema.array(),
+  'deployments?': userDeploymentSchema.array(),
+} as const;
+
+const postgresqlSchemaShape = {
+  'enabled?': 'boolean',
+  'host?': 'string',
+  'username?': 'string',
+  'database?': 'string',
+  'password?': 'string',
+  'passwordSecretName?': 'string',
+  'servicePort?': 'number',
+  'params?': 'Record<string, string>',
+  'scheme?': 'string',
+  'authProvider?': objectMapSchema,
+  'values?': objectMapSchema,
+} as const;
+
+const k8sRunLauncherSchemaShape = {
+  'imagePullPolicy?': '"Always" | "IfNotPresent" | "Never"',
+  'image?': imageSchemaShape,
+  'jobNamespace?': 'string',
+  'loadInclusterConfig?': 'boolean',
+  'kubeconfigFile?': 'string',
+  'envConfigMaps?': namedRefSchema.array(),
+  'envSecrets?': namedRefSchema.array(),
+  'envVars?': 'string[]',
+  'volumes?': objectMapArraySchema,
+  'volumeMounts?': objectMapArraySchema,
+  'labels?': 'Record<string, string>',
+  'resources?': resourceRequirementsSchemaShape,
+  'runK8sConfig?': objectMapSchema,
+  'failPodOnRunFailure?': 'boolean',
+  'securityContext?': objectMapSchema,
+} as const;
+
+const celeryWorkerQueueSchema = type({
+  name: 'string',
+  'replicaCount?': 'number',
+  'labels?': 'Record<string, string>',
+  'nodeSelector?': 'Record<string, string>',
+  'configSource?': objectMapSchema,
+  'additionalCeleryArgs?': 'string[]',
+});
+
+const celeryK8sRunLauncherSchemaShape = {
+  ...podConfigSchemaShape,
+  'imagePullPolicy?': '"Always" | "IfNotPresent" | "Never"',
+  'image?': imageSchemaShape,
+  'jobNamespace?': 'string',
+  'workerQueues?': celeryWorkerQueueSchema.array(),
+  'configSource?': objectMapSchema,
+  'env?': 'Record<string, string>',
+  'failPodOnRunFailure?': 'boolean',
+} as const;
+
+const runLauncherSchemaShape = {
+  'type?': '"K8sRunLauncher" | "CeleryK8sRunLauncher" | "CustomRunLauncher"',
+  'k8sRunLauncher?': k8sRunLauncherSchemaShape,
+  'celeryK8sRunLauncher?': celeryK8sRunLauncherSchemaShape,
+  'customRunLauncher?': objectMapSchema,
+} as const;
+
+const schedulerSchemaShape = {
+  'type?': '"DagsterDaemonScheduler" | "CustomScheduler"',
+  'config?': objectMapSchema,
+} as const;
+
+const computeLogManagerSchemaShape = {
+  'type?':
+    '"NoOpComputeLogManager" | "AzureBlobComputeLogManager" | "GCSComputeLogManager" | "S3ComputeLogManager" | "LocalComputeLogManager" | "CustomComputeLogManager"',
+  'config?': objectMapSchema,
+} as const;
+
+const flowerSchemaShape = {
+  ...podConfigSchemaShape,
+  'enabled?': 'boolean',
+  'image?': imageSchemaShape,
+  'service?': {
+    'type?': 'string',
+    'annotations?': 'Record<string, string>',
+    'port?': 'number',
+  },
+  'livenessProbe?': objectMapSchema,
+  'startupProbe?': objectMapSchema,
+} as const;
+
+const ingressEndpointSchemaShape = {
+  'host?': 'string',
+  'path?': 'string',
+  'pathType?': 'string',
+  'tls?': { 'enabled?': 'boolean', 'secretName?': 'string' },
+  'precedingPaths?': objectMapArraySchema,
+  'succeedingPaths?': objectMapArraySchema,
+} as const;
+
+const ingressSchemaShape = {
+  'enabled?': 'boolean',
+  'annotations?': 'Record<string, string>',
+  'labels?': 'Record<string, string>',
+  'ingressClassName?': 'string',
+  'dagsterWebserver?': ingressEndpointSchemaShape,
+  'readOnlyDagsterWebserver?': ingressEndpointSchemaShape,
+  'flower?': ingressEndpointSchemaShape,
+} as const;
+
+const rabbitmqSchemaShape = {
+  'enabled?': 'boolean',
+  'image?': imageSchemaShape,
+  'username?': 'string',
+  'password?': 'string',
+  'servicePort?': 'number',
+  'values?': objectMapSchema,
+} as const;
+
+const redisSchemaShape = {
+  'enabled?': 'boolean',
+  'internal?': 'boolean',
+  'image?': imageSchemaShape,
+  'usePassword?': 'boolean',
+  'password?': 'string',
+  'host?': 'string',
+  'port?': 'number',
+  'brokerDbNumber?': 'number',
+  'backendDbNumber?': 'number',
+  'brokerUrl?': 'string',
+  'backendUrl?': 'string',
+  'values?': objectMapSchema,
+} as const;
+
+const globalSchemaShape = {
+  'dagsterHome?': 'string',
+  'serviceAccountName?': 'string',
+  'postgresqlSecretName?': 'string',
+  'postgresqlAuthWifEnabled?': 'boolean',
+  'celeryConfigSecretName?': 'string',
+  'dagsterInstanceConfigMap?': 'string',
+} as const;
+
+const helmValuesSchemaShape = {
+  ...globalSchemaShape,
+  'global?': globalSchemaShape,
+  'nameOverride?': 'string',
+  'fullnameOverride?': 'string',
+  'rbacEnabled?': 'boolean',
+  'imagePullSecrets?': namedRefSchema.array(),
+  'dagsterWebserver?': webserverSchemaShape,
+  'dagsterDaemon?': daemonSchemaShape,
+  'dagster-user-deployments?': userDeploymentsSchemaShape,
+  'postgresql?': postgresqlSchemaShape,
+  'generatePostgresqlPasswordSecret?': 'boolean',
+  'generateCeleryConfigSecret?': 'boolean',
+  'rabbitmq?': rabbitmqSchemaShape,
+  'redis?': redisSchemaShape,
+  'runLauncher?': runLauncherSchemaShape,
+  'scheduler?': schedulerSchemaShape,
+  'computeLogManager?': computeLogManagerSchemaShape,
+  'flower?': flowerSchemaShape,
+  'ingress?': ingressSchemaShape,
+  'pythonLogs?': objectMapSchema,
+  'busybox?': objectMapSchema,
+  'extraManifests?': 'unknown[]',
+} as const;
+
+/** Kubernetes Secret key reference used for Dagster sensitive chart values. */
+export interface DagsterSecretKeyRef {
+  /** Name of an existing Kubernetes Secret in the Dagster deployment namespace. */
+  name: string;
+  /** Key inside the Kubernetes Secret. */
+  key: string;
+}
+
+/** Existing Secret reference source for sensitive values. */
+export interface DagsterSecretKeyRefSource {
+  /** Existing Kubernetes Secret key reference. */
+  secretRef: DagsterSecretKeyRef;
+}
+
+/** Explicit literal source intentionally supplied by the caller. */
+export interface DagsterLiteralValueSource {
+  /** Literal value. Treat as sensitive when used for credentials or tokens. */
+  value: string;
+}
+
+/** Explicit source for Dagster sensitive or configurable scalar values. */
+export type DagsterValueSource = DagsterSecretKeyRefSource | DagsterLiteralValueSource;
+
+/** Kubernetes resource requests and limits used by chart pod settings. */
+export interface DagsterResourceRequirements {
+  /** Requested resources. */
+  requests?: {
+    /** CPU request such as `500m`. */
+    cpu?: string;
+    /** Memory request such as `1Gi`. */
+    memory?: string;
+  };
+  /** Resource limits. */
+  limits?: {
+    /** CPU limit such as `2`. */
+    cpu?: string;
+    /** Memory limit such as `4Gi`. */
+    memory?: string;
+  };
+}
+
+/** Kubernetes toleration shape accepted by Dagster chart pod settings. */
+export interface DagsterToleration {
+  key?: string;
+  operator?: 'Exists' | 'Equal';
+  value?: string;
+  effect?: 'NoSchedule' | 'PreferNoSchedule' | 'NoExecute';
+  tolerationSeconds?: number;
+}
+
+/** Kubernetes-style environment variable entry used by Dagster chart settings. */
+export interface DagsterEnvVar {
+  /** Environment variable name. */
+  name: string;
+  /** Literal value. */
+  value?: string;
+  /** Kubernetes valueFrom source. This remains free-form to match Kubernetes API shape. */
+  valueFrom?: TypeKroValueTreeObject;
+}
+
+/** Reference to an existing ConfigMap or Secret by name. */
+export interface DagsterNamedRef extends TypeKroValueTreeObject {
+  name: string;
+}
+
+/** Container image settings used by Dagster system and user-code containers. */
+export interface DagsterImageConfig {
+  /** Image repository, for example `docker.io/acme/my-dagster-project`. */
+  repository: string;
+  /** Image tag. If omitted in chart-managed images, the chart may default to chart version. */
+  tag?: string;
+  /** Kubernetes image pull policy. */
+  pullPolicy?: DagsterImagePullPolicy;
+}
+
+/** Shared pod customization subset used across Dagster chart components. */
+export interface DagsterPodConfig {
+  /** Additional pod labels. */
+  labels?: Record<string, string>;
+  /** Node selector for pod scheduling. */
+  nodeSelector?: Record<string, string>;
+  /** Kubernetes affinity. Free-form because Kubernetes affinity is deeply structured. */
+  affinity?: TypeKroValueTreeObject;
+  /** Kubernetes tolerations. */
+  tolerations?: DagsterToleration[];
+  /** Pod resource requests and limits. */
+  resources?: DagsterResourceRequirements;
+  /** Kubernetes pod security context. */
+  podSecurityContext?: TypeKroValueTreeObject;
+  /** Kubernetes container security context. */
+  securityContext?: TypeKroValueTreeObject;
+  /** Additional volumes. Free-form to preserve upstream chart compatibility. */
+  volumes?: TypeKroValueTreeObject[];
+  /** Additional volume mounts. Free-form to preserve upstream chart compatibility. */
+  volumeMounts?: TypeKroValueTreeObject[];
+  /** Additional environment variables. */
+  env?: DagsterEnvVar[];
+  /** Existing ConfigMaps to expose as environment variables. */
+  envConfigMaps?: DagsterNamedRef[];
+  /** Existing Secrets to expose as environment variables. */
+  envSecrets?: DagsterNamedRef[];
+}
+
+/** Global chart convenience config mapped to `.Values.global` and related top-level fields. */
+export interface DagsterGlobalConfig {
+  /** DAGSTER_HOME path used by chart-managed containers. */
+  dagsterHome?: string;
+  /** Shared service account for this chart and subcharts. */
+  serviceAccountName?: string;
+  /** Existing PostgreSQL password Secret name. */
+  postgresqlSecretName?: string;
+  /** Enables PostgreSQL workload identity federation instead of password Secret auth. */
+  postgresqlAuthWifEnabled?: boolean;
+  /** Existing Celery config Secret name for broker/backend URLs. */
+  celeryConfigSecretName?: string;
+  /** Existing ConfigMap containing Dagster instance configuration. */
+  dagsterInstanceConfigMap?: string;
+}
+
+/** Dagster webserver convenience config. */
+export interface DagsterWebserverConfig extends DagsterPodConfig {
+  /** Number of webserver replicas. */
+  replicaCount?: number;
+  /** Webserver image override. */
+  image?: DagsterImageConfig;
+  /** Service settings for the webserver. */
+  service?: {
+    type?: string;
+    port?: number;
+    annotations?: Record<string, string>;
+  };
+  /** Optional URL path prefix, such as `/dagster`. */
+  pathPrefix?: string;
+  /** Deploy an additional read-only webserver. */
+  enableReadOnly?: boolean;
+  /** Webserver log format. */
+  logFormat?: 'colored' | 'json' | 'rich';
+  /** Uvicorn log level. */
+  logLevel?: string;
+  /** Workspace config for separately managed user-code deployments. */
+  workspace?: {
+    enabled?: boolean;
+    servers?: Array<{ host: string; port: number; name?: string }>;
+    externalConfigmap?: string;
+  };
+  /** Startup/readiness/liveness probe overrides. */
+  readinessProbe?: TypeKroValueTreeObject;
+  livenessProbe?: TypeKroValueTreeObject;
+  startupProbe?: TypeKroValueTreeObject;
+}
+
+/** Dagster daemon convenience config. */
+export interface DagsterDaemonConfig extends DagsterPodConfig {
+  /** Whether the daemon should be included. */
+  enabled?: boolean;
+  /** Daemon image override. */
+  image?: DagsterImageConfig;
+  /** Maximum heartbeat tolerance in seconds. */
+  heartbeatTolerance?: number;
+  /** Daemon log format. */
+  logFormat?: 'colored' | 'json' | 'rich';
+  /** Run coordinator convenience config. */
+  runCoordinator?: {
+    enabled?: boolean;
+    type?: 'QueuedRunCoordinator' | 'CustomRunCoordinator';
+    config?: TypeKroValueTreeObject;
+  };
+  /** Run monitoring convenience config. */
+  runMonitoring?: TypeKroValueTreeObject;
+  /** Run retries convenience config. */
+  runRetries?: TypeKroValueTreeObject;
+  /** Sensor evaluation convenience config. */
+  sensors?: TypeKroValueTreeObject;
+  /** Schedule evaluation convenience config. */
+  schedules?: TypeKroValueTreeObject;
+}
+
+/** One Dagster user-code deployment served through gRPC or code-server. */
+export interface DagsterUserDeployment {
+  /** Unique deployment name in the chart. */
+  name: string;
+  /** User-code image containing the Dagster project. */
+  image: DagsterImageConfig;
+  /** Arguments to `dagster api grpc`. Mutually exclusive with `codeServerArgs`. */
+  dagsterApiGrpcArgs?: string[];
+  /** Arguments to `dagster code-server start`. Mutually exclusive with `dagsterApiGrpcArgs`. */
+  codeServerArgs?: string[];
+  /** gRPC/code-server port. */
+  port?: number;
+  /** Number of user-code deployment replicas. */
+  replicaCount?: number;
+  /** Whether to include this deployment config in launched runs. */
+  includeConfigInLaunchedRuns?: { enabled?: boolean };
+  /** Additional env vars, env source refs, pod settings, and resources. */
+  env?: DagsterEnvVar[];
+  envConfigMaps?: DagsterNamedRef[];
+  envSecrets?: DagsterNamedRef[];
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  nodeSelector?: Record<string, string>;
+  affinity?: TypeKroValueTreeObject;
+  tolerations?: DagsterToleration[];
+  podSecurityContext?: TypeKroValueTreeObject;
+  securityContext?: TypeKroValueTreeObject;
+  resources?: DagsterResourceRequirements;
+  volumes?: TypeKroValueTreeObject[];
+  volumeMounts?: TypeKroValueTreeObject[];
+  initContainers?: TypeKroValueTreeObject[];
+  sidecarContainers?: TypeKroValueTreeObject[];
+  readinessProbe?: TypeKroValueTreeObject;
+  livenessProbe?: TypeKroValueTreeObject;
+  startupProbe?: TypeKroValueTreeObject;
+  deploymentStrategy?: TypeKroValueTreeObject;
+  service?: { annotations?: Record<string, string> };
+}
+
+/** Dagster user-code deployment chart section. */
+export interface DagsterUserDeploymentsConfig {
+  /** Creates workspace entries for user-code gRPC/code-server deployments. */
+  enabled?: boolean;
+  /** Controls whether the official subchart creates user-code resources. */
+  enableSubchart?: boolean;
+  /** Image pull Secrets for user-code containers. */
+  imagePullSecrets?: DagsterNamedRef[];
+  /** User-code deployments managed by the Dagster chart. */
+  deployments?: DagsterUserDeployment[];
+}
+
+/** PostgreSQL auth provider settings for workload identity federation. */
+export interface DagsterPostgresqlAuthProviderConfig {
+  /** Provider type. */
+  type?: DagsterPostgresqlAuthProviderType;
+  /** Azure token scope override. */
+  azureScope?: string;
+  /** AWS RDS region. */
+  awsRegion?: string;
+}
+
+/** Bundled or external PostgreSQL chart config. */
+export interface DagsterPostgresqlConfig {
+  /** Deploy bundled PostgreSQL or configure the chart for an external DB. */
+  enabled?: boolean;
+  /** External PostgreSQL host when bundled PostgreSQL is disabled. */
+  host?: string;
+  /** PostgreSQL username. */
+  username?: string;
+  /** PostgreSQL database name. */
+  database?: string;
+  /** Explicit local/dev password. Prefer `passwordSecretName` for production. */
+  password?: string;
+  /** Existing Secret name for the PostgreSQL password. */
+  passwordSecretName?: string;
+  /** PostgreSQL service port. */
+  servicePort?: number;
+  /** Additional PostgreSQL connection parameters. */
+  params?: Record<string, string>;
+  /** PostgreSQL URI scheme override. */
+  scheme?: string;
+  /** Workload identity auth provider settings. */
+  authProvider?: DagsterPostgresqlAuthProviderConfig;
+  /** Raw official postgresql subchart values merged before top-level `values`. */
+  values?: TypeKroChartValue<TypeKroValueTreeObject>;
+}
+
+/** K8sRunLauncher convenience config. */
+export interface DagsterK8sRunLauncherConfig {
+  imagePullPolicy?: DagsterImagePullPolicy;
+  image?: DagsterImageConfig;
+  jobNamespace?: string;
+  loadInclusterConfig?: boolean;
+  kubeconfigFile?: string;
+  envConfigMaps?: DagsterNamedRef[];
+  envSecrets?: DagsterNamedRef[];
+  envVars?: string[];
+  volumes?: TypeKroValueTreeObject[];
+  volumeMounts?: TypeKroValueTreeObject[];
+  labels?: Record<string, string>;
+  resources?: DagsterResourceRequirements;
+  runK8sConfig?: TypeKroValueTreeObject;
+  failPodOnRunFailure?: boolean;
+  securityContext?: TypeKroValueTreeObject;
+}
+
+/** Celery worker queue config for CeleryK8sRunLauncher. */
+export interface DagsterCeleryWorkerQueueConfig {
+  name: string;
+  replicaCount?: number;
+  labels?: Record<string, string>;
+  nodeSelector?: Record<string, string>;
+  configSource?: TypeKroValueTreeObject;
+  additionalCeleryArgs?: string[];
+}
+
+/** CeleryK8sRunLauncher convenience config. */
+export interface DagsterCeleryK8sRunLauncherConfig extends Omit<DagsterPodConfig, 'env'> {
+  imagePullPolicy?: DagsterImagePullPolicy;
+  image?: DagsterImageConfig;
+  jobNamespace?: string;
+  workerQueues?: DagsterCeleryWorkerQueueConfig[];
+  configSource?: TypeKroValueTreeObject;
+  env?: Record<string, string>;
+  failPodOnRunFailure?: boolean;
+}
+
+/** Dagster run launcher chart config. */
+export interface DagsterRunLauncherConfig {
+  type?: DagsterRunLauncherType;
+  k8sRunLauncher?: DagsterK8sRunLauncherConfig;
+  celeryK8sRunLauncher?: DagsterCeleryK8sRunLauncherConfig;
+  customRunLauncher?: TypeKroValueTreeObject;
+}
+
+/** Dagster scheduler chart config. */
+export interface DagsterSchedulerConfig {
+  type?: DagsterSchedulerType;
+  config?: TypeKroValueTreeObject;
+}
+
+/** Dagster compute log manager chart config. */
+export interface DagsterComputeLogManagerConfig {
+  type?: DagsterComputeLogManagerType;
+  config?: TypeKroValueTreeObject;
+}
+
+/** RabbitMQ chart config for Celery mode. */
+export interface DagsterRabbitmqConfig {
+  enabled?: boolean;
+  image?: DagsterImageConfig;
+  username?: string;
+  password?: string;
+  servicePort?: number;
+  values?: TypeKroChartValue<TypeKroValueTreeObject>;
+}
+
+/** Redis chart or external Redis config for Celery mode. */
+export interface DagsterRedisConfig {
+  enabled?: boolean;
+  internal?: boolean;
+  image?: DagsterImageConfig;
+  usePassword?: boolean;
+  password?: string;
+  host?: string;
+  port?: number;
+  brokerDbNumber?: number;
+  backendDbNumber?: number;
+  brokerUrl?: string;
+  backendUrl?: string;
+  values?: TypeKroChartValue<TypeKroValueTreeObject>;
+}
+
+/** Flower diagnostics UI config. */
+export interface DagsterFlowerConfig extends DagsterPodConfig {
+  enabled?: boolean;
+  image?: DagsterImageConfig;
+  service?: {
+    type?: string;
+    annotations?: Record<string, string>;
+    port?: number;
+  };
+  livenessProbe?: TypeKroValueTreeObject;
+  startupProbe?: TypeKroValueTreeObject;
+}
+
+/** Ingress route config for a Dagster chart endpoint. */
+export interface DagsterIngressEndpointConfig {
+  host?: string;
+  path?: string;
+  pathType?: string;
+  tls?: {
+    enabled?: boolean;
+    secretName?: string;
+  };
+  precedingPaths?: TypeKroValueTreeObject[];
+  succeedingPaths?: TypeKroValueTreeObject[];
+}
+
+/** Dagster chart ingress config. */
+export interface DagsterIngressConfig {
+  enabled?: boolean;
+  annotations?: Record<string, string>;
+  labels?: Record<string, string>;
+  ingressClassName?: string;
+  dagsterWebserver?: DagsterIngressEndpointConfig;
+  readOnlyDagsterWebserver?: DagsterIngressEndpointConfig;
+  flower?: DagsterIngressEndpointConfig;
+}
+
+/** Official Dagster chart values modeled as typed common fields plus free-form compatibility. */
+export interface DagsterHelmValues extends TypeKroValueTreeObject {
+  global?: TypeKroValueTreeObject;
+  nameOverride?: string;
+  fullnameOverride?: string;
+  rbacEnabled?: boolean;
+  imagePullSecrets?: DagsterNamedRef[];
+  dagsterWebserver?: TypeKroValueTreeObject;
+  dagsterDaemon?: TypeKroValueTreeObject;
+  'dagster-user-deployments'?: TypeKroValueTreeObject;
+  postgresql?: TypeKroValueTreeObject;
+  generatePostgresqlPasswordSecret?: boolean;
+  generateCeleryConfigSecret?: boolean;
+  rabbitmq?: TypeKroValueTreeObject;
+  redis?: TypeKroValueTreeObject;
+  runLauncher?: TypeKroValueTreeObject;
+  scheduler?: TypeKroValueTreeObject;
+  computeLogManager?: TypeKroValueTreeObject;
+  pythonLogs?: TypeKroValueTreeObject;
+  flower?: TypeKroValueTreeObject;
+  ingress?: TypeKroValueTreeObject;
+  busybox?: TypeKroValueTreeObject;
+  extraManifests?: TypeKroValueTree[];
+}
+
+/** Mapper output: concrete chart values or a graph-aware runtime values merge expression. */
+export type DagsterMappedHelmValues = DagsterHelmValues | ValuesMergeExpression;
+
+/** ArkType schema for Dagster bootstrap configuration. */
+export const DagsterBootstrapConfigSchema = type({
+  name: 'string',
+  'namespace?': 'string',
+  'version?': 'string',
+  'repositoryName?': 'string',
+  'repositoryNamespace?': 'string',
+  'serviceAccountName?': 'string',
+  'nameOverride?': 'string',
+  'fullnameOverride?': 'string',
+  'rbacEnabled?': 'boolean',
+  'imagePullSecrets?': namedRefSchema.array(),
+  'webserver?': webserverSchemaShape,
+  'daemon?': daemonSchemaShape,
+  'userDeployments?': userDeploymentsSchemaShape,
+  'postgresql?': postgresqlSchemaShape,
+  'runLauncher?': runLauncherSchemaShape,
+  'scheduler?': schedulerSchemaShape,
+  'computeLogManager?': computeLogManagerSchemaShape,
+  'ingress?': ingressSchemaShape,
+  'flower?': flowerSchemaShape,
+  'rabbitmq?': rabbitmqSchemaShape,
+  'redis?': redisSchemaShape,
+  'global?': globalSchemaShape,
+  'values?': helmValuesSchemaShape,
+});
+
+/** Configuration for deploying Dagster through the bootstrap composition. */
+export type DagsterBootstrapConfig = Omit<
+  typeof DagsterBootstrapConfigSchema.infer,
+  | 'webserver'
+  | 'daemon'
+  | 'userDeployments'
+  | 'postgresql'
+  | 'runLauncher'
+  | 'scheduler'
+  | 'computeLogManager'
+  | 'ingress'
+  | 'flower'
+  | 'rabbitmq'
+  | 'redis'
+  | 'global'
+  | 'values'
+> & {
+  nameOverride?: string;
+  fullnameOverride?: string;
+  rbacEnabled?: boolean;
+  imagePullSecrets?: DagsterNamedRef[];
+  webserver?: DagsterWebserverConfig;
+  daemon?: DagsterDaemonConfig;
+  userDeployments?: DagsterUserDeploymentsConfig;
+  postgresql?: DagsterPostgresqlConfig;
+  runLauncher?: DagsterRunLauncherConfig;
+  scheduler?: DagsterSchedulerConfig;
+  computeLogManager?: DagsterComputeLogManagerConfig;
+  ingress?: DagsterIngressConfig;
+  flower?: DagsterFlowerConfig;
+  rabbitmq?: DagsterRabbitmqConfig;
+  redis?: DagsterRedisConfig;
+  global?: DagsterGlobalConfig;
+  values?: TypeKroChartValue<DagsterHelmValues>;
+};
+
+/** Component readiness exposed by `DagsterBootstrapStatus`. */
+export interface DagsterBootstrapComponentStatus {
+  /** Whether the Flux HelmRepository is ready. */
+  helmRepository: boolean;
+  /** Whether the Flux HelmRelease is ready. */
+  helmRelease: boolean;
+  /** Whether the HelmRelease that owns webserver resources is ready. */
+  webserver: boolean;
+  /** Whether the HelmRelease that owns daemon resources is ready. */
+  daemon: boolean;
+  /** Whether the HelmRelease that owns user-code resources is ready. */
+  userDeployments: boolean;
+}
+
+/** Observed Dagster bootstrap status derived from owned Helm resources. */
+export interface DagsterBootstrapStatus {
+  /** Overall readiness from the owned HelmRelease Ready condition. */
+  ready: boolean;
+  /** Coarse deployment phase from the owned HelmRelease Ready condition. */
+  phase: DagsterBootstrapPhase;
+  /** Whether the owned HelmRelease Ready condition is explicitly False. */
+  failed: boolean;
+  /** Configured chart version. */
+  version?: string;
+  /** Component booleans derived from HelmRepository/HelmRelease readiness and config inclusion. */
+  components: DagsterBootstrapComponentStatus;
+}
+
+/** ArkType schema for Dagster bootstrap status. */
+export const DagsterBootstrapStatusSchema = type({
+  ready: 'boolean',
+  phase: '"Ready" | "Installing" | "Failed"',
+  failed: 'boolean',
+  'version?': 'string',
+  components: {
+    helmRepository: 'boolean',
+    helmRelease: 'boolean',
+    webserver: 'boolean',
+    daemon: 'boolean',
+    userDeployments: 'boolean',
+  },
+});
+
+/** ArkType schema for the Dagster Helm chart repository wrapper. */
+export const DagsterHelmRepositoryConfigSchema = type({
+  'name?': 'string',
+  'namespace?': 'string',
+  'url?': 'string',
+  'interval?': 'string',
+  'id?': 'string',
+});
+
+/** Configuration for the Dagster HelmRepository wrapper. */
+export type DagsterHelmRepositoryConfig = typeof DagsterHelmRepositoryConfigSchema.infer;
+
+/** ArkType schema for the Dagster Helm chart release wrapper. */
+export const DagsterHelmReleaseConfigSchema = type({
+  name: 'string',
+  'namespace?': 'string',
+  'version?': 'string',
+  'repositoryName?': 'string',
+  'repositoryNamespace?': 'string',
+  'values?': helmValuesSchemaShape,
+  'id?': 'string',
+});
+
+/** Configuration for the Dagster HelmRelease wrapper. */
+export type DagsterHelmReleaseConfig = Omit<
+  typeof DagsterHelmReleaseConfigSchema.infer,
+  'values'
+> & {
+  /** Graph-aware official Dagster chart values serialized recursively by TypeKro. */
+  values?: TypeKroChartValue<DagsterHelmValues>;
+};
+
+/** One structured configuration issue produced by Dagster validation. */
+export interface DagsterConfigurationIssue {
+  /** Stable machine-readable error code. */
+  code: DagsterConfigurationErrorCode;
+  /** Dot path to the invalid config field. */
+  path: string;
+  /** Human-readable message that does not include secret values. */
+  message: string;
+  /** Optional high-level component associated with the issue. */
+  component?: DagsterComponentName;
+}
+
+/** Validation result for Dagster typed config. */
+export interface DagsterConfigValidationResult {
+  /** True when no blocking validation issues were found. */
+  valid: boolean;
+  /** Structured issues; messages must not include secret values. */
+  issues: DagsterConfigurationIssue[];
+}
+
+/** Structured context carried by Dagster TypeKro configuration errors. */
+export interface DagsterConfigurationErrorContext extends Record<string, unknown> {
+  /** Optional instance/config name associated with validation. */
+  name?: string;
+  /** All validation issues that caused the failure. */
+  issues: DagsterConfigurationIssue[];
+}
+
+/** Structured configuration error thrown by Dagster mapper/factory validation. */
+export interface DagsterConfigurationError extends TypeKroError {
+  readonly name: 'DagsterConfigurationError';
+  readonly code: DagsterConfigurationErrorCode;
+  readonly context: DagsterConfigurationErrorContext;
+}
+
+/** Structured safe error returned by explicit Dagster lifecycle operation contracts. */
+export interface DagsterOperationError {
+  /** Stable machine-readable operation error code. */
+  code: DagsterOperationErrorCode;
+  /** Safe diagnostic message that excludes passwords, tokens, URLs with credentials, and DSNs. */
+  message: string;
+  /** Affected Dagster component, when applicable. */
+  component?: DagsterComponentName;
+  /** Kubernetes resource name, when applicable. */
+  resourceName?: string;
+  /** Kubernetes namespace, when applicable. */
+  namespace?: string;
+  /** Config or status path that produced the error, when known. */
+  path?: string;
+}
+
+/** Successful explicit Dagster operation result. */
+export interface DagsterOperationSuccess<T> {
+  ok: true;
+  value: T;
+}
+
+/** Failed explicit Dagster operation result with structured safe error details. */
+export interface DagsterOperationFailure {
+  ok: false;
+  error: DagsterOperationError;
+}
+
+/** Result type used by explicit Dagster lifecycle operation contracts. */
+export type DagsterOperationResult<T> = DagsterOperationSuccess<T> | DagsterOperationFailure;
+
+/** Public resource factory signature with an explicit typed error boundary. */
+export type DagsterResourceFactorySignature<TConfig, TSpec, TStatus> = {
+  (config: Composable<TConfig>): Enhanced<TSpec, TStatus>;
+  /** Structured errors thrown or surfaced by this factory use this shape. */
+  readonly errorType?: DagsterOperationError;
+};
+
+/** Public utility signature with an explicit typed error boundary. */
+export type DagsterUtilitySignature<
+  TInput,
+  TOutput,
+  TError extends TypeKroError | DagsterOperationError,
+> = {
+  (input: TInput): TOutput;
+  /** Structured errors thrown or surfaced by this utility use this shape. */
+  readonly errorType?: TError;
+};
+
+/** Direct resource factory with explicit Dagster operation error shape. */
+export type DagsterDirectFactoryWithErrors<TSpec extends object, TStatus extends object> =
+  DirectResourceFactory<TSpec, TStatus> & {
+    readonly errorType?: DagsterOperationError;
+  };
+
+/** KRO resource factory with explicit Dagster operation error shape. */
+export type DagsterKroFactoryWithErrors<TSpec extends object, TStatus extends object> =
+  KroResourceFactory<TSpec, TStatus> & {
+    readonly errorType?: DagsterOperationError;
+  };
+
+/** Public Dagster factory and composition error boundary map. */
+export interface DagsterFactoryErrorBoundary {
+  dagsterHelmRepository: DagsterOperationError;
+  dagsterHelmRelease: DagsterOperationError;
+  dagsterBootstrap: DagsterOperationError;
+  helmValuesMapper: DagsterOperationError;
+  configValidator: DagsterOperationError;
+}
+
+/** Public values mapper contract. */
+export type DagsterHelmValuesMapper = DagsterUtilitySignature<
+  DagsterBootstrapConfig,
+  DagsterMappedHelmValues,
+  DagsterConfigurationError
+>;
+
+/** Public validation contract for typed Dagster config. */
+export type DagsterConfigValidator = DagsterUtilitySignature<
+  DagsterBootstrapConfig,
+  DagsterConfigValidationResult,
+  DagsterConfigurationError
+>;
+
+/** Dagster HelmRepository factory signature. */
+export type DagsterHelmRepositoryFactory = DagsterResourceFactorySignature<
+  DagsterHelmRepositoryConfig,
+  HelmRepositorySpec,
+  HelmRepositoryStatus
+>;
+
+/** Dagster HelmRelease factory signature. */
+export type DagsterHelmReleaseFactory = DagsterResourceFactorySignature<
+  DagsterHelmReleaseConfig,
+  HelmReleaseSpec<DagsterHelmValues>,
+  HelmReleaseStatus
+>;
+
+/** Direct-mode Dagster bootstrap factory inherited from TypeKro compositions. */
+export type DagsterBootstrapDirectFactory = DagsterDirectFactoryWithErrors<
+  DagsterBootstrapConfig,
+  DagsterBootstrapStatus
+>;
+
+/** KRO-mode Dagster bootstrap factory inherited from TypeKro compositions. */
+export type DagsterBootstrapKroFactory = DagsterKroFactoryWithErrors<
+  DagsterBootstrapConfig,
+  DagsterBootstrapStatus
+>;
+
+/** Public selector for creating Dagster direct or KRO factories. */
+export type DagsterBootstrapFactorySelector = {
+  /** Create a direct-mode factory for deploy/apply/read/delete lifecycle operations. */
+  (mode: 'direct', options?: PublicFactoryOptions): DagsterBootstrapDirectFactory;
+  /** Create a KRO-mode factory for ResourceGraphDefinition-backed lifecycle operations. */
+  (mode: 'kro', options?: PublicFactoryOptions): DagsterBootstrapKroFactory;
+  /** Structured errors thrown or surfaced by factory creation use this shape. */
+  readonly errorType?: DagsterOperationError;
+};
+
+/** Public YAML generation operation for the Dagster bootstrap composition. */
+export type DagsterBootstrapYamlOperation = {
+  /** Generate ResourceGraphDefinition YAML or direct manifest YAML for the supplied spec. */
+  (spec?: DagsterBootstrapConfig): string;
+  /** Structured errors thrown or surfaced by YAML generation use this shape. */
+  readonly errorType?: DagsterOperationError;
+};
+
+/** Public `dagsterBootstrap` composition contract. */
+export interface DagsterBootstrapComposition {
+  /** Create a direct-mode or KRO-mode factory. */
+  factory: DagsterBootstrapFactorySelector;
+  /** Generate ResourceGraphDefinition YAML or direct manifest YAML for the supplied spec. */
+  toYaml: DagsterBootstrapYamlOperation;
+  /** Structured errors thrown or surfaced by the composition use this shape. */
+  readonly errorType?: DagsterOperationError;
+}
+
+/** Create/update operation for Dagster bootstrap instances, inherited from TypeKro. */
+export type DagsterBootstrapCreateOrUpdateOperation = DagsterBootstrapDirectFactory['deploy'];
+
+/** Read/list operation for Dagster bootstrap instances, inherited from TypeKro. */
+export type DagsterBootstrapReadOperation = DagsterBootstrapDirectFactory['getInstances'];
+
+/** Delete operation for Dagster bootstrap instances, inherited from TypeKro. */
+export type DagsterBootstrapDeleteOperation = DagsterBootstrapDirectFactory['deleteInstance'];
+
+/** Declarative create/update operation for the Dagster HelmRepository wrapper. */
+export type DagsterHelmRepositoryCreateOrUpdateOperation = DagsterHelmRepositoryFactory;
+
+/** Declarative create/update operation for the Dagster HelmRelease wrapper. */
+export type DagsterHelmReleaseCreateOrUpdateOperation = DagsterHelmReleaseFactory;
+
+/** Read operation contract for the Dagster HelmRelease status shape. */
+export type DagsterHelmReleaseReadOperation = (
+  name: string,
+  namespace?: string
+) => DagsterOperationResult<HelmReleaseStatus>;
+
+/** Delete operation contract for the Dagster HelmRelease resource. */
+export type DagsterHelmReleaseDeleteOperation = (
+  name: string,
+  namespace?: string
+) => DagsterOperationResult<void>;
+
+/** Health check contract used by tests and operational diagnostics. */
+export interface DagsterHealthCheckStatus {
+  /** Machine-readable health check name. */
+  name: DagsterHealthCheckName;
+  /** Affected Dagster component. */
+  component: DagsterComponentName;
+  /** Whether this check is healthy. */
+  healthy: boolean;
+  /** Safe diagnostic message that excludes secret values. */
+  message?: string;
+  /** Kubernetes resource name, when applicable. */
+  resourceName?: string;
+  /** Kubernetes namespace, when applicable. */
+  namespace?: string;
+}
+
+/** Metrics configuration signal emitted by values mapping and operational diagnostics. */
+export interface DagsterMetricSignal {
+  /** Machine-readable metric/configuration signal name. */
+  name: DagsterMetricSignalName;
+  /** Affected Dagster component. */
+  component: DagsterComponentName;
+  /** Whether the metric-producing feature is enabled or configured. */
+  enabled: boolean;
+  /** Optional safe metric endpoint or signal target. */
+  endpoint?: string;
+  /** Optional non-sensitive labels associated with this signal. */
+  labels?: Record<string, string>;
+}
+
+/** Safe structured log event contract; secrets, DSNs, and credential URLs are excluded. */
+export interface DagsterOperationalLogEvent {
+  /** Machine-readable operational event type. */
+  type: DagsterOperationalEventType;
+  /** Affected Dagster component. */
+  component: DagsterComponentName;
+  /** Kubernetes resource name, when applicable. */
+  resourceName?: string;
+  /** Kubernetes namespace, when applicable. */
+  namespace?: string;
+  /** Safe diagnostic message that excludes passwords, tokens, URLs with credentials, and DSNs. */
+  message: string;
+}
+
+/** Contract for graph-aware values merge behavior used by `mapDagsterConfigToHelmValues`. */
+export interface DagsterValuesMergeContract {
+  /** Typed convenience values are generated first. */
+  typedValuesFirst: true;
+  /** User-supplied raw official chart values merge last and win conflicts. */
+  rawValuesMergeLast: true;
+  /** Plain objects merge recursively. */
+  deepMergeObjects: true;
+  /** Arrays replace earlier arrays rather than concatenate. */
+  arraysReplace: true;
+  /** Primitive raw values override typed values. */
+  primitivesOverride: true;
+  /** Kubernetes refs, CEL expressions, and values-merge expressions are preserved. */
+  graphAwareValuesPreserved: true;
+}

--- a/src/factories/dagster/types.ts
+++ b/src/factories/dagster/types.ts
@@ -257,6 +257,13 @@ const userDeploymentSchema = type({
   'startupProbe?': objectMapSchema,
   'deploymentStrategy?': objectMapSchema,
   'service?': { 'annotations?': 'Record<string, string>' },
+}).narrow((deployment, ctx) => {
+  const hasGrpcArgs = Array.isArray(deployment.dagsterApiGrpcArgs) && deployment.dagsterApiGrpcArgs.length > 0;
+  const hasCodeServerArgs = Array.isArray(deployment.codeServerArgs) && deployment.codeServerArgs.length > 0;
+
+  if (hasGrpcArgs !== hasCodeServerArgs) return true;
+
+  return ctx.mustBe('a user deployment with exactly one of dagsterApiGrpcArgs or codeServerArgs');
 });
 
 const userDeploymentsSchemaShape = {

--- a/src/factories/dagster/utils/helm-values-mapper.ts
+++ b/src/factories/dagster/utils/helm-values-mapper.ts
@@ -177,11 +177,7 @@ function validatePostgresql(
 }
 
 function mergeGlobalValues(values: DagsterHelmValues, config: DagsterBootstrapConfig): void {
-  const globalValues: TypeKroValueTreeObject = {};
-  const copiedGlobalValues = copyDefinedObject(config.global);
-  if (copiedGlobalValues && isMergeObject(copiedGlobalValues)) {
-    deepMerge(globalValues, copiedGlobalValues);
-  }
+  const globalValues = mapGlobalConfig(config.global) ?? {};
 
   setIfDefined(globalValues, 'serviceAccountName', config.serviceAccountName);
   setIfDefined(globalValues, 'postgresqlSecretName', config.postgresql?.passwordSecretName);
@@ -189,6 +185,23 @@ function mergeGlobalValues(values: DagsterHelmValues, config: DagsterBootstrapCo
   if (Object.keys(globalValues).length > 0) {
     values.global = globalValues;
   }
+}
+
+function mapGlobalConfig(
+  global: DagsterBootstrapConfig['global']
+): TypeKroValueTreeObject | undefined {
+  if (!global) return undefined;
+  if (!isGraphAwareValue(global)) return copyDefinedObject(global);
+
+  const mapped: TypeKroValueTreeObject = {};
+  setIfDefined(mapped, 'dagsterHome', global.dagsterHome);
+  setIfDefined(mapped, 'serviceAccountName', global.serviceAccountName);
+  setIfDefined(mapped, 'postgresqlSecretName', global.postgresqlSecretName);
+  setIfDefined(mapped, 'postgresqlAuthWifEnabled', global.postgresqlAuthWifEnabled);
+  setIfDefined(mapped, 'celeryConfigSecretName', global.celeryConfigSecretName);
+  setIfDefined(mapped, 'dagsterInstanceConfigMap', global.dagsterInstanceConfigMap);
+
+  return mapped;
 }
 
 function mapWebserverConfig(
@@ -301,13 +314,9 @@ function mapPostgresql(values: DagsterHelmValues, config: DagsterBootstrapConfig
     mapped.service = { port: postgresql.servicePort };
   }
 
-  const subValues = asValueObject(postgresql.values);
-  if (subValues) {
-    deepMerge(mapped, subValues);
-  }
-
-  if (Object.keys(mapped).length > 0) {
-    values.postgresql = mapped;
+  const mappedWithSubValues = mergeSubValues(mapped, postgresql.values);
+  if (isEmittableValue(mappedWithSubValues)) {
+    setIfDefined(values, 'postgresql', mappedWithSubValues);
   }
 
   const generatePostgresqlPasswordSecret = falseWhenValuePresent(
@@ -340,29 +349,29 @@ function mapRunLauncher(config: DagsterBootstrapConfig): TypeKroValueTreeObject 
   return mapped;
 }
 
-function mapRabbitmq(config: DagsterBootstrapConfig): TypeKroValueTreeObject | undefined {
+function mapRabbitmq(config: DagsterBootstrapConfig): DagsterRuntimeValueTree | undefined {
   const rabbitmq = config.rabbitmq;
   if (!rabbitmq) return undefined;
 
   const mapped: TypeKroValueTreeObject = {};
   setIfDefined(mapped, 'enabled', rabbitmq.enabled);
   setIfDefined(mapped, 'image', copyDefinedObject(rabbitmq.image));
-  setIfDefined(mapped, 'username', rabbitmq.username);
-  setIfDefined(mapped, 'password', rabbitmq.password);
+
+  const rabbitmqCredentials: TypeKroValueTreeObject = {};
+  setIfDefined(rabbitmqCredentials, 'username', rabbitmq.username);
+  setIfDefined(rabbitmqCredentials, 'password', rabbitmq.password);
+  if (Object.keys(rabbitmqCredentials).length > 0) {
+    mapped.rabbitmq = rabbitmqCredentials;
+  }
 
   if (rabbitmq.servicePort !== undefined) {
     mapped.service = { port: rabbitmq.servicePort };
   }
 
-  const subValues = asValueObject(rabbitmq.values);
-  if (subValues) {
-    deepMerge(mapped, subValues);
-  }
-
-  return mapped;
+  return mergeSubValues(mapped, rabbitmq.values);
 }
 
-function mapRedis(config: DagsterBootstrapConfig): TypeKroValueTreeObject | undefined {
+function mapRedis(config: DagsterBootstrapConfig): DagsterRuntimeValueTree | undefined {
   const redis = config.redis;
   if (!redis) return undefined;
 
@@ -379,12 +388,29 @@ function mapRedis(config: DagsterBootstrapConfig): TypeKroValueTreeObject | unde
   setIfDefined(mapped, 'brokerUrl', redis.brokerUrl);
   setIfDefined(mapped, 'backendUrl', redis.backendUrl);
 
-  const subValues = asValueObject(redis.values);
+  return mergeSubValues(mapped, redis.values);
+}
+
+function mergeSubValues(
+  mapped: TypeKroValueTreeObject,
+  values: unknown
+): DagsterRuntimeValueTree {
+  if (values === undefined) return mapped;
+  if (isKubernetesRef(values) || isCelExpression(values) || isValuesMergeExpression(values)) {
+    return mergeValuesExpression(mapped, values);
+  }
+
+  const subValues = asValueObject(values);
   if (subValues) {
     deepMerge(mapped, subValues);
   }
 
   return mapped;
+}
+
+function isEmittableValue(value: DagsterRuntimeValueTree): boolean {
+  if (isValuesMergeExpression(value) || isKubernetesRef(value) || isCelExpression(value)) return true;
+  return !isMergeObject(value) || Object.keys(value).length > 0;
 }
 
 function hasRawPath(values: unknown, key: string): boolean {

--- a/src/factories/dagster/utils/helm-values-mapper.ts
+++ b/src/factories/dagster/utils/helm-values-mapper.ts
@@ -179,11 +179,45 @@ function validatePostgresql(
 function mergeGlobalValues(values: DagsterHelmValues, config: DagsterBootstrapConfig): void {
   const globalValues = mapGlobalConfig(config.global) ?? {};
 
-  setIfDefined(globalValues, 'serviceAccountName', config.serviceAccountName);
-  setIfDefined(globalValues, 'postgresqlSecretName', config.postgresql?.passwordSecretName);
+  overlayGlobalValue(
+    globalValues,
+    'serviceAccountName',
+    config.serviceAccountName,
+    'schema.spec.serviceAccountName',
+    'schema.spec.global.serviceAccountName'
+  );
+  overlayGlobalValue(
+    globalValues,
+    'postgresqlSecretName',
+    config.postgresql?.passwordSecretName,
+    'schema.spec.postgresql.passwordSecretName',
+    'schema.spec.global.postgresqlSecretName'
+  );
 
   if (Object.keys(globalValues).length > 0) {
     values.global = globalValues;
+  }
+}
+
+function overlayGlobalValue(
+  target: TypeKroValueTreeObject,
+  key: string,
+  overlayValue: unknown,
+  overlayPath: string,
+  fallbackPath: string
+): void {
+  const fallbackValue = target[key];
+  if (overlayValue === undefined) return;
+
+  if (isGraphAwareValue(overlayValue) || isValuesMergeExpression(overlayValue)) {
+    target[key] = Cel.expr<string>(
+      `${hasSchemaPath(overlayPath)} ? ${overlayPath} : ${hasSchemaPath(fallbackPath)} ? ${fallbackPath} : omit()`
+    ) as TypeKroValueTree;
+    return;
+  }
+
+  if (fallbackValue !== undefined || overlayValue !== undefined) {
+    target[key] = overlayValue as TypeKroValueTree;
   }
 }
 

--- a/src/factories/dagster/utils/helm-values-mapper.ts
+++ b/src/factories/dagster/utils/helm-values-mapper.ts
@@ -1,0 +1,554 @@
+/**
+ * Dagster Helm values mapper and validation.
+ *
+ * The mapper intentionally builds only Dagster chart values. Bootstrap-only
+ * fields such as `name`, `namespace`, chart version, and Flux repository names
+ * stay in TypeKro resource configuration and are never forwarded to Helm.
+ */
+
+import {
+  isValuesMergeExpression,
+  mergeValuesExpression,
+  type ValuesMergeExpression,
+} from '../../../core/aspects/values-merge.js';
+import { TypeKroError } from '../../../core/errors.js';
+import { Cel } from '../../../core/references/cel.js';
+import type { TypeKroValueTree, TypeKroValueTreeObject } from '../../../core/types/common.js';
+import { isCelExpression, isKubernetesRef } from '../../../utils/type-guards.js';
+import type {
+  DagsterBootstrapConfig,
+  DagsterConfigValidationResult,
+  DagsterConfigurationErrorCode,
+  DagsterConfigurationIssue,
+  DagsterHelmValues,
+  DagsterImageConfig,
+  DagsterMappedHelmValues,
+  DagsterUserDeployment,
+} from '../types.js';
+
+type DagsterRuntimeValueTree = TypeKroValueTree | ValuesMergeExpression;
+type DagsterRuntimeValueTreeObject = { [key: string]: DagsterRuntimeValueTree };
+
+const DEFAULT_USER_DEPLOYMENT_PORT = 3030;
+const DEFAULT_USER_DEPLOYMENT_PULL_POLICY = 'IfNotPresent';
+const GRAPH_AWARE_DEEP_MERGE_SECTIONS = new Set([
+  'global',
+  'dagsterWebserver',
+  'dagsterDaemon',
+  'dagster-user-deployments',
+  'postgresql',
+  'runLauncher',
+  'scheduler',
+  'computeLogManager',
+  'ingress',
+  'flower',
+  'rabbitmq',
+  'redis',
+]);
+
+/** Error thrown when typed Dagster configuration violates safety invariants. */
+export class DagsterConfigurationValidationError extends TypeKroError {
+  constructor(
+    code: DagsterConfigurationErrorCode,
+    message: string,
+    context: { name?: string; issues: DagsterConfigurationIssue[] }
+  ) {
+    super(message, code, context);
+    this.name = 'DagsterConfigurationError';
+  }
+}
+
+/** Validate cross-field Dagster config rules that ArkType cannot express alone. */
+export function validateDagsterConfig(config: DagsterBootstrapConfig): DagsterConfigValidationResult {
+  const issues: DagsterConfigurationIssue[] = [];
+
+  validateUserDeployments(config, issues);
+  validateRunLauncher(config, issues);
+  validatePostgresql(config, issues);
+
+  return { valid: issues.length === 0, issues };
+}
+
+/** Map typed Dagster bootstrap config into official Dagster Helm chart values. */
+export function mapDagsterConfigToHelmValues(
+  config: DagsterBootstrapConfig
+): DagsterMappedHelmValues {
+  const validation = validateDagsterConfig(config);
+  if (!validation.valid) {
+    const firstIssue = validation.issues[0];
+    throw new DagsterConfigurationValidationError(
+      firstIssue?.code ?? 'DAGSTER_INVALID_CONFIG',
+      `DagsterConfigurationError ${firstIssue?.code ?? 'DAGSTER_INVALID_CONFIG'}: ${validation.issues
+        .map((issue) => issue.path)
+        .join(', ')}`,
+      { name: config.name, issues: validation.issues }
+    );
+  }
+
+  const values: DagsterHelmValues = {};
+
+  setIfDefined(values, 'nameOverride', config.nameOverride);
+  setIfDefined(values, 'fullnameOverride', config.fullnameOverride);
+  setIfDefined(values, 'rbacEnabled', config.rbacEnabled);
+  setIfDefined(values, 'imagePullSecrets', copyDefinedArray(config.imagePullSecrets));
+  mergeGlobalValues(values, config);
+  setIfDefined(values, 'dagsterWebserver', mapWebserverConfig(config.webserver));
+  setIfDefined(values, 'dagsterDaemon', mapDaemonConfig(config.daemon));
+  setIfDefined(values, 'dagster-user-deployments', mapUserDeployments(config));
+  mapPostgresql(values, config);
+  setIfDefined(values, 'runLauncher', mapRunLauncher(config));
+  setIfDefined(values, 'scheduler', copyDefinedObject(config.scheduler));
+  setIfDefined(values, 'computeLogManager', copyDefinedObject(config.computeLogManager));
+  setIfDefined(values, 'ingress', copyDefinedObject(config.ingress));
+  setIfDefined(values, 'flower', copyDefinedObject(config.flower));
+  setIfDefined(values, 'rabbitmq', mapRabbitmq(config));
+  setIfDefined(values, 'redis', mapRedis(config));
+
+  const generateCeleryConfigSecret = falseWhenValuePresent(
+    config.global?.celeryConfigSecretName,
+    'schema.spec.global.celeryConfigSecretName'
+  );
+  setIfDefined(values, 'generateCeleryConfigSecret', generateCeleryConfigSecret);
+
+  return mergeRawValuesLast(values, config.values);
+}
+
+function validateUserDeployments(
+  config: DagsterBootstrapConfig,
+  issues: DagsterConfigurationIssue[]
+): void {
+  const deployments = config.userDeployments?.deployments;
+  if (!Array.isArray(deployments)) return;
+
+  deployments.forEach((deployment, index) => {
+    const hasGrpcArgs = hasNonEmptyArray(deployment.dagsterApiGrpcArgs);
+    const hasCodeServerArgs = hasNonEmptyArray(deployment.codeServerArgs);
+    if (hasGrpcArgs === hasCodeServerArgs) {
+      issues.push({
+        code: 'DAGSTER_REQUIRED_CONFIG_MISSING',
+        path: `userDeployments.deployments[${index}]`,
+        component: 'userDeployments',
+        message:
+          'Each typed Dagster user deployment must set exactly one server argument field.',
+      });
+    }
+  });
+}
+
+function validateRunLauncher(
+  config: DagsterBootstrapConfig,
+  issues: DagsterConfigurationIssue[]
+): void {
+  if (config.runLauncher?.type !== 'CeleryK8sRunLauncher') return;
+
+  const hasRabbitmq = config.rabbitmq?.enabled === true;
+  const hasRedis =
+    config.redis?.enabled === true ||
+    config.redis?.internal === true ||
+    !!config.redis?.host ||
+    !!config.redis?.brokerUrl ||
+    !!config.redis?.backendUrl;
+  const hasSecret = !!config.global?.celeryConfigSecretName;
+  const hasRawCeleryConfig = hasRawPath(config.values, 'runLauncher') || hasRawPath(config.values, 'redis');
+
+  if (!hasRabbitmq && !hasRedis && !hasSecret && !hasRawCeleryConfig) {
+    issues.push({
+      code: 'DAGSTER_REQUIRED_CONFIG_MISSING',
+      path: 'runLauncher.celeryK8sRunLauncher',
+      component: 'runLauncher',
+      message: 'CeleryK8sRunLauncher requires RabbitMQ, Redis, or explicit raw Celery config.',
+    });
+  }
+}
+
+function validatePostgresql(
+  config: DagsterBootstrapConfig,
+  issues: DagsterConfigurationIssue[]
+): void {
+  if (config.postgresql?.enabled !== false) return;
+  if (config.postgresql.host || hasRawPath(config.values, 'postgresql')) return;
+
+  issues.push({
+    code: 'DAGSTER_REQUIRED_CONFIG_MISSING',
+    path: 'postgresql.host',
+    component: 'postgresql',
+    message: 'External PostgreSQL config requires a host or raw chart PostgreSQL values.',
+  });
+}
+
+function mergeGlobalValues(values: DagsterHelmValues, config: DagsterBootstrapConfig): void {
+  const globalValues: TypeKroValueTreeObject = {};
+  const copiedGlobalValues = copyDefinedObject(config.global);
+  if (copiedGlobalValues && isMergeObject(copiedGlobalValues)) {
+    deepMerge(globalValues, copiedGlobalValues);
+  }
+
+  setIfDefined(globalValues, 'serviceAccountName', config.serviceAccountName);
+  setIfDefined(globalValues, 'postgresqlSecretName', config.postgresql?.passwordSecretName);
+
+  if (Object.keys(globalValues).length > 0) {
+    values.global = globalValues;
+  }
+}
+
+function mapWebserverConfig(
+  webserver: DagsterBootstrapConfig['webserver']
+): TypeKroValueTreeObject | undefined {
+  if (!webserver) return undefined;
+  if (!isGraphAwareValue(webserver)) return copyDefinedObject(webserver);
+
+  const mapped: TypeKroValueTreeObject = {};
+  setIfDefined(mapped, 'replicaCount', webserver.replicaCount);
+  setIfDefined(mapped, 'image', copyDefinedObject(webserver.image));
+  setIfDefined(mapped, 'service', copyDefinedObject(webserver.service));
+  setIfDefined(mapped, 'pathPrefix', webserver.pathPrefix);
+  setIfDefined(mapped, 'enableReadOnly', webserver.enableReadOnly);
+  setIfDefined(mapped, 'logFormat', webserver.logFormat);
+  setIfDefined(mapped, 'logLevel', webserver.logLevel);
+  setIfDefined(mapped, 'workspace', copyDefinedObject(webserver.workspace));
+  setIfDefined(mapped, 'readinessProbe', copyDefinedObject(webserver.readinessProbe));
+  setIfDefined(mapped, 'livenessProbe', copyDefinedObject(webserver.livenessProbe));
+  setIfDefined(mapped, 'startupProbe', copyDefinedObject(webserver.startupProbe));
+  mapPodConfig(mapped, webserver);
+
+  return mapped;
+}
+
+function mapDaemonConfig(
+  daemon: DagsterBootstrapConfig['daemon']
+): TypeKroValueTreeObject | undefined {
+  if (!daemon) return undefined;
+  if (!isGraphAwareValue(daemon)) return copyDefinedObject(daemon);
+
+  const mapped: TypeKroValueTreeObject = {};
+  setIfDefined(mapped, 'enabled', daemon.enabled);
+  setIfDefined(mapped, 'image', copyDefinedObject(daemon.image));
+  setIfDefined(mapped, 'heartbeatTolerance', daemon.heartbeatTolerance);
+  setIfDefined(mapped, 'logFormat', daemon.logFormat);
+  setIfDefined(mapped, 'runCoordinator', copyDefinedObject(daemon.runCoordinator));
+  setIfDefined(mapped, 'runMonitoring', copyDefinedObject(daemon.runMonitoring));
+  setIfDefined(mapped, 'runRetries', copyDefinedObject(daemon.runRetries));
+  setIfDefined(mapped, 'sensors', copyDefinedObject(daemon.sensors));
+  setIfDefined(mapped, 'schedules', copyDefinedObject(daemon.schedules));
+  mapPodConfig(mapped, daemon);
+
+  return mapped;
+}
+
+function mapPodConfig(target: TypeKroValueTreeObject, podConfig: NonNullable<DagsterBootstrapConfig['webserver']>): void {
+  setIfDefined(target, 'labels', podConfig.labels);
+  setIfDefined(target, 'nodeSelector', podConfig.nodeSelector);
+  setIfDefined(target, 'affinity', copyDefinedObject(podConfig.affinity));
+  setIfDefined(target, 'tolerations', copyDefinedArray(podConfig.tolerations));
+  setIfDefined(target, 'resources', copyDefinedObject(podConfig.resources));
+  setIfDefined(target, 'podSecurityContext', copyDefinedObject(podConfig.podSecurityContext));
+  setIfDefined(target, 'securityContext', copyDefinedObject(podConfig.securityContext));
+  setIfDefined(target, 'volumes', copyDefinedArray(podConfig.volumes));
+  setIfDefined(target, 'volumeMounts', copyDefinedArray(podConfig.volumeMounts));
+  setIfDefined(target, 'env', copyDefinedArray(podConfig.env));
+  setIfDefined(target, 'envConfigMaps', copyDefinedArray(podConfig.envConfigMaps));
+  setIfDefined(target, 'envSecrets', copyDefinedArray(podConfig.envSecrets));
+}
+
+function mapUserDeployments(config: DagsterBootstrapConfig): TypeKroValueTreeObject | undefined {
+  const userDeployments = config.userDeployments;
+  if (!userDeployments) return undefined;
+
+  const mapped: TypeKroValueTreeObject = {};
+  setIfDefined(mapped, 'enabled', userDeployments.enabled);
+  setIfDefined(mapped, 'enableSubchart', userDeployments.enableSubchart ?? true);
+  setIfDefined(mapped, 'imagePullSecrets', copyDefinedArray(userDeployments.imagePullSecrets));
+
+  const deployments = userDeployments.deployments;
+  if (Array.isArray(deployments)) {
+    mapped.deployments = deployments.map(mapUserDeployment);
+  } else {
+    setIfDefined(mapped, 'deployments', copyDefinedArray(deployments));
+  }
+
+  return mapped;
+}
+
+function mapUserDeployment(deployment: DagsterUserDeployment): TypeKroValueTreeObject {
+  const mapped = copyDefinedObject(deployment) ?? {};
+  setIfDefined(mapped, 'port', deployment.port ?? DEFAULT_USER_DEPLOYMENT_PORT);
+  mapped.image = mapUserDeploymentImage(deployment.image);
+  return mapped;
+}
+
+function mapUserDeploymentImage(image: DagsterImageConfig): TypeKroValueTreeObject {
+  return {
+    ...copyDefinedObject(image),
+    pullPolicy: image.pullPolicy ?? DEFAULT_USER_DEPLOYMENT_PULL_POLICY,
+  };
+}
+
+function mapPostgresql(values: DagsterHelmValues, config: DagsterBootstrapConfig): void {
+  const postgresql = config.postgresql;
+  if (!postgresql) return;
+
+  const mapped: TypeKroValueTreeObject = {};
+  setIfDefined(mapped, 'enabled', postgresql.enabled);
+  setIfDefined(mapped, 'postgresqlHost', postgresql.host);
+  setIfDefined(mapped, 'postgresqlUsername', postgresql.username);
+  setIfDefined(mapped, 'postgresqlDatabase', postgresql.database);
+  setIfDefined(mapped, 'postgresqlPassword', postgresql.password);
+  setIfDefined(mapped, 'postgresqlParams', postgresql.params);
+  setIfDefined(mapped, 'postgresqlScheme', postgresql.scheme);
+  setIfDefined(mapped, 'authProvider', copyDefinedObject(postgresql.authProvider));
+
+  if (postgresql.servicePort !== undefined) {
+    mapped.service = { port: postgresql.servicePort };
+  }
+
+  const subValues = asValueObject(postgresql.values);
+  if (subValues) {
+    deepMerge(mapped, subValues);
+  }
+
+  if (Object.keys(mapped).length > 0) {
+    values.postgresql = mapped;
+  }
+
+  const generatePostgresqlPasswordSecret = falseWhenValuePresent(
+    postgresql.passwordSecretName,
+    'schema.spec.postgresql.passwordSecretName'
+  );
+  setIfDefined(values, 'generatePostgresqlPasswordSecret', generatePostgresqlPasswordSecret);
+}
+
+function mapRunLauncher(config: DagsterBootstrapConfig): TypeKroValueTreeObject | undefined {
+  const runLauncher = config.runLauncher;
+  if (!runLauncher) return undefined;
+
+  const mapped: TypeKroValueTreeObject = {};
+  setIfDefined(mapped, 'type', runLauncher.type);
+
+  const launcherConfig: TypeKroValueTreeObject = {};
+  setIfDefined(launcherConfig, 'k8sRunLauncher', copyDefinedObject(runLauncher.k8sRunLauncher));
+  setIfDefined(
+    launcherConfig,
+    'celeryK8sRunLauncher',
+    copyDefinedObject(runLauncher.celeryK8sRunLauncher)
+  );
+  setIfDefined(launcherConfig, 'customRunLauncher', copyDefinedObject(runLauncher.customRunLauncher));
+
+  if (Object.keys(launcherConfig).length > 0) {
+    mapped.config = launcherConfig;
+  }
+
+  return mapped;
+}
+
+function mapRabbitmq(config: DagsterBootstrapConfig): TypeKroValueTreeObject | undefined {
+  const rabbitmq = config.rabbitmq;
+  if (!rabbitmq) return undefined;
+
+  const mapped: TypeKroValueTreeObject = {};
+  setIfDefined(mapped, 'enabled', rabbitmq.enabled);
+  setIfDefined(mapped, 'image', copyDefinedObject(rabbitmq.image));
+  setIfDefined(mapped, 'username', rabbitmq.username);
+  setIfDefined(mapped, 'password', rabbitmq.password);
+
+  if (rabbitmq.servicePort !== undefined) {
+    mapped.service = { port: rabbitmq.servicePort };
+  }
+
+  const subValues = asValueObject(rabbitmq.values);
+  if (subValues) {
+    deepMerge(mapped, subValues);
+  }
+
+  return mapped;
+}
+
+function mapRedis(config: DagsterBootstrapConfig): TypeKroValueTreeObject | undefined {
+  const redis = config.redis;
+  if (!redis) return undefined;
+
+  const mapped: TypeKroValueTreeObject = {};
+  setIfDefined(mapped, 'enabled', redis.enabled);
+  setIfDefined(mapped, 'internal', redis.internal);
+  setIfDefined(mapped, 'image', copyDefinedObject(redis.image));
+  setIfDefined(mapped, 'usePassword', redis.usePassword);
+  setIfDefined(mapped, 'password', redis.password);
+  setIfDefined(mapped, 'host', redis.host);
+  setIfDefined(mapped, 'port', redis.port);
+  setIfDefined(mapped, 'brokerDbNumber', redis.brokerDbNumber);
+  setIfDefined(mapped, 'backendDbNumber', redis.backendDbNumber);
+  setIfDefined(mapped, 'brokerUrl', redis.brokerUrl);
+  setIfDefined(mapped, 'backendUrl', redis.backendUrl);
+
+  const subValues = asValueObject(redis.values);
+  if (subValues) {
+    deepMerge(mapped, subValues);
+  }
+
+  return mapped;
+}
+
+function hasRawPath(values: unknown, key: string): boolean {
+  const rawValues = asValueObject(values);
+  return rawValues ? rawValues[key] !== undefined : false;
+}
+
+function hasNonEmptyArray(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0;
+}
+
+function setIfDefined(target: TypeKroValueTreeObject, key: string, value: unknown): void {
+  if (value !== undefined) {
+    target[key] = value as TypeKroValueTree;
+  }
+}
+
+function copyDefinedObject(source: object | undefined): TypeKroValueTreeObject | undefined {
+  if (!source) return undefined;
+  if (!isMergeObject(source)) return source as TypeKroValueTreeObject;
+
+  const result: TypeKroValueTreeObject = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      result[key] = copyDefinedArray(value);
+    } else if (isMergeObject(value)) {
+      const nested = copyDefinedObject(value);
+      if (nested && Object.keys(nested).length > 0) {
+        result[key] = nested;
+      }
+    } else {
+      result[key] = value as TypeKroValueTree;
+    }
+  }
+
+  return result;
+}
+
+function copyDefinedArray(values: readonly unknown[] | undefined): TypeKroValueTree | undefined {
+  if (!values) return undefined;
+  if (isKubernetesRef(values)) {
+    return values;
+  }
+  if (isCelExpression(values)) {
+    return values;
+  }
+
+  return values.map((value) => {
+    if (Array.isArray(value)) return copyDefinedArray(value) ?? [];
+    if (isMergeObject(value)) return copyDefinedObject(value) ?? {};
+    return value as TypeKroValueTree;
+  });
+}
+
+function deepMerge(target: TypeKroValueTreeObject, source: TypeKroValueTreeObject): void {
+  const runtimeTarget = target as DagsterRuntimeValueTreeObject;
+  for (const [key, sourceValue] of Object.entries(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+    const targetValue = runtimeTarget[key];
+    if (isMergeObject(targetValue) && isMergeObject(sourceValue)) {
+      deepMerge(targetValue, sourceValue);
+    } else {
+      runtimeTarget[key] = mergeValue(key, targetValue, sourceValue);
+    }
+  }
+}
+
+function mergeValue(key: string, baseValue: unknown, overlayValue: unknown): DagsterRuntimeValueTree {
+  if (baseValue === undefined) return overlayValue as DagsterRuntimeValueTree;
+  if (overlayValue === undefined) return baseValue as DagsterRuntimeValueTree;
+
+  if (
+    (isGraphAwareValue(baseValue) &&
+      isGraphAwareValue(overlayValue) &&
+      shouldDeepMergeGraphAwareSection(key)) ||
+    (isGraphAwareValue(baseValue) && isMergeObject(overlayValue)) ||
+    (isMergeObject(baseValue) && isGraphAwareValue(overlayValue)) ||
+    isValuesMergeExpression(baseValue) ||
+    isValuesMergeExpression(overlayValue)
+  ) {
+    return mergeValuesExpression(baseValue, overlayValue);
+  }
+
+  return overlayValue as DagsterRuntimeValueTree;
+}
+
+function shouldDeepMergeGraphAwareSection(key: string): boolean {
+  return GRAPH_AWARE_DEEP_MERGE_SECTIONS.has(key);
+}
+
+function asValueObject(value: unknown): TypeKroValueTreeObject | undefined {
+  return isMergeObject(value) ? (value as TypeKroValueTreeObject) : undefined;
+}
+
+function mergeRawValuesLast(
+  baseValues: DagsterHelmValues,
+  rawValues: unknown
+): DagsterMappedHelmValues {
+  if (rawValues === undefined) return baseValues;
+  if (isKubernetesRef(rawValues) || isCelExpression(rawValues) || isValuesMergeExpression(rawValues)) {
+    return createDagsterValuesMerge(baseValues, rawValues);
+  }
+
+  const rawValueObject = asValueObject(rawValues);
+  if (rawValueObject) {
+    deepMerge(baseValues, rawValueObject);
+  }
+
+  return baseValues;
+}
+
+function createDagsterValuesMerge(
+  baseValues: DagsterHelmValues,
+  rawValues: unknown
+): ValuesMergeExpression {
+  if (!isKubernetesRef(rawValues) && !isCelExpression(rawValues) && !isValuesMergeExpression(rawValues)) {
+    throw new DagsterConfigurationValidationError(
+      'DAGSTER_INVALID_CONFIG',
+      'DagsterConfigurationError DAGSTER_INVALID_CONFIG: values',
+      {
+        issues: [
+          {
+            code: 'DAGSTER_INVALID_CONFIG',
+            path: 'values',
+            message: 'Graph-aware raw values merge requires a KubernetesRef, CEL expression, or values merge expression.',
+          },
+        ],
+      }
+    );
+  }
+
+  return mergeValuesExpression(baseValues, rawValues);
+}
+
+function falseWhenValuePresent(value: unknown, schemaPath: string): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (isGraphAwareValue(value) || isValuesMergeExpression(value)) {
+    return Cel.expr<boolean>(`${hasSchemaPath(schemaPath)} ? false : omit()`) as boolean;
+  }
+
+  return false;
+}
+
+function hasSchemaPath(path: string): string {
+  const parts = path.split('.');
+  const guards: string[] = [];
+  for (let index = 2; index < parts.length; index++) {
+    guards.push(`has(${parts.slice(0, index + 1).join('.')})`);
+  }
+  return guards.join(' && ');
+}
+
+function isGraphAwareValue(value: unknown): boolean {
+  return isKubernetesRef(value) || isCelExpression(value);
+}
+
+function isMergeObject(value: unknown): value is TypeKroValueTreeObject {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    !isKubernetesRef(value) &&
+    !isCelExpression(value) &&
+    !isValuesMergeExpression(value)
+  );
+}

--- a/src/factories/dagster/utils/index.ts
+++ b/src/factories/dagster/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './helm-values-mapper.js';

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -96,6 +96,12 @@ describe('Dagster bootstrap composition', () => {
     expect(yaml).toContain('schema.spec.userDeployments.deployments');
     expect(yaml).toContain('schema.spec.webserver.image');
     expect(yaml).toContain('schema.spec.daemon.image');
+    expect(yaml).toContain('schema.spec.global.dagsterHome');
+    expect(yaml).toContain('schema.spec.global.celeryConfigSecretName');
+    expect(yaml).toContain('schema.spec.global.dagsterInstanceConfigMap');
+    expect(yaml).toContain('schema.spec.postgresql.values');
+    expect(yaml).toContain('schema.spec.rabbitmq.values');
+    expect(yaml).toContain('schema.spec.redis.values');
     expect(yaml).toContain('postgresqlHost');
     expect(yaml).toContain('k8sRunLauncher');
     expect(yaml).toContain(
@@ -107,6 +113,28 @@ describe('Dagster bootstrap composition', () => {
     expect(yaml).not.toContain('__typekroSchemaKey');
     expect(yaml).not.toContain('[object Object]');
     expect(yaml).not.toContain('undefined');
+  });
+
+  it('Reject KRO instance YAML with invalid typed user deployment arguments', () => {
+    const factory = dagsterBootstrap.factory('kro', {
+      namespace: 'typekro-dagster-test',
+    });
+
+    expect(() =>
+      factory.toYaml({
+        name: 'broken-dagster',
+        namespace: 'dagster-broken',
+        userDeployments: {
+          enabled: true,
+          deployments: [
+            {
+              name: 'broken-repo',
+              image: { repository: 'ghcr.io/acme/broken', tag: '1' },
+            },
+          ],
+        },
+      })
+    ).toThrow(/exactly one of dagsterApiGrpcArgs or codeServerArgs|user deployment/);
   });
 
   it('Generate direct-mode YAML with Dagster deployment values', async () => {

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'bun:test';
+import { dagsterBootstrap } from '../../../src/factories/dagster/index.js';
+import {
+  DagsterBootstrapConfigSchema,
+  DagsterBootstrapStatusSchema,
+} from '../../../src/factories/dagster/types.js';
+
+// Test decision: use the Dagster package barrel for bootstrap behavior so this
+// suite catches missing public wiring, not only a helper-only composition file.
+// Direct composition imports were rejected because `typekro/dagster` is the
+// approved user-facing seam.
+describe('Dagster bootstrap composition', () => {
+  it('Accept valid Dagster bootstrap config through the config schema', () => {
+    const result = DagsterBootstrapConfigSchema({
+      name: 'analytics',
+      namespace: 'dagster',
+      version: '1.13.8',
+      userDeployments: {
+        enabled: true,
+        deployments: [
+          {
+            name: 'analytics-repo',
+            image: {
+              repository: 'ghcr.io/acme/dagster-analytics',
+              tag: '2026.06.01',
+            },
+            codeServerArgs: ['-m', 'analytics.definitions'],
+          },
+        ],
+      },
+      postgresql: {
+        enabled: false,
+        host: 'dagster-postgres.postgres.svc.cluster.local',
+        username: 'dagster',
+        database: 'dagster',
+        passwordSecretName: 'dagster-postgres',
+      },
+      runLauncher: {
+        type: 'K8sRunLauncher',
+        k8sRunLauncher: { jobNamespace: 'dagster-runs' },
+      },
+      ingress: {
+        enabled: true,
+        dagsterWebserver: { host: 'dagster.example.com' },
+      },
+      values: { busybox: { image: { tag: '1.36' } } },
+    });
+
+    expect(result instanceof Error).toBe(false);
+  });
+
+  it('Expose Dagster bootstrap status fields from owned Helm resources', () => {
+    const result = DagsterBootstrapStatusSchema({
+      ready: true,
+      phase: 'Ready',
+      failed: false,
+      version: '1.13.8',
+      components: {
+        helmRepository: true,
+        helmRelease: true,
+        webserver: true,
+        daemon: true,
+        userDeployments: true,
+      },
+    });
+
+    expect(result instanceof Error).toBe(false);
+  });
+
+  it('Generate ResourceGraphDefinition YAML with owned resources and status CEL', () => {
+    const yaml = dagsterBootstrap.toYaml();
+
+    expect(yaml).toContain('apiVersion: kro.run/v1alpha1');
+    expect(yaml).toContain('kind: ResourceGraphDefinition');
+    expect(yaml).toContain('name: dagster-bootstrap');
+    expect(yaml).toContain('dagsterNamespace');
+    expect(yaml).toContain('dagsterHelmRepository');
+    expect(yaml).toContain('dagsterHelmRelease');
+    expect(yaml).toContain('kind: Namespace');
+    expect(yaml).toContain('kind: HelmRepository');
+    expect(yaml).toContain('kind: HelmRelease');
+    expect(yaml).toContain('https://dagster-io.github.io/helm');
+    expect(yaml).toContain('chart: dagster');
+    expect(yaml).toContain('1.13.8');
+    expect(yaml).toContain('ready: ${dagsterHelmRelease.status.conditions');
+    expect(yaml).toContain('phase: "${dagsterHelmRelease.status.conditions');
+    expect(yaml).not.toContain('kind: Deployment');
+    expect(yaml).not.toContain('kind: Pod');
+  });
+
+  it('Preserve graph-aware Helm values in ResourceGraphDefinition YAML without raw markers', () => {
+    const yaml = dagsterBootstrap.toYaml();
+
+    expect(yaml).toContain('schema.spec.values');
+    expect(yaml).toContain('json.unmarshal(json.marshal(schema.spec.values))');
+    expect(yaml).toContain('schema.spec.userDeployments.deployments');
+    expect(yaml).toContain('schema.spec.webserver.image');
+    expect(yaml).toContain('schema.spec.daemon.image');
+    expect(yaml).toContain('postgresqlHost');
+    expect(yaml).toContain('k8sRunLauncher');
+    expect(yaml).toContain(
+      'has(schema.spec.postgresql) && has(schema.spec.postgresql.passwordSecretName) ? false : omit()'
+    );
+    expect(yaml).not.toContain('\\"deployments\\": [(has(schema.spec.userDeployments');
+    expect(yaml).not.toContain('\\"imagePullSecrets\\": [(has(schema.spec.imagePullSecrets');
+    expect(yaml).not.toContain('__KUBERNETES_REF_');
+    expect(yaml).not.toContain('__typekroSchemaKey');
+    expect(yaml).not.toContain('[object Object]');
+    expect(yaml).not.toContain('undefined');
+  });
+
+  it('Generate direct-mode YAML with Dagster deployment values', async () => {
+    const factory = dagsterBootstrap.factory('direct', {
+      namespace: 'typekro-dagster-test',
+    });
+    const yaml = await factory.toYaml({
+      name: 'analytics',
+      namespace: 'dagster-analytics',
+      userDeployments: {
+        enabled: true,
+        deployments: [
+          {
+            name: 'analytics-repo',
+            image: {
+              repository: 'ghcr.io/acme/dagster-analytics',
+              tag: '2026.06.01',
+            },
+            dagsterApiGrpcArgs: ['-m', 'analytics.grpc'],
+          },
+        ],
+      },
+      postgresql: {
+        enabled: false,
+        host: 'dagster-postgres.postgres.svc.cluster.local',
+        username: 'dagster',
+        database: 'dagster',
+        passwordSecretName: 'dagster-postgres',
+      },
+      runLauncher: {
+        type: 'K8sRunLauncher',
+        k8sRunLauncher: { jobNamespace: 'dagster-runs' },
+      },
+      values: {
+        busybox: { image: { repository: 'busybox', tag: '1.36' } },
+      },
+    });
+
+    expect(yaml).toContain('kind: Namespace');
+    expect(yaml).toContain('kind: HelmRepository');
+    expect(yaml).toContain('kind: HelmRelease');
+    expect(yaml).toContain('ghcr.io/acme/dagster-analytics');
+    expect(yaml).toContain('analytics.grpc');
+    expect(yaml).toContain('dagster-postgres.postgres.svc.cluster.local');
+    expect(yaml).toContain('dagster-postgres');
+    expect(yaml).toContain('K8sRunLauncher');
+    expect(yaml).toContain('dagster-runs');
+    expect(yaml).toContain('busybox');
+    expect(yaml).not.toContain('undefined');
+    expect(yaml).not.toContain('[object Object]');
+  });
+});

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -98,7 +98,15 @@ describe('Dagster bootstrap composition', () => {
     expect(yaml).toContain('schema.spec.daemon.image');
     expect(yaml).toContain('schema.spec.global.dagsterHome');
     expect(yaml).toContain('schema.spec.global.celeryConfigSecretName');
+    expect(yaml).toContain('schema.spec.global.serviceAccountName');
+    expect(yaml).toContain('schema.spec.global.postgresqlSecretName');
     expect(yaml).toContain('schema.spec.global.dagsterInstanceConfigMap');
+    expect(yaml).toContain(
+      'has(schema.spec.serviceAccountName) ? schema.spec.serviceAccountName : has(schema.spec.global) && has(schema.spec.global.serviceAccountName) ? schema.spec.global.serviceAccountName : omit()'
+    );
+    expect(yaml).toContain(
+      'has(schema.spec.postgresql) && has(schema.spec.postgresql.passwordSecretName) ? schema.spec.postgresql.passwordSecretName : has(schema.spec.global) && has(schema.spec.global.postgresqlSecretName) ? schema.spec.global.postgresqlSecretName : omit()'
+    );
     expect(yaml).toContain('schema.spec.postgresql.values');
     expect(yaml).toContain('schema.spec.rabbitmq.values');
     expect(yaml).toContain('schema.spec.redis.values');

--- a/test/factories/dagster/exports.test.ts
+++ b/test/factories/dagster/exports.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'bun:test';
+import * as dagster from '../../../src/factories/dagster/index.js';
+
+describe('Dagster public exports', () => {
+  it('Import Dagster APIs from typekro/dagster through package metadata', async () => {
+    const packageJson = (await Bun.file('package.json').json()) as {
+      exports: Record<string, Record<string, string>>;
+      files: string[];
+    };
+
+    expect(packageJson.exports['./dagster']).toEqual({
+      import: './dist/factories/dagster/index.js',
+      types: './dist/factories/dagster/index.d.ts',
+    });
+    expect(packageJson.files).toContain('dist');
+    expect(packageJson.files).not.toContain('src/factories/dagster');
+  });
+
+  it('Export Dagster wrappers, composition, mapper, schemas, and constants', () => {
+    expect(typeof dagster.dagsterHelmRepository).toBe('function');
+    expect(typeof dagster.dagsterHelmRelease).toBe('function');
+    expect(dagster.dagsterBootstrap).toBeDefined();
+    expect(typeof dagster.mapDagsterConfigToHelmValues).toBe('function');
+    expect(typeof dagster.validateDagsterConfig).toBe('function');
+    expect(dagster.DagsterBootstrapConfigSchema).toBeDefined();
+    expect(dagster.DagsterBootstrapStatusSchema).toBeDefined();
+    expect(dagster.DagsterHelmRepositoryConfigSchema).toBeDefined();
+    expect(dagster.DagsterHelmReleaseConfigSchema).toBeDefined();
+    expect(dagster.DEFAULT_DAGSTER_REPO_URL).toBe('https://dagster-io.github.io/helm');
+    expect(dagster.DEFAULT_DAGSTER_REPO_NAME).toBe('dagster');
+    expect(dagster.DEFAULT_DAGSTER_VERSION).toBe('1.13.8');
+  });
+
+  it('Document Dagster API usage and expose Dagster in the API sidebar', async () => {
+    const docsPage = await Bun.file('docs/api/dagster/index.md').text();
+    const docsConfig = await Bun.file('docs/.vitepress/config.ts').text();
+
+    expect(docsPage).toContain("from 'typekro/dagster'");
+    expect(docsPage).toContain('dagsterBootstrap');
+    expect(docsPage).toContain('external PostgreSQL');
+    expect(docsPage).toContain('Secrets');
+    expect(docsPage).toContain('Troubleshooting');
+    expect(docsPage).toContain('Next Steps');
+    expect(docsConfig).toContain('/api/dagster/');
+    expect(docsConfig).toContain('Dagster');
+  });
+});

--- a/test/factories/dagster/helm.test.ts
+++ b/test/factories/dagster/helm.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  DEFAULT_DAGSTER_REPO_NAME,
+  DEFAULT_DAGSTER_REPO_URL,
+  DEFAULT_DAGSTER_VERSION,
+  dagsterHelmRelease,
+  dagsterHelmRepository,
+} from '../../../src/factories/dagster/resources/helm.js';
+import {
+  CEL_EXPRESSION_BRAND,
+  KUBERNETES_REF_BRAND,
+} from '../../../src/core/constants/brands.js';
+import type { CelExpression, KubernetesRef } from '../../../src/core/types/common.js';
+
+describe('Dagster Helm wrappers', () => {
+  describe('dagsterHelmRepository', () => {
+    it('Create Dagster HelmRepository resources with official chart defaults', () => {
+      const repository = dagsterHelmRepository({ id: 'dagsterHelmRepository' });
+
+      expect(repository.id).toBe('dagsterHelmRepository');
+      expect(repository.kind).toBe('HelmRepository');
+      expect(repository.apiVersion).toBe('source.toolkit.fluxcd.io/v1');
+      expect(repository.metadata.name).toBe(DEFAULT_DAGSTER_REPO_NAME);
+      expect(repository.metadata.namespace).toBe('flux-system');
+      expect(repository.spec.url).toBe(DEFAULT_DAGSTER_REPO_URL);
+      expect(repository.spec.url).toBe('https://dagster-io.github.io/helm');
+      expect(repository.spec.interval).toBe('5m');
+      expect(repository.readinessEvaluator).toBeDefined();
+    });
+
+    it('Create Dagster HelmRepository resources with explicit repository overrides', () => {
+      const repository = dagsterHelmRepository({
+        id: 'customDagsterRepository',
+        name: 'dagster-custom',
+        namespace: 'platform-flux',
+        url: 'https://example.invalid/dagster/charts',
+        interval: '15m',
+      });
+
+      expect(repository.id).toBe('customDagsterRepository');
+      expect(repository.metadata.name).toBe('dagster-custom');
+      expect(repository.metadata.namespace).toBe('platform-flux');
+      expect(repository.spec.url).toBe('https://example.invalid/dagster/charts');
+      expect(repository.spec.interval).toBe('15m');
+    });
+  });
+
+  describe('dagsterHelmRelease', () => {
+    it('Create Dagster HelmRelease resources with official chart defaults', () => {
+      const release = dagsterHelmRelease({
+        id: 'dagsterHelmRelease',
+        name: 'dagster',
+      });
+
+      expect(release.id).toBe('dagsterHelmRelease');
+      expect(release.kind).toBe('HelmRelease');
+      expect(release.apiVersion).toBe('helm.toolkit.fluxcd.io/v2');
+      expect(release.metadata.name).toBe('dagster');
+      expect(release.metadata.namespace).toBe('dagster');
+      expect(release.spec.chart.spec.chart).toBe('dagster');
+      expect(release.spec.chart.spec.version).toBe(DEFAULT_DAGSTER_VERSION);
+      expect(release.spec.chart.spec.version).toBe('1.13.8');
+      expect(release.spec.chart.spec.sourceRef.name).toBe(DEFAULT_DAGSTER_REPO_NAME);
+      expect(release.spec.chart.spec.sourceRef.namespace).toBe('flux-system');
+      expect(release.readinessEvaluator).toBeDefined();
+    });
+
+    it('Create Dagster HelmRelease resources with explicit release overrides', () => {
+      const release = dagsterHelmRelease({
+        id: 'dagsterProdHelmRelease',
+        name: 'dagster-prod',
+        namespace: 'data-platform',
+        repositoryName: 'dagster-prod-source',
+        repositoryNamespace: 'platform-flux',
+        version: '1.13.7',
+        values: {
+          dagsterWebserver: { replicaCount: 2 },
+        },
+      });
+
+      expect(release.id).toBe('dagsterProdHelmRelease');
+      expect(release.metadata.name).toBe('dagster-prod');
+      expect(release.metadata.namespace).toBe('data-platform');
+      expect(release.spec.chart.spec.chart).toBe('dagster');
+      expect(release.spec.chart.spec.version).toBe('1.13.7');
+      expect(release.spec.chart.spec.sourceRef.name).toBe('dagster-prod-source');
+      expect(release.spec.chart.spec.sourceRef.namespace).toBe('platform-flux');
+      expect(release.spec.values?.dagsterWebserver).toEqual({ replicaCount: 2 });
+    });
+
+    it('Preserve TypeKro magic-proxy refs and CEL values inside nested Helm values', () => {
+      const userImageRef = {
+        [KUBERNETES_REF_BRAND]: true,
+        resourceId: 'imageConfig',
+        fieldPath: 'status.repository',
+      } satisfies KubernetesRef<string>;
+      const tagExpression = {
+        [CEL_EXPRESSION_BRAND]: true,
+        expression: 'schema.spec.version',
+      } satisfies CelExpression<string>;
+
+      const release = dagsterHelmRelease({
+        id: 'dagsterGraphAwareValues',
+        name: 'dagster',
+        values: {
+          'dagster-user-deployments': {
+            deployments: [
+              {
+                name: 'repo',
+                image: {
+                  repository: userImageRef,
+                  tag: tagExpression,
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const userDeployments = release.spec.values?.['dagster-user-deployments'] as
+        | {
+            deployments?: Array<{
+              image?: { repository?: unknown; tag?: unknown };
+            }>;
+          }
+        | undefined;
+      expect(userDeployments).toBeDefined();
+      expect(userDeployments?.deployments?.[0]?.image?.repository).toBe(userImageRef);
+      expect(userDeployments?.deployments?.[0]?.image?.tag).toBe(tagExpression);
+    });
+  });
+});

--- a/test/factories/dagster/values-mapper.test.ts
+++ b/test/factories/dagster/values-mapper.test.ts
@@ -303,6 +303,38 @@ describe('Dagster Helm values mapper', () => {
     expect(values.redis?.values).toBeUndefined();
   });
 
+  it('Preserve global chart fields unless top-level conveniences override them', () => {
+    const globalOnly = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      global: {
+        serviceAccountName: 'global-service-account',
+        postgresqlSecretName: 'global-postgresql-secret',
+      },
+    }));
+    const topLevelOverride = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      serviceAccountName: 'top-level-service-account',
+      global: {
+        serviceAccountName: 'global-service-account',
+        postgresqlSecretName: 'global-postgresql-secret',
+      },
+      postgresql: {
+        enabled: false,
+        host: 'dagster-postgres.postgres.svc.cluster.local',
+        passwordSecretName: 'top-level-postgresql-secret',
+      },
+    }));
+
+    expect(globalOnly.global).toMatchObject({
+      serviceAccountName: 'global-service-account',
+      postgresqlSecretName: 'global-postgresql-secret',
+    });
+    expect(topLevelOverride.global).toMatchObject({
+      serviceAccountName: 'top-level-service-account',
+      postgresqlSecretName: 'top-level-postgresql-secret',
+    });
+  });
+
   it('Map RabbitMQ credentials to the official nested chart path', () => {
     const values = concreteValues(mapDagsterConfigToHelmValues({
       ...minimalConfig,

--- a/test/factories/dagster/values-mapper.test.ts
+++ b/test/factories/dagster/values-mapper.test.ts
@@ -8,7 +8,11 @@ import {
   mapDagsterConfigToHelmValues,
   validateDagsterConfig,
 } from '../../../src/factories/dagster/utils/helm-values-mapper.js';
-import type { CelExpression, KubernetesRef } from '../../../src/core/types/common.js';
+import type {
+  CelExpression,
+  KubernetesRef,
+  TypeKroValueTreeObject,
+} from '../../../src/core/types/common.js';
 import type {
   DagsterBootstrapConfig,
   DagsterHelmValues,
@@ -283,9 +287,10 @@ describe('Dagster Helm values mapper', () => {
     }));
 
     expect(values.generateCeleryConfigSecret).toBe(false);
+    expect(values.global).toMatchObject({ celeryConfigSecretName: 'dagster-celery-config' });
     expect(values.rabbitmq).toMatchObject({
       enabled: true,
-      username: 'dagster',
+      rabbitmq: { username: 'dagster' },
       service: { port: 5672 },
       persistence: { enabled: true },
     });
@@ -296,6 +301,63 @@ describe('Dagster Helm values mapper', () => {
       master: { persistence: { enabled: true } },
     });
     expect(values.redis?.values).toBeUndefined();
+  });
+
+  it('Map RabbitMQ credentials to the official nested chart path', () => {
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      global: { celeryConfigSecretName: 'dagster-celery-config' },
+      runLauncher: { type: 'CeleryK8sRunLauncher' },
+      rabbitmq: {
+        enabled: true,
+        username: 'dagster-user',
+        password: 'dagster-password',
+      },
+    }));
+
+    expect(values.rabbitmq).toMatchObject({
+      enabled: true,
+      rabbitmq: {
+        username: 'dagster-user',
+        password: 'dagster-password',
+      },
+    });
+    expect(values.rabbitmq?.username).toBeUndefined();
+    expect(values.rabbitmq?.password).toBeUndefined();
+  });
+
+  it('Preserve graph-aware subchart values as nested values merge expressions', () => {
+    const postgresqlValues = {
+      [KUBERNETES_REF_BRAND]: true,
+      resourceId: 'postgresqlValues',
+      fieldPath: 'status.values',
+    } satisfies KubernetesRef<TypeKroValueTreeObject>;
+    const rabbitmqValues = {
+      [KUBERNETES_REF_BRAND]: true,
+      resourceId: 'rabbitmqValues',
+      fieldPath: 'status.values',
+    } satisfies KubernetesRef<TypeKroValueTreeObject>;
+    const redisValues = {
+      [KUBERNETES_REF_BRAND]: true,
+      resourceId: 'redisValues',
+      fieldPath: 'status.values',
+    } satisfies KubernetesRef<TypeKroValueTreeObject>;
+
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      global: { celeryConfigSecretName: 'dagster-celery-config' },
+      runLauncher: { type: 'CeleryK8sRunLauncher' },
+      postgresql: { enabled: true, values: postgresqlValues },
+      rabbitmq: { enabled: true, values: rabbitmqValues },
+      redis: { enabled: true, values: redisValues },
+    }));
+
+    expect(isValuesMergeExpression(values.postgresql)).toBe(true);
+    expect(isValuesMergeExpression(values.rabbitmq)).toBe(true);
+    expect(isValuesMergeExpression(values.redis)).toBe(true);
+    expect((values.postgresql as { overlays?: unknown[] }).overlays?.[0]).toBe(postgresqlValues);
+    expect((values.rabbitmq as { overlays?: unknown[] }).overlays?.[0]).toBe(rabbitmqValues);
+    expect((values.redis as { overlays?: unknown[] }).overlays?.[0]).toBe(redisValues);
   });
 
   it('Preserve TypeKro refs and CEL expressions inside nested raw values', () => {

--- a/test/factories/dagster/values-mapper.test.ts
+++ b/test/factories/dagster/values-mapper.test.ts
@@ -1,0 +1,412 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  CEL_EXPRESSION_BRAND,
+  KUBERNETES_REF_BRAND,
+} from '../../../src/core/constants/brands.js';
+import { isValuesMergeExpression } from '../../../src/core/aspects/values-merge.js';
+import {
+  mapDagsterConfigToHelmValues,
+  validateDagsterConfig,
+} from '../../../src/factories/dagster/utils/helm-values-mapper.js';
+import type { CelExpression, KubernetesRef } from '../../../src/core/types/common.js';
+import type {
+  DagsterBootstrapConfig,
+  DagsterHelmValues,
+  DagsterMappedHelmValues,
+} from '../../../src/factories/dagster/types.js';
+
+const minimalConfig: DagsterBootstrapConfig = {
+  name: 'analytics',
+  namespace: 'dagster',
+  userDeployments: {
+    enabled: true,
+    deployments: [
+      {
+        name: 'analytics-repo',
+        image: {
+          repository: 'ghcr.io/acme/dagster-analytics',
+          tag: '2026.06.01',
+        },
+        codeServerArgs: ['-m', 'analytics.definitions'],
+      },
+    ],
+  },
+};
+
+function concreteValues(values: DagsterMappedHelmValues): DagsterHelmValues {
+  if (isValuesMergeExpression(values)) {
+    throw new Error('Expected concrete Dagster Helm values in this test.');
+  }
+  return values;
+}
+
+describe('Dagster Helm values mapper', () => {
+  it('Map typed Dagster user deployments into official chart values', () => {
+    const values = concreteValues(mapDagsterConfigToHelmValues(minimalConfig));
+    const userDeployments = values['dagster-user-deployments'] as {
+      enabled?: boolean;
+      enableSubchart?: boolean;
+      deployments?: Array<{
+        name?: string;
+        image?: { repository?: string; tag?: string; pullPolicy?: string };
+        codeServerArgs?: string[];
+        port?: number;
+      }>;
+    };
+
+    expect(userDeployments.enabled).toBe(true);
+    expect(userDeployments.enableSubchart).toBe(true);
+    expect(userDeployments.deployments?.[0]).toMatchObject({
+      name: 'analytics-repo',
+      image: {
+        repository: 'ghcr.io/acme/dagster-analytics',
+        tag: '2026.06.01',
+        pullPolicy: 'IfNotPresent',
+      },
+      codeServerArgs: ['-m', 'analytics.definitions'],
+      port: 3030,
+    });
+  });
+
+  it('Preserve explicit user deployment port and image pull policy overrides', () => {
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      userDeployments: {
+        enabled: true,
+        deployments: [
+          {
+            name: 'analytics-repo',
+            image: {
+              repository: 'ghcr.io/acme/dagster-analytics',
+              tag: '2026.06.01',
+              pullPolicy: 'Always',
+            },
+            codeServerArgs: ['-m', 'analytics.definitions'],
+            port: 4040,
+          },
+        ],
+      },
+    }));
+    const userDeployments = values['dagster-user-deployments'] as {
+      deployments?: Array<{ image?: { pullPolicy?: string }; port?: number }>;
+    };
+
+    expect(userDeployments.deployments?.[0]?.image?.pullPolicy).toBe('Always');
+    expect(userDeployments.deployments?.[0]?.port).toBe(4040);
+  });
+
+  it('Map common Dagster chart convenience fields', () => {
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      webserver: {
+        replicaCount: 2,
+        pathPrefix: '/dagster',
+        service: { type: 'ClusterIP', port: 8080 },
+        logFormat: 'json',
+      },
+      daemon: {
+        enabled: true,
+        heartbeatTolerance: 120,
+        runRetries: { enabled: true, maxRetries: 2 },
+      },
+      postgresql: {
+        enabled: false,
+        host: 'dagster-postgres.postgres.svc.cluster.local',
+        username: 'dagster',
+        database: 'dagster',
+        passwordSecretName: 'dagster-postgres',
+        servicePort: 5432,
+      },
+      runLauncher: {
+        type: 'K8sRunLauncher',
+        k8sRunLauncher: {
+          jobNamespace: 'dagster-runs',
+          envSecrets: [{ name: 'dagster-run-env' }],
+          resources: { requests: { cpu: '250m', memory: '512Mi' } },
+        },
+      },
+      ingress: {
+        enabled: true,
+        ingressClassName: 'nginx',
+        dagsterWebserver: {
+          host: 'dagster.example.com',
+          path: '/',
+          tls: { enabled: true, secretName: 'dagster-tls' },
+        },
+      },
+      computeLogManager: {
+        type: 'S3ComputeLogManager',
+        config: { bucket: 'dagster-compute-logs', prefix: 'runs' },
+      },
+      nameOverride: 'dagster-short',
+      fullnameOverride: 'dagster-analytics',
+      rbacEnabled: true,
+      imagePullSecrets: [{ name: 'dagster-registry' }],
+    }));
+
+    expect(values.nameOverride).toBe('dagster-short');
+    expect(values.fullnameOverride).toBe('dagster-analytics');
+    expect(values.rbacEnabled).toBe(true);
+    expect(values.imagePullSecrets).toEqual([{ name: 'dagster-registry' }]);
+    expect(values.dagsterWebserver).toMatchObject({
+      replicaCount: 2,
+      pathPrefix: '/dagster',
+      service: { type: 'ClusterIP', port: 8080 },
+      logFormat: 'json',
+    });
+    expect(values.dagsterDaemon).toMatchObject({
+      enabled: true,
+      heartbeatTolerance: 120,
+      runRetries: { enabled: true, maxRetries: 2 },
+    });
+    expect(values.postgresql).toMatchObject({
+      enabled: false,
+      postgresqlHost: 'dagster-postgres.postgres.svc.cluster.local',
+      postgresqlUsername: 'dagster',
+      postgresqlDatabase: 'dagster',
+      service: { port: 5432 },
+    });
+    expect(values.global).toMatchObject({ postgresqlSecretName: 'dagster-postgres' });
+    expect(values.generatePostgresqlPasswordSecret).toBe(false);
+    expect(values.runLauncher).toMatchObject({
+      type: 'K8sRunLauncher',
+      config: {
+        k8sRunLauncher: {
+          jobNamespace: 'dagster-runs',
+          envSecrets: [{ name: 'dagster-run-env' }],
+        },
+      },
+    });
+    expect(values.ingress).toMatchObject({
+      enabled: true,
+      ingressClassName: 'nginx',
+      dagsterWebserver: {
+        host: 'dagster.example.com',
+        path: '/',
+        tls: { enabled: true, secretName: 'dagster-tls' },
+      },
+    });
+    expect(values.computeLogManager).toMatchObject({
+      type: 'S3ComputeLogManager',
+      config: { bucket: 'dagster-compute-logs', prefix: 'runs' },
+    });
+  });
+
+  it('Exclude bootstrap-only fields from Helm values', () => {
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      version: '1.13.8',
+      repositoryName: 'dagster-source',
+      repositoryNamespace: 'flux-system',
+      serviceAccountName: 'dagster-runtime',
+    }));
+
+    expect('name' in values).toBe(false);
+    expect('namespace' in values).toBe(false);
+    expect('version' in values).toBe(false);
+    expect('repositoryName' in values).toBe(false);
+    expect('repositoryNamespace' in values).toBe(false);
+    expect(values.global).toMatchObject({ serviceAccountName: 'dagster-runtime' });
+  });
+
+  it('Merge raw values last while preserving typed values at unrelated paths', () => {
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      webserver: { replicaCount: 1, pathPrefix: '/typed' },
+      values: {
+        dagsterWebserver: { replicaCount: 3 },
+        busybox: { image: { repository: 'busybox', tag: '1.36' } },
+      },
+    }));
+
+    expect(values.dagsterWebserver).toMatchObject({
+      replicaCount: 3,
+      pathPrefix: '/typed',
+    });
+    expect(values.busybox).toEqual({
+      image: { repository: 'busybox', tag: '1.36' },
+    });
+  });
+
+  it('Replace arrays and override primitive raw values during deep merge', () => {
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      userDeployments: {
+        enabled: true,
+        deployments: [
+          {
+            name: 'typed-repo',
+            image: { repository: 'ghcr.io/acme/typed', tag: '1' },
+            dagsterApiGrpcArgs: ['-m', 'typed.repo'],
+          },
+        ],
+      },
+      values: {
+        rbacEnabled: false,
+        'dagster-user-deployments': {
+          deployments: [
+            {
+              name: 'raw-repo',
+              image: { repository: 'ghcr.io/acme/raw', tag: '2' },
+              codeServerArgs: ['-m', 'raw.repo'],
+            },
+          ],
+        },
+      },
+    }));
+    const userDeployments = values['dagster-user-deployments'] as {
+      deployments?: Array<{ name?: string; image?: { repository?: string } }>;
+    };
+
+    expect(values.rbacEnabled).toBe(false);
+    expect(userDeployments.deployments).toHaveLength(1);
+    expect(userDeployments.deployments?.[0]?.name).toBe('raw-repo');
+    expect(userDeployments.deployments?.[0]?.image?.repository).toBe('ghcr.io/acme/raw');
+  });
+
+  it('Merge RabbitMQ and Redis raw sub-values into official chart blocks', () => {
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      global: { celeryConfigSecretName: 'dagster-celery-config' },
+      runLauncher: { type: 'CeleryK8sRunLauncher' },
+      rabbitmq: {
+        enabled: true,
+        username: 'dagster',
+        servicePort: 5672,
+        values: { persistence: { enabled: true } },
+      },
+      redis: {
+        enabled: true,
+        brokerDbNumber: 0,
+        values: { master: { persistence: { enabled: true } } },
+      },
+    }));
+
+    expect(values.generateCeleryConfigSecret).toBe(false);
+    expect(values.rabbitmq).toMatchObject({
+      enabled: true,
+      username: 'dagster',
+      service: { port: 5672 },
+      persistence: { enabled: true },
+    });
+    expect(values.rabbitmq?.values).toBeUndefined();
+    expect(values.redis).toMatchObject({
+      enabled: true,
+      brokerDbNumber: 0,
+      master: { persistence: { enabled: true } },
+    });
+    expect(values.redis?.values).toBeUndefined();
+  });
+
+  it('Preserve TypeKro refs and CEL expressions inside nested raw values', () => {
+    const secretName = {
+      [KUBERNETES_REF_BRAND]: true,
+      resourceId: 'postgresSecret',
+      fieldPath: 'metadata.name',
+    } satisfies KubernetesRef<string>;
+    const hostname = {
+      [CEL_EXPRESSION_BRAND]: true,
+      expression: 'schema.spec.ingress.host',
+    } satisfies CelExpression<string>;
+
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      values: {
+        global: { postgresqlSecretName: secretName },
+        ingress: { dagsterWebserver: { host: hostname } },
+      },
+    }));
+    const ingress = values.ingress as
+      | { dagsterWebserver?: { host?: unknown } }
+      | undefined;
+
+    expect(values.global?.postgresqlSecretName).toBe(secretName);
+    expect(ingress?.dagsterWebserver?.host).toBe(hostname);
+  });
+
+  it('Reject typed user deployments with missing or conflicting server arguments', () => {
+    const missingArgs = validateDagsterConfig({
+      ...minimalConfig,
+      userDeployments: {
+        enabled: true,
+        deployments: [
+          { name: 'broken', image: { repository: 'ghcr.io/acme/broken', tag: '1' } },
+        ],
+      },
+    });
+    const conflictingArgs = validateDagsterConfig({
+      ...minimalConfig,
+      userDeployments: {
+        enabled: true,
+        deployments: [
+          {
+            name: 'broken',
+            image: { repository: 'ghcr.io/acme/broken', tag: '1' },
+            dagsterApiGrpcArgs: ['-m', 'grpc'],
+            codeServerArgs: ['-m', 'code_server'],
+          },
+        ],
+      },
+    });
+
+    expect(missingArgs.valid).toBe(false);
+    expect(missingArgs.issues).toContainEqual(
+      expect.objectContaining({ path: 'userDeployments.deployments[0]' })
+    );
+    expect(conflictingArgs.valid).toBe(false);
+    expect(conflictingArgs.issues).toContainEqual(
+      expect.objectContaining({ path: 'userDeployments.deployments[0]' })
+    );
+  });
+
+  it('Reject CeleryK8sRunLauncher without a broker path', () => {
+    const result = validateDagsterConfig({
+      ...minimalConfig,
+      runLauncher: {
+        type: 'CeleryK8sRunLauncher',
+        celeryK8sRunLauncher: { workerQueues: [{ name: 'default' }] },
+      },
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'DAGSTER_REQUIRED_CONFIG_MISSING',
+        component: 'runLauncher',
+      })
+    );
+  });
+
+  it('Reject external PostgreSQL typed config without a host or raw PostgreSQL override', () => {
+    const result = validateDagsterConfig({
+      ...minimalConfig,
+      postgresql: { enabled: false, username: 'dagster', database: 'dagster' },
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: 'DAGSTER_REQUIRED_CONFIG_MISSING',
+        path: 'postgresql.host',
+      })
+    );
+    expect(result.issues.every((issue) => !issue.message.includes('password'))).toBe(true);
+  });
+
+  it('Throw structured TypeKroError failures before deploy or YAML generation', () => {
+    expect(() =>
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        userDeployments: {
+          enabled: true,
+          deployments: [
+            {
+              name: 'broken',
+              image: { repository: 'ghcr.io/acme/broken', tag: '1' },
+            },
+          ],
+        },
+      })
+    ).toThrow(/DAGSTER_REQUIRED_CONFIG_MISSING|DagsterConfigurationError/);
+  });
+});

--- a/test/integration/dagster/bootstrap-composition.test.ts
+++ b/test/integration/dagster/bootstrap-composition.test.ts
@@ -1,0 +1,419 @@
+import { spawnSync } from 'node:child_process';
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  setDefaultTimeout,
+} from 'bun:test';
+import type * as k8s from '@kubernetes/client-node';
+import { buildContainer } from '../../../src/core/containers/index.js';
+import { getKubeConfig } from '../../../src/core/kubernetes/client-provider.js';
+import {
+  createKubernetesObjectApiClient,
+  deleteNamespaceIfExists,
+  ensureNamespaceExists,
+  isClusterAvailable,
+} from '../shared-kubeconfig.js';
+
+setDefaultTimeout(900000);
+
+const clusterAvailable = isClusterAvailable();
+const requireClusterTests = process.env.REQUIRE_CLUSTER_TESTS === 'true';
+const defaultValidationImageName = 'typekro-dagster-validation';
+const defaultValidationImageTag = '1.13.8';
+const defaultLocalValidationImage = `${defaultValidationImageName}:${defaultValidationImageTag}`;
+const envConfiguredValidationImage = process.env.DAGSTER_TEST_VALIDATION_IMAGE;
+const configuredValidationImage =
+  envConfiguredValidationImage ??
+  (hasLocalDockerImage(defaultLocalValidationImage) ? defaultLocalValidationImage : undefined);
+const configuredUserCodeImage =
+  configuredValidationImage ??
+  process.env.DAGSTER_TEST_USER_CODE_IMAGE ??
+  'docker.io/dagster/user-code-example:1.13.8';
+const configuredDagsterSystemImage =
+  configuredValidationImage ?? process.env.DAGSTER_TEST_DAGSTER_IMAGE;
+const defaultDagsterImagesPullOnThisHost = process.arch !== 'arm64';
+const liveImagesAvailable =
+  defaultDagsterImagesPullOnThisHost ||
+  configuredValidationImage !== undefined ||
+  canBuildLocalValidationImage() ||
+  (process.env.DAGSTER_TEST_USER_CODE_IMAGE !== undefined &&
+    configuredDagsterSystemImage !== undefined);
+const describeLiveOrSkip =
+  (clusterAvailable && liveImagesAvailable) || requireClusterTests
+    ? describe
+    : describe.skip;
+
+function splitImage(image: string): { repository: string; tag: string } {
+  const separatorIndex = image.lastIndexOf(':');
+  if (separatorIndex <= image.lastIndexOf('/')) {
+    return { repository: image, tag: '1.13.8' };
+  }
+
+  return {
+    repository: image.slice(0, separatorIndex),
+    tag: image.slice(separatorIndex + 1),
+  };
+}
+
+function hasLocalDockerImage(image: string): boolean {
+  if (process.arch !== 'arm64') return false;
+
+  const result = spawnSync('docker', ['image', 'inspect', image], {
+    stdio: 'ignore',
+    timeout: 10000,
+  });
+  return result.status === 0;
+}
+
+function canBuildLocalValidationImage(): boolean {
+  if (process.arch !== 'arm64') return false;
+
+  const result = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+    stdio: 'ignore',
+    timeout: 10000,
+  });
+  return result.status === 0;
+}
+
+async function resolveValidationImage(): Promise<string | undefined> {
+  if (envConfiguredValidationImage) return envConfiguredValidationImage;
+  if (process.arch !== 'arm64') return undefined;
+  if (hasLocalDockerImage(defaultLocalValidationImage)) return defaultLocalValidationImage;
+
+  const result = await buildContainer({
+    context: 'test/integration/dagster/fixtures/arm64-validation',
+    imageName: defaultValidationImageName,
+    tag: defaultValidationImageTag,
+    platform: 'linux/arm64',
+    registry: { type: 'orbstack' },
+    timeout: 900000,
+  });
+
+  return result.imageUri;
+}
+
+async function deleteClusterObjectIfExists(
+  kubeConfig: k8s.KubeConfig,
+  apiVersion: string,
+  kind: string,
+  name: string
+): Promise<void> {
+  const objectApi = createKubernetesObjectApiClient(kubeConfig);
+  try {
+    await objectApi.delete({ apiVersion, kind, metadata: { name } });
+    await waitForClusterObjectDeleted(kubeConfig, apiVersion, kind, name);
+  } catch (error: unknown) {
+    const statusCode = (error as { statusCode?: number; body?: { reason?: string } }).statusCode;
+    const reason = (error as { body?: { reason?: string } }).body?.reason;
+    if (statusCode !== 404 && reason !== 'NotFound') {
+      throw error;
+    }
+  }
+}
+
+async function waitForClusterObjectDeleted(
+  kubeConfig: k8s.KubeConfig,
+  apiVersion: string,
+  kind: string,
+  name: string
+): Promise<void> {
+  const objectApi = createKubernetesObjectApiClient(kubeConfig);
+  const deadline = Date.now() + 60000;
+  while (Date.now() < deadline) {
+    try {
+      await objectApi.read({ apiVersion, kind, metadata: { name } });
+    } catch (error: unknown) {
+      const statusCode = (error as { statusCode?: number; body?: { reason?: string } }).statusCode;
+      const reason = (error as { body?: { reason?: string } }).body?.reason;
+      if (statusCode === 404 || reason === 'NotFound') return;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  throw new Error(`${kind} ${name} was not deleted within 60000ms.`);
+}
+
+async function resetDagsterKroDefinition(kubeConfig: k8s.KubeConfig): Promise<void> {
+  await deleteClusterObjectIfExists(
+    kubeConfig,
+    'kro.run/v1alpha1',
+    'ResourceGraphDefinition',
+    'dagster-bootstrap'
+  );
+  await deleteClusterObjectIfExists(
+    kubeConfig,
+    'apiextensions.k8s.io/v1',
+    'CustomResourceDefinition',
+    'dagsterbootstraps.kro.run'
+  );
+}
+
+// Test decision: keep the live deploy path gated by real cluster and image
+// prerequisites while still testing KRO YAML generation without cluster reads.
+// Always requiring a cluster was rejected because unit verification must remain
+// local; unit-only coverage was rejected because the plan requires a direct-mode
+// integration path when live prerequisites are available.
+describeLiveOrSkip('Dagster bootstrap composition live deployment', () => {
+  let kubeConfig: k8s.KubeConfig;
+  let factory: { deleteInstance(instanceName: string): Promise<void> } | undefined;
+  let kroFactory: { deleteInstance(instanceName: string): Promise<void> } | undefined;
+  const suffix = Math.random().toString(36).slice(2, 7);
+  const factoryNamespace = `typekro-dagster-${suffix}`;
+  const kroFactoryNamespace = `typekro-dagster-kro-${suffix}`;
+  const dagsterNamespace = `dagster-${suffix}`;
+  const dagsterKroNamespace = `dagster-kro-${suffix}`;
+  let userCodeImage = splitImage(configuredUserCodeImage);
+  let dagsterSystemImage = configuredDagsterSystemImage
+    ? splitImage(configuredDagsterSystemImage)
+    : undefined;
+
+  beforeAll(async () => {
+    if (!clusterAvailable) {
+      throw new Error('REQUIRE_CLUSTER_TESTS=true but no Kubernetes cluster is available.');
+    }
+    if (!liveImagesAvailable) {
+      throw new Error(
+        'REQUIRE_CLUSTER_TESTS=true but live Dagster images are unavailable. Set ' +
+          'DAGSTER_TEST_VALIDATION_IMAGE to a locally built/loaded fixture image, or set ' +
+          'DAGSTER_TEST_USER_CODE_IMAGE and DAGSTER_TEST_DAGSTER_IMAGE to images pullable ' +
+          'by this cluster architecture.'
+      );
+    }
+
+    const validationImage = await resolveValidationImage();
+    if (validationImage) {
+      userCodeImage = splitImage(validationImage);
+      dagsterSystemImage = splitImage(validationImage);
+    }
+
+    kubeConfig = getKubeConfig({ skipTLSVerify: true });
+    await resetDagsterKroDefinition(kubeConfig);
+    await ensureNamespaceExists(factoryNamespace, kubeConfig);
+    await ensureNamespaceExists(kroFactoryNamespace, kubeConfig);
+  });
+
+  afterAll(async () => {
+    if (kroFactory) {
+      try {
+        await kroFactory.deleteInstance('dagster-kro-test');
+      } catch (error) {
+        console.error('Dagster KRO deleteInstance failed:', (error as Error).message);
+      }
+    }
+
+    if (factory) {
+      try {
+        await factory.deleteInstance('dagster-test');
+      } catch (error) {
+        console.error('Dagster deleteInstance failed:', (error as Error).message);
+      }
+    }
+
+    try {
+      await deleteNamespaceIfExists(factoryNamespace, kubeConfig);
+    } catch (error) {
+      console.error('Dagster factory namespace cleanup failed:', (error as Error).message);
+    }
+
+    try {
+      await deleteNamespaceIfExists(kroFactoryNamespace, kubeConfig);
+    } catch (error) {
+      console.error('Dagster KRO factory namespace cleanup failed:', (error as Error).message);
+    }
+
+    try {
+      await deleteNamespaceIfExists(dagsterNamespace, kubeConfig);
+    } catch (error) {
+      console.error('Dagster app namespace cleanup failed:', (error as Error).message);
+    }
+
+    try {
+      await deleteNamespaceIfExists(dagsterKroNamespace, kubeConfig);
+    } catch (error) {
+      console.error('Dagster KRO app namespace cleanup failed:', (error as Error).message);
+    }
+
+    try {
+      await resetDagsterKroDefinition(kubeConfig);
+    } catch (error) {
+      console.error('Dagster KRO definition cleanup failed:', (error as Error).message);
+    }
+  });
+
+  it('Deploy Dagster through the direct factory and hydrate HelmRelease status', async () => {
+    const { dagsterBootstrap } = await import(
+      '../../../src/factories/dagster/index.js'
+    );
+
+    const directFactory = dagsterBootstrap.factory('direct', {
+      namespace: factoryNamespace,
+      waitForReady: true,
+      timeout: 600000,
+      kubeConfig,
+    });
+    factory = directFactory;
+
+    const instance = await directFactory.deploy({
+      name: 'dagster-test',
+      namespace: dagsterNamespace,
+      userDeployments: {
+        enabled: true,
+        deployments: [
+          {
+            name: 'example-repo',
+            image: { ...userCodeImage, pullPolicy: 'IfNotPresent' },
+            codeServerArgs: ['-f', '/opt/dagster/app/definitions.py'],
+            port: 3030,
+          },
+        ],
+      },
+      postgresql: { enabled: true },
+      ...(dagsterSystemImage && {
+        webserver: {
+          image: { ...dagsterSystemImage, pullPolicy: 'IfNotPresent' },
+        },
+        daemon: {
+          image: { ...dagsterSystemImage, pullPolicy: 'IfNotPresent' },
+        },
+      }),
+      runLauncher: {
+        type: 'K8sRunLauncher',
+        k8sRunLauncher: { jobNamespace: dagsterNamespace },
+      },
+      values: { dagsterWebserver: { service: { type: 'ClusterIP' } } },
+    });
+
+    expect(instance.spec.name).toBe('dagster-test');
+    expect(instance.spec.namespace).toBe(dagsterNamespace);
+    expect(instance.status.ready).toBe(true);
+    expect(instance.status.phase).toBe('Ready');
+    expect(instance.status.failed).toBe(false);
+    expect(instance.status.version).toBe('1.13.8');
+    expect(instance.status.components.helmRepository).toBe(true);
+    expect(instance.status.components.helmRelease).toBe(true);
+    expect(instance.status.components.webserver).toBe(true);
+    expect(instance.status.components.daemon).toBe(true);
+    expect(instance.status.components.userDeployments).toBe(true);
+  });
+
+  it('Deploy Dagster through KRO and reconcile the HelmRelease to Ready', async () => {
+    const { dagsterBootstrap } = await import(
+      '../../../src/factories/dagster/index.js'
+    );
+
+    const createdKroFactory = dagsterBootstrap.factory('kro', {
+      namespace: kroFactoryNamespace,
+      waitForReady: true,
+      timeout: 900000,
+      kubeConfig,
+    });
+    kroFactory = createdKroFactory;
+
+    const instance = await createdKroFactory.deploy({
+      name: 'dagster-kro-test',
+      namespace: dagsterKroNamespace,
+      userDeployments: {
+        enabled: true,
+        deployments: [
+          {
+            name: 'example-repo',
+            image: { ...userCodeImage, pullPolicy: 'IfNotPresent' },
+            codeServerArgs: ['-f', '/opt/dagster/app/definitions.py'],
+            port: 3030,
+          },
+        ],
+      },
+      postgresql: { enabled: true },
+      ...(dagsterSystemImage && {
+        webserver: {
+          image: { ...dagsterSystemImage, pullPolicy: 'IfNotPresent' },
+        },
+        daemon: {
+          image: { ...dagsterSystemImage, pullPolicy: 'IfNotPresent' },
+        },
+      }),
+      runLauncher: {
+        type: 'K8sRunLauncher',
+        k8sRunLauncher: { jobNamespace: dagsterKroNamespace },
+      },
+      values: { dagsterWebserver: { service: { type: 'ClusterIP' } } },
+    });
+
+    expect(instance.spec.name).toBe('dagster-kro-test');
+    expect(instance.spec.namespace).toBe(dagsterKroNamespace);
+    expect(instance.status.ready).toBe(true);
+    expect(instance.status.phase).toBe('Ready');
+    expect(instance.status.failed).toBe(false);
+    expect(instance.status.components.helmRepository).toBe(true);
+    expect(instance.status.components.helmRelease).toBe(true);
+    expect(instance.status.components.webserver).toBe(true);
+    expect(instance.status.components.daemon).toBe(true);
+    expect(instance.status.components.userDeployments).toBe(true);
+  });
+});
+
+describe('Dagster bootstrap composition integration surfaces', () => {
+  const factoryNamespace = 'typekro-dagster-test';
+
+  it('Provide an architecture-compatible live validation fixture image path', async () => {
+    const dockerfile = Bun.file(
+      'test/integration/dagster/fixtures/arm64-validation/Dockerfile'
+    );
+    const definitions = Bun.file(
+      'test/integration/dagster/fixtures/arm64-validation/definitions.py'
+    );
+
+    expect(await dockerfile.exists()).toBe(true);
+    expect(await definitions.exists()).toBe(true);
+
+    const dockerfileText = await dockerfile.text();
+    const definitionsText = await definitions.text();
+
+    expect(dockerfileText).toContain('dagster==1.13.8');
+    expect(dockerfileText).toContain('dagster-webserver==1.13.8');
+    expect(dockerfileText).toContain('definitions.py');
+    expect(definitionsText).toContain('Definitions');
+    expect(definitionsText).not.toContain('password');
+    expect(definitionsText).not.toContain('secret');
+  });
+
+  it('Generate ResourceGraphDefinition YAML for KRO mode without cluster reads', async () => {
+    const { dagsterBootstrap } = await import(
+      '../../../src/factories/dagster/index.js'
+    );
+
+    const yaml = dagsterBootstrap.toYaml();
+
+    expect(yaml).toContain('kind: ResourceGraphDefinition');
+    expect(yaml).toContain('dagsterNamespace');
+    expect(yaml).toContain('dagsterHelmRepository');
+    expect(yaml).toContain('dagsterHelmRelease');
+    expect(yaml).toContain('https://dagster-io.github.io/helm');
+    expect(yaml).toContain('chart: dagster');
+    expect(yaml).toContain('1.13.8');
+    expect(yaml).toContain('dagsterHelmRelease.status.conditions');
+    expect(yaml).not.toContain('__KUBERNETES_REF_');
+    expect(yaml).not.toContain('[object Object]');
+    expect(yaml).not.toContain('undefined');
+  });
+
+  it('Support both direct and KRO factory strategies for Dagster bootstrap', async () => {
+    const { dagsterBootstrap } = await import(
+      '../../../src/factories/dagster/index.js'
+    );
+
+    const directFactory = dagsterBootstrap.factory('direct', {
+      namespace: factoryNamespace,
+    });
+    const kroFactory = dagsterBootstrap.factory('kro', {
+      namespace: factoryNamespace,
+    });
+
+    expect(directFactory.mode).toBe('direct');
+    expect(kroFactory.mode).toBe('kro');
+  });
+});

--- a/test/integration/dagster/fixtures/arm64-validation/Dockerfile
+++ b/test/integration/dagster/fixtures/arm64-validation/Dockerfile
@@ -1,0 +1,23 @@
+FROM public.ecr.aws/docker/library/python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    DAGSTER_HOME=/opt/dagster/dagster_home
+
+WORKDIR /opt/dagster/app
+
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+    python -m pip install --no-cache-dir \
+      dagster==1.13.8 \
+      dagster-webserver==1.13.8 \
+      dagster-graphql==1.13.8 \
+      dagster-k8s==0.29.8 \
+      dagster-postgres==0.29.8
+
+COPY definitions.py /opt/dagster/app/definitions.py
+
+RUN mkdir -p /opt/dagster/dagster_home
+
+EXPOSE 3030 3000
+
+CMD ["dagster", "api", "grpc", "-h", "0.0.0.0", "-p", "3030", "-f", "/opt/dagster/app/definitions.py"]

--- a/test/integration/dagster/fixtures/arm64-validation/definitions.py
+++ b/test/integration/dagster/fixtures/arm64-validation/definitions.py
@@ -1,0 +1,9 @@
+from dagster import Definitions, asset
+
+
+@asset
+def validation_asset() -> str:
+    return "ok"
+
+
+defs = Definitions(assets=[validation_asset])


### PR DESCRIPTION
## Summary
- Add `typekro/dagster` with Dagster HelmRepository/HelmRelease wrappers, bootstrap composition, typed config schemas, and raw Helm values passthrough.
- Preserve graph-aware refs/CEL in Dagster Helm values and validate unsafe typed configurations before deploy/YAML generation.
- Add Dagster docs, navigation, package export, focused unit tests, live direct/KRO integration coverage, and sharpen the integration authoring skill with lessons learned.

## Verification
- `bun test test/factories/dagster/helm.test.ts test/factories/dagster/values-mapper.test.ts test/factories/dagster/bootstrap-composition.test.ts test/factories/dagster/exports.test.ts --timeout 10000` -> 25 pass, 0 fail
- `bun run typecheck` -> passed
- `bun run lint` -> passed
- `bun run test` -> 4370 pass, 12 skip, 1 todo, 0 fail
- `bun run docs:validate` -> passed with existing Next Steps warnings
- Prior live `bun run test:integration:dagster` -> direct and KRO deploys reached HelmRelease Ready=True