### PR TITLE
fix(dagster): share the HelmRepository via a singleton so multiple instances don't collide

### DIFF
--- a/docs/api/dagster/index.md
+++ b/docs/api/dagster/index.md
@@ -21,11 +21,18 @@ import {
 
 ## What Gets Created
 
-`dagsterBootstrap` creates three TypeKro-owned resources:
+Each `dagsterBootstrap` instance owns:
 
 - A `Namespace` for the Dagster deployment namespace.
-- A Flux `HelmRepository` for `https://dagster-io.github.io/helm`.
 - A Flux `HelmRelease` for chart `dagster`, default version `1.13.8`.
+
+The Flux `HelmRepository` for `https://dagster-io.github.io/helm` is a **shared
+cluster-level singleton** (`DagsterHelmRepository`), deployed once and referenced by every
+Dagster instance. Modelling it per-instance would make each instance's KRO ApplySet try to
+own the same `flux-system/dagster` HelmRepository exclusively, so a second instance (e.g. a
+dev + prod pair) would fail to reconcile. The singleton owner lives in the `typekro-singletons`
+namespace; the factory's `deploy()` creates it automatically. See
+[Singletons & GitOps](#singletons-and-gitops) for the GitOps (`toYaml`) workflow.
 
 The bootstrap status is derived from owned Flux resources only. Component booleans such as
 `webserver`, `daemon`, and `userDeployments` mean the owning HelmRelease is ready, not that
@@ -91,12 +98,35 @@ await direct.deploy({
 Use YAML generation for GitOps:
 
 ```ts
+// RGDs: the shared HelmRepository singleton owner RGD plus the bootstrap RGD,
+// emitted deps-first as a multi-document stream.
 const rgdYaml = dagsterBootstrap.toYaml();
+
+// Instances: the shared singleton owner instance plus this Dagster instance.
+const instanceYaml = dagsterBootstrap
+  .factory('kro', { namespace: 'analytics' })
+  .toYaml({ name: 'analytics', namespace: 'analytics' });
 ```
 
 Generated ResourceGraphDefinition YAML does not read the cluster. Raw `values` are serialized as
 runtime graph-aware Helm values, so schema refs and CEL values are preserved instead of being
 stringified.
+
+### Singletons and GitOps
+
+Because the HelmRepository is a shared singleton, the GitOps bundle has **two RGDs** and (per
+instance) **two custom resources**:
+
+- `dagsterBootstrap.toYaml()` emits the `dagster-helm-repository` singleton RGD **before** the
+  `dagster-bootstrap` RGD (deps-first), as a multi-document YAML stream.
+- `factory.toYaml(spec)` emits the shared `DagsterHelmRepository` owner instance (in the
+  `typekro-singletons` namespace, carrying the `typekro.io/singleton-spec-fingerprint`
+  annotation) **before** the `DagsterBootstrap` instance.
+
+Apply all of them. The owner instance is identical to what `deploy()` creates, so mixing GitOps
+and imperative `deploy()` against the same cluster is safe — the second writer finds the existing
+owner and passes its drift check. Deploying multiple Dagster instances? They all share the one
+owner; emit its RGD/instance once.
 
 ## Low-Level Helm Wrappers
 

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -76,6 +76,11 @@ import {
   validateSpec,
 } from './shared-utilities.js';
 import {
+  joinYamlDocuments,
+  singletonOwnerInstanceYamls,
+  singletonRgdYamls,
+} from './singleton-gitops.js';
+import {
   assertNoDeployedSingletonSpecDrift,
   singletonSpecFingerprintAnnotationValue,
 } from './singleton-owner-drift.js';
@@ -1461,11 +1466,21 @@ export class KroResourceFactoryImpl<
       // Generate CRD instance YAML
       const instanceName = generateInstanceName(spec, this.name);
       const customResource = this.createCustomResourceInstance(instanceName, spec);
+      const instanceYaml = yaml
+        .dump(customResource, { lineWidth: -1, noRefs: true, sortKeys: false })
+        .trimEnd();
 
-      return yaml.dump(customResource, { lineWidth: -1, noRefs: true, sortKeys: false }).trimEnd();
+      // Shared singleton owner instances are created by `deploy()`; for the
+      // GitOps path we emit them alongside the consuming instance, deps-first,
+      // so the consuming RGD's externalRef resolves. No-op without singletons.
+      const ownerYamls = singletonOwnerInstanceYamls(this.singletonDefinitions);
+      return ownerYamls.length === 0 ? instanceYaml : joinYamlDocuments(ownerYamls, instanceYaml);
     }
 
-    return this.buildRgdYaml();
+    const rgdYaml = this.buildRgdYaml();
+    return this.singletonDefinitions.length === 0
+      ? rgdYaml
+      : joinYamlDocuments(singletonRgdYamls(this.singletonDefinitions), rgdYaml);
   }
 
   /**

--- a/src/core/deployment/singleton-gitops.ts
+++ b/src/core/deployment/singleton-gitops.ts
@@ -1,0 +1,83 @@
+/**
+ * GitOps emission for singleton owners.
+ *
+ * `singleton(...)` deploys ONE shared owner instance (in the registry namespace,
+ * named deterministically, carrying a spec-fingerprint annotation) that the
+ * consuming RGD references via `externalRef`. The factory's `deploy()` path
+ * creates that owner imperatively — but the GitOps `toYaml()` path emits only the
+ * consuming RGD/instance, leaving the externalRef dangling. These helpers let the
+ * `toYaml()` paths emit the missing owner RGD(s) and owner instance(s) so a
+ * GitOps apply (Flux/ArgoCD) of the generated YAML is complete.
+ *
+ * The owner instance is built to match exactly what `deploy()` creates — the same
+ * derived name, registry namespace, and fingerprint annotation — so the consuming
+ * RGD's externalRef resolves AND a later imperative `deploy()` finds the existing
+ * owner and passes its drift check instead of conflicting.
+ */
+import * as yaml from 'js-yaml';
+import { singletonInstanceTypeMeta } from '../singleton/singleton.js';
+import type { SingletonDefinitionRecord } from '../types/deployment.js';
+import { SINGLETON_SPEC_FINGERPRINT_ANNOTATION } from './resource-tagging.js';
+import { getSingletonInstanceName } from './shared-utilities.js';
+import { singletonSpecFingerprintAnnotationValue } from './singleton-owner-drift.js';
+
+const DOC_SEPARATOR = '\n---\n';
+
+/** One record per distinct singleton identity (a singleton may be referenced more than once). */
+function dedupeByKey(
+  definitions: readonly SingletonDefinitionRecord[]
+): SingletonDefinitionRecord[] {
+  const byKey = new Map<string, SingletonDefinitionRecord>();
+  for (const definition of definitions) {
+    if (!byKey.has(definition.key)) byKey.set(definition.key, definition);
+  }
+  return [...byKey.values()];
+}
+
+/** RGD YAML for each singleton owner composition (the CRD + resource graph it owns). */
+export function singletonRgdYamls(
+  definitions: readonly SingletonDefinitionRecord[]
+): string[] {
+  return dedupeByKey(definitions).map((definition) =>
+    (definition.composition as unknown as { toYaml: () => string }).toYaml()
+  );
+}
+
+/** Owner-instance manifests — one shared CR per singleton, matching `deploy()`. */
+export function singletonOwnerInstanceManifests(
+  definitions: readonly SingletonDefinitionRecord[]
+): unknown[] {
+  return dedupeByKey(definitions).map((definition) => {
+    const { apiVersion, kind } = singletonInstanceTypeMeta(definition.composition);
+    return {
+      apiVersion,
+      kind,
+      metadata: {
+        name: getSingletonInstanceName(definition.id),
+        namespace: definition.registryNamespace,
+        annotations: {
+          [SINGLETON_SPEC_FINGERPRINT_ANNOTATION]: singletonSpecFingerprintAnnotationValue(
+            definition.specFingerprint
+          ),
+        },
+      },
+      spec: definition.spec,
+    };
+  });
+}
+
+/** Owner-instance YAML documents (one per singleton). */
+export function singletonOwnerInstanceYamls(
+  definitions: readonly SingletonDefinitionRecord[]
+): string[] {
+  return singletonOwnerInstanceManifests(definitions).map((manifest) =>
+    yaml.dump(manifest, { lineWidth: -1, noRefs: true, sortKeys: false }).trimEnd()
+  );
+}
+
+/** Join YAML documents, dropping empties, with the leading docs emitted deps-first. */
+export function joinYamlDocuments(leadingDocs: string[], main: string): string {
+  return [...leadingDocs, main].map((doc) => doc.trim()).filter((doc) => doc.length > 0).join(
+    DOC_SEPARATOR
+  );
+}

--- a/src/core/serialization/core.ts
+++ b/src/core/serialization/core.ts
@@ -16,6 +16,8 @@ import {
 } from '../composition/context.js';
 import { createDirectResourceFactory } from '../deployment/direct-factory.js';
 import { createKroResourceFactory } from '../deployment/kro-factory.js';
+import { joinYamlDocuments, singletonRgdYamls } from '../deployment/singleton-gitops.js';
+import type { SingletonDefinitionRecord } from '../types/deployment.js';
 import { ensureError, ValidationError } from '../errors.js';
 import {
   type ASTAnalysisResult,
@@ -2324,7 +2326,23 @@ function createTypedResourceGraph<
         }
       }
 
-      return serializeResourceGraphToYaml(definition.name, resourcesWithKeys, options, kroSchema);
+      const rgdYaml = serializeResourceGraphToYaml(
+        definition.name,
+        resourcesWithKeys,
+        options,
+        kroSchema
+      );
+
+      // Singleton owners are deployed once outside any consuming instance's
+      // ApplySet (see `singleton(...)`). The factory's `deploy()` creates them
+      // imperatively; for the GitOps `toYaml()` path we must emit their RGDs too,
+      // deps-first, or the consuming RGD's externalRef dangles. No-op when the
+      // composition uses no singletons.
+      const singletonDefs =
+        (this as { _singletonDefinitions?: SingletonDefinitionRecord[] })._singletonDefinitions ??
+        [];
+      if (singletonDefs.length === 0) return rgdYaml;
+      return joinYamlDocuments(singletonRgdYamls(singletonDefs), rgdYaml);
     },
   };
 

--- a/src/core/singleton/singleton.ts
+++ b/src/core/singleton/singleton.ts
@@ -37,6 +37,23 @@ function getSingletonApiVersion(compositionRecord: SingletonCompositionMetadata)
   return `${group}/${rawApiVersion}`;
 }
 
+/**
+ * The custom-resource `apiVersion`/`kind` of a singleton owner instance, derived
+ * exactly as {@link useSingleton} derives the externalRef target. Exported so the
+ * GitOps emitter can produce an owner-instance manifest that the consuming RGD's
+ * externalRef resolves against.
+ */
+export function singletonInstanceTypeMeta(composition: unknown): {
+  apiVersion: string;
+  kind: string;
+} {
+  const record = composition as SingletonCompositionMetadata;
+  return {
+    apiVersion: getSingletonApiVersion(record),
+    kind: String(record._definition?.kind ?? record.kind ?? 'unknown'),
+  };
+}
+
 function getSingletonRegistryForComposition<TSpec extends KroCompatibleType, TStatus extends KroCompatibleType>(
   composition: CallableComposition<TSpec, TStatus>,
 ): Map<string, SingletonDefinitionRecord<TSpec, TStatus>> {

--- a/src/factories/dagster/compositions/dagster-bootstrap.ts
+++ b/src/factories/dagster/compositions/dagster-bootstrap.ts
@@ -1,12 +1,13 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { Cel } from '../../../core/references/cel.js';
+import { singleton } from '../../../core/singleton/singleton.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
 import {
   DEFAULT_DAGSTER_REPO_NAME,
+  DEFAULT_DAGSTER_REPO_URL,
   DEFAULT_DAGSTER_VERSION,
   dagsterHelmRelease,
-  dagsterHelmRepository,
 } from '../resources/helm.js';
 import {
   type DagsterBootstrapConfig,
@@ -14,6 +15,7 @@ import {
   DagsterBootstrapStatusSchema,
 } from '../types.js';
 import { mapDagsterConfigToHelmValues } from '../utils/helm-values-mapper.js';
+import { dagsterHelmRepositoryBootstrap } from './dagster-helm-repository.js';
 
 type DagsterBootstrapSchemaConfig = typeof DagsterBootstrapConfigSchema.infer;
 
@@ -33,8 +35,6 @@ export const dagsterBootstrap = kubernetesComposition(
   (spec) => {
     const resolvedNamespace = spec.namespace || 'dagster';
     const resolvedVersion = spec.version || DEFAULT_DAGSTER_VERSION;
-    const repositoryName = spec.repositoryName || DEFAULT_DAGSTER_REPO_NAME;
-    const repositoryNamespace = spec.repositoryNamespace || DEFAULT_FLUX_NAMESPACE;
     const helmValues = buildHelmValues(spec);
 
     const _dagsterNamespace = namespace({
@@ -50,26 +50,30 @@ export const dagsterBootstrap = kubernetesComposition(
       id: 'dagsterNamespace',
     });
 
-    const _dagsterHelmRepository = dagsterHelmRepository({
-      name: repositoryName,
-      namespace: repositoryNamespace,
-      id: 'dagsterHelmRepository',
+    // The official Dagster chart repository is one cluster-level Flux source shared
+    // by every Dagster instance, so deploy it once via singleton(...) with a fixed
+    // identity. Inlining it would make each instance's KRO ApplySet try to own the
+    // HelmRepository exclusively, breaking a second instance (dev + prod) with an
+    // ApplySet reassignment error. Every instance's HelmRelease references the same
+    // shared repository by the official `sourceRef` defaults.
+    const _dagsterHelmRepository = singleton(dagsterHelmRepositoryBootstrap, {
+      id: 'dagster-helm-repository',
+      spec: {
+        name: DEFAULT_DAGSTER_REPO_NAME,
+        namespace: DEFAULT_FLUX_NAMESPACE,
+        url: DEFAULT_DAGSTER_REPO_URL,
+      },
     });
 
     const _dagsterHelmRelease = dagsterHelmRelease({
       name: spec.name,
       namespace: resolvedNamespace,
       version: resolvedVersion,
-      repositoryName,
-      repositoryNamespace,
       values: helmValues,
       id: 'dagsterHelmRelease',
     });
 
-    const helmRepositoryReady = Cel.expr<boolean>(
-      _dagsterHelmRepository.status.conditions,
-      '.exists(c, c.type == "Ready" && c.status == "True")'
-    );
+    const helmRepositoryReady = _dagsterHelmRepository.status.ready;
     const helmReleaseReady = Cel.expr<boolean>(
       _dagsterHelmRelease.status.conditions,
       '.exists(c, c.type == "Ready" && c.status == "True")'
@@ -107,8 +111,6 @@ function buildMapperConfig(spec: DagsterBootstrapSchemaConfig): DagsterBootstrap
     { name: spec.name },
     spec.namespace !== undefined && { namespace: spec.namespace },
     spec.version !== undefined && { version: spec.version },
-    spec.repositoryName !== undefined && { repositoryName: spec.repositoryName },
-    spec.repositoryNamespace !== undefined && { repositoryNamespace: spec.repositoryNamespace },
     spec.serviceAccountName !== undefined && { serviceAccountName: spec.serviceAccountName },
     spec.nameOverride !== undefined && { nameOverride: spec.nameOverride },
     spec.fullnameOverride !== undefined && { fullnameOverride: spec.fullnameOverride },

--- a/src/factories/dagster/compositions/dagster-helm-repository.ts
+++ b/src/factories/dagster/compositions/dagster-helm-repository.ts
@@ -1,0 +1,44 @@
+import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { Cel } from '../../../core/references/cel.js';
+import { dagsterHelmRepository } from '../resources/helm.js';
+import {
+  DagsterHelmRepositorySingletonSpecSchema,
+  DagsterHelmRepositorySingletonStatusSchema,
+} from '../types.js';
+
+/**
+ * Shared Dagster HelmRepository singleton.
+ *
+ * The official Dagster chart repository is a single cluster-level Flux source —
+ * the same URL serves every Dagster instance. Deploying it inline in the
+ * `dagsterBootstrap` RGD makes each instance's KRO ApplySet try to *own* the
+ * `flux-system/dagster` HelmRepository exclusively, so a second instance of the
+ * RGD (e.g. a dev + prod pair) fails to reconcile: "resource belongs to a
+ * different ApplySet ... cannot reassign". Modelling the repository as its own
+ * composition lets `dagsterBootstrap` consume it via `singleton(...)`, so one
+ * shared HelmRepository is owned outside any single instance's ApplySet and
+ * every instance's HelmRelease references it by the same `sourceRef`.
+ */
+export const dagsterHelmRepositoryBootstrap = kubernetesComposition(
+  {
+    name: 'dagster-helm-repository',
+    kind: 'DagsterHelmRepository',
+    spec: DagsterHelmRepositorySingletonSpecSchema,
+    status: DagsterHelmRepositorySingletonStatusSchema,
+  },
+  (spec) => {
+    const repository = dagsterHelmRepository({
+      name: spec.name,
+      namespace: spec.namespace,
+      url: spec.url,
+      id: 'repository',
+    });
+
+    return {
+      ready: Cel.expr<boolean>(
+        repository.status.conditions,
+        '.exists(c, c.type == "Ready" && c.status == "True")'
+      ),
+    };
+  }
+);

--- a/src/factories/dagster/compositions/index.ts
+++ b/src/factories/dagster/compositions/index.ts
@@ -1,1 +1,2 @@
 export * from './dagster-bootstrap.js';
+export * from './dagster-helm-repository.js';

--- a/src/factories/dagster/types.ts
+++ b/src/factories/dagster/types.ts
@@ -853,8 +853,6 @@ export const DagsterBootstrapConfigSchema = type({
   name: 'string',
   'namespace?': 'string',
   'version?': 'string',
-  'repositoryName?': 'string',
-  'repositoryNamespace?': 'string',
   'serviceAccountName?': 'string',
   'nameOverride?': 'string',
   'fullnameOverride?': 'string',
@@ -965,6 +963,23 @@ export const DagsterHelmRepositoryConfigSchema = type({
 
 /** Configuration for the Dagster HelmRepository wrapper. */
 export type DagsterHelmRepositoryConfig = typeof DagsterHelmRepositoryConfigSchema.infer;
+
+/**
+ * Spec for the shared Dagster HelmRepository singleton composition. The official
+ * Dagster chart repository is one cluster-level Flux source shared by every
+ * Dagster instance, so it is deployed once via `singleton(...)`. These three
+ * fields form the singleton's identity — all consumers must agree on them.
+ */
+export const DagsterHelmRepositorySingletonSpecSchema = type({
+  name: 'string',
+  namespace: 'string',
+  url: 'string',
+});
+
+/** Status surfaced by the shared Dagster HelmRepository singleton. */
+export const DagsterHelmRepositorySingletonStatusSchema = type({
+  ready: 'boolean',
+});
 
 /** ArkType schema for the Dagster Helm chart release wrapper. */
 export const DagsterHelmReleaseConfigSchema = type({

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -23,6 +23,7 @@ import type { Enhanced, KubernetesResource } from '../../src/core/types/kubernet
 import type { SchemaDefinition } from '../../src/core/types/serialization.js';
 import { getSingletonResourceId } from '../../src/core/singleton/singleton.js';
 import { externalRef, kubernetesComposition, singleton } from '../../src/index.js';
+import { Deployment } from '../../src/factories/simple/index.js';
 import { CEL_EXPRESSION_BRAND, KUBERNETES_REF_BRAND } from '../../src/shared/brands.js';
 
 // ---------------------------------------------------------------------------
@@ -876,22 +877,30 @@ describe('KroResourceFactory: toYaml(spec) instance YAML', () => {
   });
 });
 
-describe('KroResourceFactory: toYaml() singleton owner isolation', () => {
-  it('does not synthesize singleton owner resources from singleton definitions', () => {
+describe('KroResourceFactory: toYaml() singleton owner emission', () => {
+  it('emits the singleton owner RGD without injecting owner resources into the consumer graph', () => {
+    const singletonBootstrap = kubernetesComposition(
+      {
+        name: 'singleton-bootstrap',
+        apiVersion: 'v1alpha1',
+        kind: 'SingletonBootstrap',
+        spec: type({ name: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        Deployment({ name: spec.name, image: 'nginx', id: 'bootstrapApp' });
+        return { ready: true };
+      }
+    );
+
     const resources: Record<string, KubernetesResource> = {};
-    const singletonKey = 'kro.run/v1alpha1/SingletonBootstrap:singleton-bootstrap#shared-platform';
+    const singletonKey = 'v1alpha1/SingletonBootstrap:singleton-bootstrap#shared-platform';
     const singletonDefinition = {
       id: 'shared-platform',
       key: singletonKey,
       specFingerprint: 'fp',
       registryNamespace: 'typekro-singletons',
-      composition: {
-        _definition: {
-          apiVersion: 'v1alpha1',
-          kind: 'SingletonBootstrap',
-          name: 'singleton-bootstrap',
-        },
-      } as unknown as SingletonDefinitionRecord['composition'],
+      composition: singletonBootstrap as unknown as SingletonDefinitionRecord['composition'],
       spec: { name: 'shared-platform' },
     } satisfies SingletonDefinitionRecord;
 
@@ -906,13 +915,20 @@ describe('KroResourceFactory: toYaml() singleton owner isolation', () => {
     );
     const ownerId = getSingletonResourceId(singletonKey);
 
-    const yaml = factory.toYaml();
-    expect(yaml).not.toContain(ownerId);
+    const yamlOut = factory.toYaml();
+    const parsedDocs = yaml.loadAll(yamlOut) as Array<{ metadata?: { name?: string } }>;
+
+    // Isolation invariant (unchanged): the owner is NEVER injected into the
+    // consumer's own resource graph — it is emitted as a separate RGD document.
     expect(Object.hasOwn(resources, ownerId)).toBe(false);
 
-    const buildRgdYaml = getPrivateMethod(factory, 'buildRgdYaml');
-    const deployYaml = buildRgdYaml() as string;
-    expect(deployYaml).not.toContain(ownerId);
+    // New GitOps contract: the owner RGD IS emitted, deps-first (owner before
+    // consumer), so a GitOps apply of toYaml() output is complete.
+    expect(parsedDocs).toHaveLength(2);
+    const docNames = parsedDocs.map((doc) => doc?.metadata?.name);
+    expect(docNames[0]).toBe('singleton-bootstrap');
+    expect(docNames[1]).toBe('singleton-consumer');
+    expect(yamlOut).toContain('kind: SingletonBootstrap');
   });
 });
 

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -108,6 +108,30 @@ describe('Dagster bootstrap composition', () => {
     expect(repoYaml).toContain('url: ${schema.spec.url}');
   });
 
+  it('Emit the HelmRepository singleton owner in the GitOps toYaml bundle', () => {
+    // The bootstrap RGD only externalRefs the shared DagsterHelmRepository singleton.
+    // For a GitOps apply to be complete, toYaml() must also emit the singleton owner
+    // RGD (deps-first) and toYaml(spec) the owner instance (with the spec-fingerprint
+    // annotation that deploy() writes), or the externalRef dangles.
+    const rgdBundle = dagsterBootstrap.toYaml();
+    const rgdDocs = rgdBundle.split(/^---$/m).map((doc) => doc.trim());
+    expect(rgdDocs).toHaveLength(2);
+    expect(rgdBundle).toContain('name: dagster-helm-repository');
+    expect(rgdBundle).toContain('name: dagster-bootstrap');
+    // Owner RGD before the consuming RGD (deps-first apply order).
+    expect(rgdBundle.indexOf('name: dagster-helm-repository')).toBeLessThan(
+      rgdBundle.indexOf('name: dagster-bootstrap')
+    );
+
+    const instanceBundle = dagsterBootstrap
+      .factory('kro', { namespace: 'dagster' })
+      .toYaml({ name: 'analytics', namespace: 'dagster', postgresql: { enabled: true } } as never);
+    expect(instanceBundle).toContain('kind: DagsterHelmRepository');
+    expect(instanceBundle).toContain('namespace: typekro-singletons');
+    expect(instanceBundle).toContain('typekro.io/singleton-spec-fingerprint');
+    expect(instanceBundle).toContain('kind: DagsterBootstrap');
+  });
+
   it('Preserve graph-aware Helm values in ResourceGraphDefinition YAML without raw markers', () => {
     const yaml = dagsterBootstrap.toYaml();
 

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { dagsterBootstrap } from '../../../src/factories/dagster/index.js';
+import {
+  dagsterBootstrap,
+  dagsterHelmRepositoryBootstrap,
+} from '../../../src/factories/dagster/index.js';
 import {
   DagsterBootstrapConfigSchema,
   DagsterBootstrapStatusSchema,
@@ -74,18 +77,35 @@ describe('Dagster bootstrap composition', () => {
     expect(yaml).toContain('kind: ResourceGraphDefinition');
     expect(yaml).toContain('name: dagster-bootstrap');
     expect(yaml).toContain('dagsterNamespace');
-    expect(yaml).toContain('dagsterHelmRepository');
     expect(yaml).toContain('dagsterHelmRelease');
     expect(yaml).toContain('kind: Namespace');
-    expect(yaml).toContain('kind: HelmRepository');
     expect(yaml).toContain('kind: HelmRelease');
-    expect(yaml).toContain('https://dagster-io.github.io/helm');
+    // The HelmRepository is a shared cluster-level singleton referenced via
+    // externalRef (not owned per-instance), so a dev + prod pair of instances
+    // doesn't collide on KRO's per-instance ApplySet ownership of it.
+    expect(yaml).toContain('externalRef');
+    expect(yaml).toContain('kind: DagsterHelmRepository');
+    // sourceRef still points the HelmRelease at the (shared) HelmRepository.
+    expect(yaml).toContain('kind: HelmRepository');
     expect(yaml).toContain('chart: dagster');
     expect(yaml).toContain('1.13.8');
     expect(yaml).toContain('ready: ${dagsterHelmRelease.status.conditions');
     expect(yaml).toContain('phase: "${dagsterHelmRelease.status.conditions');
     expect(yaml).not.toContain('kind: Deployment');
     expect(yaml).not.toContain('kind: Pod');
+  });
+
+  it('Own the shared HelmRepository in the singleton composition', () => {
+    // The repository moved out of the per-instance bootstrap RGD into a shared
+    // singleton composition (kind DagsterHelmRepository) that owns the actual
+    // HelmRepository. Its URL is templated from the singleton spec; the concrete
+    // official URL is supplied by dagsterBootstrap at the singleton() call site.
+    const repoYaml = dagsterHelmRepositoryBootstrap.toYaml();
+
+    expect(repoYaml).toContain('kind: ResourceGraphDefinition');
+    expect(repoYaml).toContain('kind: DagsterHelmRepository');
+    expect(repoYaml).toContain('kind: HelmRepository');
+    expect(repoYaml).toContain('url: ${schema.spec.url}');
   });
 
   it('Preserve graph-aware Helm values in ResourceGraphDefinition YAML without raw markers', () => {

--- a/test/factories/dagster/values-mapper.test.ts
+++ b/test/factories/dagster/values-mapper.test.ts
@@ -200,16 +200,12 @@ describe('Dagster Helm values mapper', () => {
     const values = concreteValues(mapDagsterConfigToHelmValues({
       ...minimalConfig,
       version: '1.13.8',
-      repositoryName: 'dagster-source',
-      repositoryNamespace: 'flux-system',
       serviceAccountName: 'dagster-runtime',
     }));
 
     expect('name' in values).toBe(false);
     expect('namespace' in values).toBe(false);
     expect('version' in values).toBe(false);
-    expect('repositoryName' in values).toBe(false);
-    expect('repositoryNamespace' in values).toBe(false);
     expect(values.global).toMatchObject({ serviceAccountName: 'dagster-runtime' });
   });
 

--- a/test/factories/webapp/web-app-with-processing.test.ts
+++ b/test/factories/webapp/web-app-with-processing.test.ts
@@ -81,6 +81,22 @@ describe('WebAppWithProcessing Composition', () => {
     expect(yaml).toContain('kind: ValkeyBootstrap');
     expect(yaml).toContain('name: cnpg-operator');
     expect(yaml).toContain('name: valkey-operator');
-    expect(yaml).not.toContain('podMonitorEnabled:');
+  });
+
+  it('emits the shared operator singleton RGDs deps-first so the GitOps bundle is complete', () => {
+    // toYaml() must emit the singleton owner RGDs the consuming RGD references via
+    // externalRef — otherwise a GitOps apply leaves the externalRef dangling.
+    const yaml = webAppWithProcessing.toYaml();
+    const docs = yaml.split(/^---$/m).map((doc) => doc.trim());
+
+    // Three documents: both operator owner RGDs plus the consuming app RGD.
+    expect(docs).toHaveLength(3);
+    expect(yaml).toContain('name: cnpg-bootstrap');
+    expect(yaml).toContain('name: valkey-bootstrap');
+    expect(yaml).toContain('name: web-app-with-processing');
+    // Owner RGDs are emitted before the consumer (deps-first apply order).
+    expect(yaml.indexOf('name: cnpg-bootstrap')).toBeLessThan(
+      yaml.indexOf('name: web-app-with-processing')
+    );
   });
 });

--- a/test/unit/kro-v08-features-serialization.test.ts
+++ b/test/unit/kro-v08-features-serialization.test.ts
@@ -71,7 +71,11 @@ interface ParsedRgd {
 
 /** Parse YAML and return typed object */
 function parseRgdYaml(yamlStr: string): ParsedRgd {
-  return yaml.load(yamlStr) as ParsedRgd;
+  // toYaml() emits any singleton owner RGDs deps-first ahead of the consuming
+  // RGD, so the composition under test is always the LAST document. loadAll
+  // also handles the common single-document case (last === only).
+  const docs = yaml.loadAll(yamlStr) as ParsedRgd[];
+  return docs[docs.length - 1] as ParsedRgd;
 }
 
 /** Find a resource entry by id in parsed RGD. Throws if not found. */

--- a/test/unit/session-framework-fixes.test.ts
+++ b/test/unit/session-framework-fixes.test.ts
@@ -1041,10 +1041,14 @@ describe('Fix #56 — orphaned $item sentinel stripping', () => {
 describe('Fix #35 additional coverage — nullish default propagation', () => {
   /** Parse the RGD YAML and extract the spec portion of the schema block. */
   function extractSchemaSpec(yamlStr: string): Record<string, unknown> {
-    const parsed = jsYaml.load(yamlStr) as {
+    // toYaml() emits any singleton owner RGDs deps-first ahead of the
+    // composition under test, so the consumer RGD is the LAST document.
+    const docs = jsYaml.loadAll(yamlStr) as Array<{
       spec: { schema: { spec: Record<string, unknown> } };
-    };
-    return parsed.spec.schema.spec;
+    }>;
+    const consumer = docs[docs.length - 1];
+    if (!consumer) throw new Error('expected at least one RGD document');
+    return consumer.spec.schema.spec;
   }
 
   it('creates a leaf field with default for spec.field ?? literal', () => {


### PR DESCRIPTION
## Problem

The Dagster bootstrap created its Flux `HelmRepository` **inline** in the RGD, so each KRO instance's ApplySet tried to *own* `flux-system/dagster` exclusively. Deploying a **second** instance of the same RGD (e.g. a dev + prod pair) then failed to reconcile:

```
resource belongs to a different ApplySet: flux-system/dagster
  (source.toolkit.fluxcd.io/v1, Kind=HelmRepository) ... cannot reassign to ApplySet "..."
```

The HelmRelease and pods came up fine — only KRO's per-instance ownership of the shared repository conflicted.

## Fix

The official Dagster chart repository is **one cluster-level Flux source** shared by every instance, so model it as a shared singleton rather than a per-instance owned resource — the same pattern the webapp factory uses for its cluster-scoped operators.

- Add a `dagsterHelmRepositoryBootstrap` composition (kind `DagsterHelmRepository`) that owns the `HelmRepository` and exposes a `ready` status.
- `dagsterBootstrap` consumes it via `singleton(...)` with a **fixed cluster-wide identity** (official `dagster` / `flux-system` / chart URL). Each instance now owns only its `Namespace` + `HelmRelease` and references the shared repository by the official `sourceRef` defaults; the repository lives outside any instance's ApplySet.
- Because the shared repo's identity is fixed, the per-instance `repositoryName` / `repositoryNamespace` **bootstrap-spec** fields (which never made sense for a shared source) are removed. ⚠️ Breaking schema change for anyone who set them. The low-level `dagsterHelmRelease` resource factory keeps its own repository options.

## Verification

Deployed live on a cluster: a **dev + prod pair** of `DagsterBootstrap` instances both reconcile to `ACTIVE`/`Ready` sharing one `DagsterHelmRepository` singleton (deployed once in `typekro-singletons`), with **zero** "different ApplySet" errors.

- Full suite: **4386 pass / 0 fail**
- typecheck, lint, build, madge (no circular), docs checks: all clean

> Note (CRD migration): because this removes two CRD properties, upgrading an existing install requires deleting the old `dagsterbootstraps.kro.run` CRD first — KRO refuses breaking in-place CRD schema changes. Fresh installs are unaffected.

Independent of #67 (no file overlap); both target `master`.