### PR TITLE
feat(dagster): serviceAccount IRSA passthrough (release v0.15.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {

--- a/src/factories/dagster/types.ts
+++ b/src/factories/dagster/types.ts
@@ -408,9 +408,17 @@ const globalSchemaShape = {
   'dagsterInstanceConfigMap?': 'string',
 } as const;
 
+/** Official chart `serviceAccount` block — notably `annotations` (e.g. IRSA `eks.amazonaws.com/role-arn`). */
+const serviceAccountSchemaShape = {
+  'create?': 'boolean',
+  'name?': 'string',
+  'annotations?': objectMapSchema,
+} as const;
+
 const helmValuesSchemaShape = {
   ...globalSchemaShape,
   'global?': globalSchemaShape,
+  'serviceAccount?': serviceAccountSchemaShape,
   'nameOverride?': 'string',
   'fullnameOverride?': 'string',
   'rbacEnabled?': 'boolean',

--- a/test/factories/dagster/values-mapper.test.ts
+++ b/test/factories/dagster/values-mapper.test.ts
@@ -209,6 +209,26 @@ describe('Dagster Helm values mapper', () => {
     expect(values.global).toMatchObject({ serviceAccountName: 'dagster-runtime' });
   });
 
+  it('Pass serviceAccount (annotations/create/name) through the raw values surface (IRSA)', () => {
+    const values = concreteValues(mapDagsterConfigToHelmValues({
+      ...minimalConfig,
+      serviceAccountName: 'dbt',
+      values: {
+        serviceAccount: {
+          create: true,
+          name: 'dbt',
+          annotations: { 'eks.amazonaws.com/role-arn': 'arn:aws:iam::123:role/dbt-data' },
+        },
+      },
+    }));
+
+    expect(values.serviceAccount).toEqual({
+      create: true,
+      name: 'dbt',
+      annotations: { 'eks.amazonaws.com/role-arn': 'arn:aws:iam::123:role/dbt-data' },
+    });
+  });
+
   it('Merge raw values last while preserving typed values at unrelated paths', () => {
     const values = concreteValues(mapDagsterConfigToHelmValues({
       ...minimalConfig,


### PR DESCRIPTION
Expose `serviceAccount` (`create`/`name`/`annotations`) on the dagster Helm values passthrough. `helmValuesSchemaShape` omitted it, so the official chart's `serviceAccount.annotations` was stripped at decode — blocking IRSA (`eks.amazonaws.com/role-arn`) annotation of the dagster ServiceAccount. Now deep-merges into chart values. New mapper test covers it. Bumps to **0.15.4** (→ CI OIDC publish on merge).

Clean diff off current master: `src/factories/dagster/types.ts` (+8), `test/factories/dagster/values-mapper.test.ts` (+test), `package.json` (0.15.4). Full suite green locally (4364 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)