### PR TITLE
fix(dagster): serviceAccount.annotations as Record<string,string> CRD map (v0.15.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {

--- a/src/factories/dagster/types.ts
+++ b/src/factories/dagster/types.ts
@@ -412,7 +412,9 @@ const globalSchemaShape = {
 const serviceAccountSchemaShape = {
   'create?': 'boolean',
   'name?': 'string',
-  'annotations?': objectMapSchema,
+  // Record<string,string> (not objectMapSchema/`object`) so the generated CRD field is an object map with
+  // string values — `object` serializes to `type: string`, which k8s rejects for an annotations map (422).
+  'annotations?': 'Record<string, string>',
 } as const;
 
 const helmValuesSchemaShape = {


### PR DESCRIPTION
Follow-up to v0.15.4. `serviceAccount.annotations` used `objectMapSchema` (`type('object')`), which generates a CRD field of `type: string` — so applying an annotations **object** was rejected with 422 (`must be of type string`). Switch to `Record<string, string>` (the same pattern as every other annotations/labels map) so the generated CRD is an object map with string values. One-line fix + version bump to 0.15.5.

Full suite green (4364 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)