### PR TITLE
fix(deployment): honor readiness timeout when the k8s client/exec-auth hangs

### DIFF
--- a/src/core/config/defaults.ts
+++ b/src/core/config/defaults.ts
@@ -29,6 +29,18 @@ export const DEFAULT_KRO_INSTANCE_TIMEOUT = 600_000;
 /** Default timeout for HTTP read operations — GET/LIST (30 seconds) */
 export const DEFAULT_HTTP_READ_TIMEOUT = 30_000;
 
+/**
+ * Hard per-attempt deadline for a single readiness probe (60 seconds).
+ *
+ * Bounds one `k8sApi.read` call during a readiness poll so a probe that hangs
+ * before the HTTP layer ever arms its own timeout — e.g. an exec credential
+ * plugin (`aws eks get-token`) blocking on expired AWS/SSO credentials — cannot
+ * stall the poll loop indefinitely. Each attempt is also clamped to the
+ * remaining overall readiness budget, so the configured `timeout` is always
+ * honored as the wall-clock ceiling regardless of a stuck client/auth.
+ */
+export const DEFAULT_READINESS_PROBE_TIMEOUT = 60_000;
+
 /** Default timeout for cluster readiness checks (30 seconds) */
 export const DEFAULT_CLUSTER_READY_TIMEOUT = 30_000;
 

--- a/src/core/deployment/readiness-waiter.ts
+++ b/src/core/deployment/readiness-waiter.ts
@@ -6,7 +6,11 @@
  */
 
 import type * as k8s from '@kubernetes/client-node';
-import { DEFAULT_DEPLOYMENT_TIMEOUT, DEFAULT_POLL_INTERVAL } from '../config/defaults.js';
+import {
+  DEFAULT_DEPLOYMENT_TIMEOUT,
+  DEFAULT_POLL_INTERVAL,
+  DEFAULT_READINESS_PROBE_TIMEOUT,
+} from '../config/defaults.js';
 import { DeploymentTimeoutError, ensureError, ResourceGraphFactoryError } from '../errors.js';
 import type { TypeKroLogger } from '../logging/index.js';
 import { getMetadataField, getReadinessEvaluator } from '../metadata/index.js';
@@ -165,17 +169,26 @@ export class ReadinessWaiter {
       try {
         // Use custom readiness evaluator
         // In the new API, methods return objects directly (no .body wrapper)
-        // Wrap with abort signal handling to stop waiting if aborted
+        // Bound this single probe with a HARD per-attempt deadline (clamped to the
+        // remaining overall budget) AND the external abort signal. Without the
+        // deadline a probe that hangs *before* the HTTP layer arms its own timeout —
+        // e.g. an exec credential plugin (`aws eks get-token`) blocking on expired
+        // AWS/SSO credentials — would never return, so the `while` condition below
+        // (only re-checked between iterations) would never re-evaluate and the
+        // configured `timeout` would never fire. The deadline guarantees the loop
+        // makes progress and ultimately throws DeploymentTimeoutError.
         const clusterScoped = getMetadataField(deployedResource.manifest, 'scope') === 'cluster';
-        const liveResource = await this.withAbortSignal(
-          this.k8sApi.read({
+        const remaining = timeout - (Date.now() - startTime);
+        const liveResource = await this.readWithDeadline(
+          {
             apiVersion: deployedResource.manifest.apiVersion || '',
             kind: deployedResource.kind,
             metadata: {
               name: deployedResource.name,
               ...(clusterScoped ? {} : { namespace: deployedResource.namespace }),
             },
-          }),
+          },
+          remaining,
           abortSignal
         );
 
@@ -297,6 +310,68 @@ export class ReadinessWaiter {
       timeout,
       'readiness'
     );
+  }
+
+  /**
+   * Read a resource from the cluster bounded by a HARD deadline.
+   *
+   * Races the (abort-aware) read against a wall-clock timer so that an attempt
+   * which never settles — because the underlying client or its auth (e.g. an
+   * exec credential plugin spawning `aws eks get-token`) is stuck and ignores
+   * the abort — is force-rejected. The deadline is the smaller of the remaining
+   * overall readiness budget and a per-attempt probe cap, so the configured
+   * `timeout` is always honored as the wall-clock ceiling.
+   *
+   * Two distinct abort sources:
+   *  - `externalSignal` (an outer deployment-level abort) is threaded straight
+   *    into `withAbortSignal`, so an external abort surfaces as an AbortError the
+   *    poll loop re-throws — cancelling the wait, as intended.
+   *  - the internal per-attempt deadline rejects with a dedicated
+   *    `ReadinessProbeTimeoutError` (NOT AbortError) so the loop treats a single
+   *    stalled probe as a transient failure and keeps polling until the OVERALL
+   *    budget is exhausted, then throws the resource-named DeploymentTimeoutError.
+   */
+  private async readWithDeadline(
+    resourceRef: Parameters<k8s.KubernetesObjectApi['read']>[0],
+    remainingBudgetMs: number,
+    externalSignal?: AbortSignal
+  ): Promise<k8s.KubernetesObject> {
+    // Per-attempt cap, never longer than what's left of the overall budget.
+    // A non-positive budget means we're already past the deadline.
+    const deadlineMs = Math.max(1, Math.min(DEFAULT_READINESS_PROBE_TIMEOUT, remainingBudgetMs));
+
+    // Internal controller used ONLY to tear down the in-flight request when the
+    // deadline fires (best-effort — a stuck exec-auth call may not honor it).
+    const teardown = new AbortController();
+
+    // The read is raced against both the external signal (genuine cancellation)
+    // and the internal teardown signal (deadline cleanup). Swallow the wrapper's
+    // rejection on the non-winning branch so a dangling read promise does not
+    // surface as an unhandled rejection after the race settles.
+    const linked = externalSignal
+      ? AbortSignal.any([externalSignal, teardown.signal])
+      : teardown.signal;
+    const readPromise = this.withAbortSignal(this.k8sApi.read(resourceRef), linked);
+    readPromise.catch(() => {
+      // intentionally ignored — see above
+    });
+
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      deadlineTimer = setTimeout(() => {
+        teardown.abort();
+        const err = new Error(`Readiness probe timed out after ${deadlineMs}ms`);
+        err.name = 'ReadinessProbeTimeoutError';
+        reject(err);
+      }, deadlineMs);
+      deadlineTimer.unref?.();
+    });
+
+    try {
+      return (await Promise.race([readPromise, deadline])) as k8s.KubernetesObject;
+    } finally {
+      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+    }
   }
 
   /**

--- a/src/core/deployment/readiness.ts
+++ b/src/core/deployment/readiness.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_FAST_POLL_INTERVAL,
   DEFAULT_POLL_INTERVAL,
   DEFAULT_READINESS_MAX_BACKOFF,
+  DEFAULT_READINESS_PROBE_TIMEOUT,
 } from '../config/defaults.js';
 import { ensureError } from '../errors.js';
 import type { DeploymentEvent, DeploymentOptions, ReadinessConfig } from '../types/deployment.js';
@@ -81,15 +82,23 @@ export class ResourceReadinessChecker {
       attempt++;
 
       try {
-        // In the new API, methods return objects directly (no .body wrapper)
-        const currentResource = await this.k8sApi.read({
-          apiVersion: deployedResource.manifest.apiVersion,
-          kind: deployedResource.kind,
-          metadata: {
-            name: deployedResource.name,
-            namespace: deployedResource.namespace,
+        // In the new API, methods return objects directly (no .body wrapper).
+        // Bound the probe with a HARD per-attempt deadline (clamped to the
+        // remaining budget) so a read that hangs before the HTTP layer arms its
+        // own timeout — e.g. exec credential auth (`aws eks get-token`) blocking
+        // on expired credentials — cannot stall the poll loop indefinitely. This
+        // path has no abort signal, so the deadline is the only escape hatch.
+        const currentResource = await this.readWithDeadline(
+          {
+            apiVersion: deployedResource.manifest.apiVersion,
+            kind: deployedResource.kind,
+            metadata: {
+              name: deployedResource.name,
+              namespace: deployedResource.namespace,
+            },
           },
-        });
+          readinessConfig.timeout - (Date.now() - startTime)
+        );
 
         const isReady = this.isResourceReady(currentResource);
 
@@ -199,6 +208,47 @@ export class ResourceReadinessChecker {
     }
 
     throw new ResourceReadinessTimeoutError(deployedResource, readinessConfig.timeout);
+  }
+
+  /**
+   * Read a resource from the cluster bounded by a HARD per-attempt deadline.
+   *
+   * Races the read against a wall-clock timer (the smaller of the remaining
+   * readiness budget and a per-attempt probe cap) so an attempt that never
+   * settles — because the underlying client or its exec credential auth is
+   * stuck and ignores the abort — is force-rejected. The deadline rejection
+   * (a `ReadinessProbeTimeoutError`) is caught by the poll loop and treated as
+   * a transient read failure, so polling continues until the OVERALL budget is
+   * exhausted and the loop throws ResourceReadinessTimeoutError.
+   */
+  private async readWithDeadline(
+    resourceRef: Parameters<k8s.KubernetesObjectApi['read']>[0],
+    remainingBudgetMs: number
+  ): Promise<k8s.KubernetesObject> {
+    const deadlineMs = Math.max(1, Math.min(DEFAULT_READINESS_PROBE_TIMEOUT, remainingBudgetMs));
+
+    const readPromise = this.k8sApi.read(resourceRef);
+    // Swallow the non-winning branch's rejection so a dangling read promise does
+    // not surface as an unhandled rejection after the deadline wins the race.
+    // (The pending socket is unref'd by the HTTP layer, so it won't keep the
+    // process alive.)
+    readPromise.catch(() => undefined);
+
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      deadlineTimer = setTimeout(() => {
+        const err = new Error(`Readiness probe timed out after ${deadlineMs}ms`);
+        err.name = 'ReadinessProbeTimeoutError';
+        reject(err);
+      }, deadlineMs);
+      deadlineTimer.unref?.();
+    });
+
+    try {
+      return (await Promise.race([readPromise, deadline])) as k8s.KubernetesObject;
+    } finally {
+      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+    }
   }
 
   /**

--- a/test/unit/readiness-waiter.test.ts
+++ b/test/unit/readiness-waiter.test.ts
@@ -13,6 +13,7 @@ import { ResourceReadinessChecker } from '../../src/core/deployment/readiness.js
 import type { ReadinessWaiterDeps } from '../../src/core/deployment/readiness-waiter.js';
 import { ReadinessWaiter } from '../../src/core/deployment/readiness-waiter.js';
 import { DeploymentTimeoutError, ResourceGraphFactoryError } from '../../src/core/errors.js';
+import { ResourceReadinessTimeoutError } from '../../src/core/deployment/errors.js';
 import type { TypeKroLogger } from '../../src/core/logging/types.js';
 import {
   clearResourceMetadata,
@@ -399,6 +400,45 @@ describe('ReadinessWaiter', () => {
       ).rejects.toBeInstanceOf(DeploymentTimeoutError);
     });
 
+    it('rejects with DeploymentTimeoutError when the k8s read never settles (hung exec-auth)', async () => {
+      // Reproduces the production hang: when the kube client's exec credential
+      // plugin (`aws eks get-token`) blocks on expired AWS/SSO credentials, the
+      // underlying read promise never resolves. Without a per-attempt deadline
+      // the poll loop's `while (Date.now() - startTime < timeout)` condition is
+      // never re-evaluated (the await never returns), so the configured timeout
+      // is never honored — the wait hangs indefinitely (observed ~6 hours).
+      const deployed = makeDeployedResource({ kind: 'Deployment', name: 'hung-read' });
+      setReadinessEvaluator(deployed.manifest, () => ({ ready: false }));
+
+      // A read that NEVER settles — models the stuck exec-auth call.
+      (mockK8sApi.read as ReturnType<typeof mock>).mockImplementation(
+        () => new Promise(() => {})
+      );
+
+      const deps = createMockDeps();
+      const waiter = new ReadinessWaiter(
+        mockK8sApi,
+        readyResources,
+        readinessChecker,
+        logger,
+        undefined,
+        deps
+      );
+
+      // Short overall timeout: the wait must REJECT promptly (within ~timeout),
+      // not hang. The per-attempt deadline is clamped to the remaining budget,
+      // so the loop exits and throws DeploymentTimeoutError.
+      const start = Date.now();
+      await expect(
+        waiter.waitForResourceReady(deployed, { mode: 'direct', timeout: 200 })
+      ).rejects.toBeInstanceOf(DeploymentTimeoutError);
+      const elapsed = Date.now() - start;
+
+      // Should fail close to the configured window, never run away. Generous
+      // upper bound to stay non-flaky while still proving it does not hang.
+      expect(elapsed).toBeLessThan(5_000);
+    });
+
     it('emits resource-ready event when resource becomes ready', async () => {
       const deployed = makeDeployedResource({ kind: 'Deployment', name: 'event-deploy' });
       setReadinessEvaluator(deployed.manifest, () => ({ ready: true }));
@@ -647,6 +687,33 @@ describe('ReadinessWaiter', () => {
 
       await waiter.isDeployedResourceReady(deployed);
       expect(logSpy).toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // ResourceReadinessChecker.waitForResourceReady (the no-abort-signal path)
+  // ===========================================================================
+
+  describe('ResourceReadinessChecker.waitForResourceReady', () => {
+    it('rejects with ResourceReadinessTimeoutError when the k8s read never settles', async () => {
+      // The generic polling path has NO abort-signal plumbing, so a per-attempt
+      // deadline is the only escape hatch from a hung exec-auth read. Without it,
+      // a never-settling read stalls the loop indefinitely.
+      const deployed = makeDeployedResource({ kind: 'Deployment', name: 'hung-generic' });
+
+      (mockK8sApi.read as ReturnType<typeof mock>).mockImplementation(
+        () => new Promise(() => {})
+      );
+
+      const checker = new ResourceReadinessChecker(mockK8sApi);
+
+      const start = Date.now();
+      await expect(
+        checker.waitForResourceReady(deployed, { mode: 'direct', timeout: 200 }, () => {})
+      ).rejects.toBeInstanceOf(ResourceReadinessTimeoutError);
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(5_000);
     });
   });
 });


### PR DESCRIPTION
## Problem
When deploying with `waitForReady`, if the Kubernetes client's exec-credential auth (e.g. `aws eks get-token`) hangs — typically because the underlying AWS/SSO credentials expired mid-deploy — the readiness wait **hangs indefinitely** (observed ~6h in production) instead of failing at the configured `timeout`.

## Root cause
Both readiness poll loops (`ReadinessWaiter.waitForResourceReady`, `ResourceReadinessChecker.waitForResourceReadyWithPolling`) bound the wait with `while (Date.now() - startTime < timeout)`, but `await` the per-attempt `k8sApi.read(...)` with **no per-attempt deadline**. The wall-clock condition is only re-evaluated *between* iterations, so a hung `await` in the body is never re-checked → the configured timeout never fires. The exec-credential call runs inside the client's `applyToRequest()` *before* any HTTP request is built, so the HTTP-layer read timeout / abort signal (both downstream of auth) never arm.

## Fix
Add `readWithDeadline()` to both poll loops: each read races a hard deadline = `min(remaining wall-clock budget, 60s probe cap)`. A stalled probe rejects with `ReadinessProbeTimeoutError` so the loop keeps polling until the overall budget is spent, then throws the resource-named `DeploymentTimeoutError` / `ResourceReadinessTimeoutError`. Genuine deployment-level aborts still propagate as `AbortError` (threaded via `AbortSignal.any`). No public API change — reuses the existing `timeout` semantics plus a sensible internal probe cap.

## Tests
New tests drive both paths with a never-settling mocked read and assert they reject within the configured window (verified to hang indefinitely on the pre-fix source). Full unit suite: **4380 pass / 0 fail**; `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
