### PR TITLE
perf(factories): serialize factory resource graphs lazily

### DIFF
--- a/src/core/composition/lazy-composition.ts
+++ b/src/core/composition/lazy-composition.ts
@@ -1,0 +1,116 @@
+/**
+ * Lazy Composition Wrapper
+ *
+ * `kubernetesComposition(...)` executes eagerly: calling it runs the
+ * composition function, builds the ResourceGraphDefinition, and runs the full
+ * CEL analysis/optimization (serialization) pipeline — emitting
+ * `resource-graph-serialization` log lines. That eager contract is correct for
+ * direct callers (and is relied upon by tests), but it is a performance/hygiene
+ * problem for the BUILT-IN FACTORY CATALOG.
+ *
+ * The factory barrel (`src/factories/index.ts`) re-exports every built-in
+ * factory. Each factory module declares its composition at module scope
+ * (`export const xBootstrap = kubernetesComposition(...)`). Because of the
+ * barrel, importing ANY factory — or the top-level `typekro` entry — eagerly
+ * imports and therefore SERIALIZES the entire catalog (apisix, ory, cilium,
+ * cert-manager, external-dns, pebble, ...), even when the consumer only
+ * instantiates one. None of those graphs are deployed; the work is pure wasted
+ * CPU and log noise at converge time. (`ory-identity-stack` was observed
+ * serializing 60+ times.)
+ *
+ * {@link lazyComposition} defers a single composition's construction behind a
+ * memoized thunk. The returned value is a `CallableComposition`-shaped Proxy
+ * that builds the real composition on first use — the first time any property
+ * is read, the composition is invoked as a function, enumerated, or described.
+ * A factory that is imported but never used is therefore never serialized,
+ * while a factory that IS used materializes on first touch and behaves
+ * identically to an eagerly-constructed one (same eager-execution semantics,
+ * same logs, same public surface: `.factory(...)`, `.toYaml(...)`,
+ * `.resources`, `.status`, resource access, callable-with-spec).
+ */
+
+import type { CallableComposition } from '../types/deployment.js';
+import type { KroCompatibleType } from '../types/serialization.js';
+
+/**
+ * Wrap a composition factory thunk so the underlying composition is only
+ * built (and serialized) on first use.
+ *
+ * @param build - A thunk that constructs and returns the real composition,
+ *   typically `() => kubernetesComposition(definition, fn, options)`.
+ * @returns A `CallableComposition` proxy that materializes `build()` lazily and
+ *   memoizes the result. All property reads, calls, enumeration, and
+ *   descriptor lookups transparently forward to the materialized composition.
+ */
+export function lazyComposition<
+  TSpec extends KroCompatibleType,
+  TStatus extends KroCompatibleType,
+>(build: () => CallableComposition<TSpec, TStatus>): CallableComposition<TSpec, TStatus> {
+  let built: CallableComposition<TSpec, TStatus> | undefined;
+  const materialize = (): CallableComposition<TSpec, TStatus> => {
+    if (!built) {
+      built = build();
+    }
+    return built;
+  };
+
+  // The proxy target is a function so the result is callable (compositions can
+  // be invoked with a spec). The target itself is never used — every trap
+  // forwards to the materialized composition.
+  const target = (() => undefined) as unknown as CallableComposition<TSpec, TStatus>;
+
+  return new Proxy(target, {
+    apply(_target, thisArg, argArray) {
+      // Calling the composition with a spec is a "use" — materialize, then
+      // invoke the real callable.
+      return Reflect.apply(
+        materialize() as unknown as (...args: unknown[]) => unknown,
+        thisArg,
+        argArray
+      );
+    },
+    get(_target, prop, _receiver) {
+      const real = materialize() as unknown as object;
+      // Forward to the real composition. Use the real composition as the
+      // receiver so getters and `this`-dependent accessors resolve correctly.
+      return Reflect.get(real, prop, real);
+    },
+    has(_target, prop) {
+      return Reflect.has(materialize() as unknown as object, prop);
+    },
+    ownKeys(_target) {
+      return Reflect.ownKeys(materialize() as unknown as object);
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(
+        materialize() as unknown as object,
+        prop
+      );
+      // Proxy invariant: a non-configurable descriptor may only be reported for
+      // a key that is a non-configurable own property of the TARGET. The target
+      // (an empty stub function) has none of the composition's keys, and the
+      // real composition defines several keys as `configurable: false` (e.g.
+      // the callable-composition brand, `status`). Force `configurable: true`
+      // so this transparent forwarding proxy never violates the invariant. The
+      // forwarded value is unchanged — only the descriptor's configurability
+      // flag is relaxed, which is purely a reflection detail.
+      if (descriptor) {
+        descriptor.configurable = true;
+      }
+      return descriptor;
+    },
+    getPrototypeOf(_target) {
+      return Reflect.getPrototypeOf(materialize() as unknown as object);
+    },
+    set(_target, prop, value, _receiver) {
+      const real = materialize() as unknown as object;
+      return Reflect.set(real, prop, value, real);
+    },
+    defineProperty(_target, prop, descriptor) {
+      return Reflect.defineProperty(materialize() as unknown as object, prop, descriptor);
+    },
+    deleteProperty(_target, prop) {
+      return Reflect.deleteProperty(materialize() as unknown as object, prop);
+    },
+  });
+}

--- a/src/factories/apisix/compositions/apisix-bootstrap.ts
+++ b/src/factories/apisix/compositions/apisix-bootstrap.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { getCurrentCompositionContext } from '../../../core/composition/context.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { Cel } from '../../../core/references/cel.js';
@@ -338,51 +339,66 @@ function createApisixBootstrap(requireDefinitionCredentials = false) {
   );
 }
 
-const apisixBootstrapBase = createApisixBootstrap(false);
+/**
+ * Build the configured APISIX bootstrap composition, installing the custom
+ * `.factory`/`.toYaml` wrappers that require concrete admin credentials when a
+ * KRO definition is generated without a spec.
+ *
+ * This runs lazily (see {@link lazyComposition} below) so importing this module
+ * does NOT eagerly serialize the APISIX resource graph — the whole point of the
+ * lazy-factory fix. Everything that previously ran at module scope (including
+ * reading `.factory`, which would itself force serialization) now runs only on
+ * first use of the factory.
+ */
+function buildApisixBootstrap() {
+  const apisixBootstrapBase = createApisixBootstrap(false);
 
-const originalFactory = apisixBootstrapBase.factory.bind(apisixBootstrapBase);
-function apisixBootstrapFactory(
-  mode: 'kro',
-  options?: PublicFactoryOptions
-): KroResourceFactory<APISixBootstrapConfig, APISixBootstrapStatus>;
-function apisixBootstrapFactory(
-  mode: 'direct',
-  options?: PublicFactoryOptions
-): DirectResourceFactory<APISixBootstrapConfig, APISixBootstrapStatus>;
-function apisixBootstrapFactory(
-  mode: 'kro' | 'direct',
-  options?: PublicFactoryOptions
-):
-  | KroResourceFactory<APISixBootstrapConfig, APISixBootstrapStatus>
-  | DirectResourceFactory<APISixBootstrapConfig, APISixBootstrapStatus> {
-  if (mode === 'kro') {
-    const factory = createApisixBootstrap(false).factory('kro', options);
-    const originalToYaml = factory.toYaml.bind(factory);
-    (factory as { toYaml: (spec?: APISixBootstrapConfig) => string }).toYaml = (
-      spec?: APISixBootstrapConfig
-    ) => {
-      if (spec !== undefined) {
-        return originalToYaml(spec);
-      }
-      return createApisixBootstrap(true).factory('kro', options).toYaml();
-    };
-    return factory;
+  const originalFactory = apisixBootstrapBase.factory.bind(apisixBootstrapBase);
+  function apisixBootstrapFactory(
+    mode: 'kro',
+    options?: PublicFactoryOptions
+  ): KroResourceFactory<APISixBootstrapConfig, APISixBootstrapStatus>;
+  function apisixBootstrapFactory(
+    mode: 'direct',
+    options?: PublicFactoryOptions
+  ): DirectResourceFactory<APISixBootstrapConfig, APISixBootstrapStatus>;
+  function apisixBootstrapFactory(
+    mode: 'kro' | 'direct',
+    options?: PublicFactoryOptions
+  ):
+    | KroResourceFactory<APISixBootstrapConfig, APISixBootstrapStatus>
+    | DirectResourceFactory<APISixBootstrapConfig, APISixBootstrapStatus> {
+    if (mode === 'kro') {
+      const factory = createApisixBootstrap(false).factory('kro', options);
+      const originalToYaml = factory.toYaml.bind(factory);
+      (factory as { toYaml: (spec?: APISixBootstrapConfig) => string }).toYaml = (
+        spec?: APISixBootstrapConfig
+      ) => {
+        if (spec !== undefined) {
+          return originalToYaml(spec);
+        }
+        return createApisixBootstrap(true).factory('kro', options).toYaml();
+      };
+      return factory;
+    }
+    return originalFactory(mode, options);
   }
-  return originalFactory(mode, options);
+
+  (apisixBootstrapBase as { factory: typeof apisixBootstrapBase.factory }).factory =
+    apisixBootstrapFactory;
+
+  // Require concrete credentials when generating a KRO definition so omitted
+  // CR fields do not become chart defaults.
+  (apisixBootstrapBase as { toYaml: (spec?: APISixBootstrapConfig) => string }).toYaml = (
+    spec?: APISixBootstrapConfig
+  ) => {
+    if (spec !== undefined) {
+      return createApisixBootstrap(false).factory('kro').toYaml(spec);
+    }
+    return createApisixBootstrap(true).toYaml();
+  };
+
+  return apisixBootstrapBase;
 }
 
-(apisixBootstrapBase as { factory: typeof apisixBootstrapBase.factory }).factory =
-  apisixBootstrapFactory;
-
-// Keep module imports side-effect safe, but require concrete credentials when
-// generating a KRO definition so omitted CR fields do not become chart defaults.
-(apisixBootstrapBase as { toYaml: (spec?: APISixBootstrapConfig) => string }).toYaml = (
-  spec?: APISixBootstrapConfig
-) => {
-  if (spec !== undefined) {
-    return createApisixBootstrap(false).factory('kro').toYaml(spec);
-  }
-  return createApisixBootstrap(true).toYaml();
-};
-
-export const apisixBootstrap = apisixBootstrapBase;
+export const apisixBootstrap = lazyComposition(buildApisixBootstrap);

--- a/src/factories/cert-manager/compositions/cert-manager-bootstrap.ts
+++ b/src/factories/cert-manager/compositions/cert-manager-bootstrap.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { Cel } from '../../../core/references/cel.js';
 import { ensureVersionPrefix } from '../../../utils/string.js';
@@ -53,7 +54,7 @@ import { mapCertManagerConfigToHelmValues } from '../utils/helm-values-mapper.js
  * });
  * ```
  */
-export const certManagerBootstrap = kubernetesComposition(
+export const certManagerBootstrap = lazyComposition(() => kubernetesComposition(
   {
     name: 'cert-manager-bootstrap',
     // apiVersion defaults to 'v1alpha1' and Kro adds kro.run group automatically
@@ -349,4 +350,4 @@ export const certManagerBootstrap = kubernetesComposition(
       },
     };
   }
-);
+));

--- a/src/factories/cilium/compositions/cilium-bootstrap.ts
+++ b/src/factories/cilium/compositions/cilium-bootstrap.ts
@@ -7,6 +7,7 @@
 
 import { type } from 'arktype';
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { Cel } from '../../../core/references/cel.js';
 import {
@@ -163,7 +164,7 @@ export const CiliumBootstrapStatusSchema = type({
  * Creates a complete Cilium deployment using Helm with comprehensive configuration
  * options and status outputs for integration with other systems.
  */
-export const ciliumBootstrap = kubernetesComposition(
+export const ciliumBootstrap = lazyComposition(() => kubernetesComposition(
   {
     name: 'cilium-bootstrap',
     apiVersion: 'cilium.io/v1alpha1',
@@ -357,4 +358,4 @@ export const ciliumBootstrap = kubernetesComposition(
       },
     };
   }
-);
+));

--- a/src/factories/cnpg/compositions/cnpg-bootstrap.ts
+++ b/src/factories/cnpg/compositions/cnpg-bootstrap.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { setMetadataField } from '../../../core/metadata/index.js';
 import { Cel } from '../../../core/references/cel.js';
@@ -41,7 +42,7 @@ import { mapCnpgConfigToHelmValues } from '../utils/helm-values-mapper.js';
  * });
  * ```
  */
-export const cnpgBootstrap = kubernetesComposition(
+export const cnpgBootstrap = lazyComposition(() => kubernetesComposition(
   {
     name: 'cnpg-bootstrap',
     kind: 'CnpgBootstrap',
@@ -157,4 +158,4 @@ export const cnpgBootstrap = kubernetesComposition(
       version: resolvedVersion,
     };
   }
-);
+));

--- a/src/factories/dagster/compositions/dagster-bootstrap.ts
+++ b/src/factories/dagster/compositions/dagster-bootstrap.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { Cel } from '../../../core/references/cel.js';
 import { singleton } from '../../../core/singleton/singleton.js';
@@ -25,7 +26,7 @@ type DagsterBootstrapSchemaConfig = typeof DagsterBootstrapConfigSchema.infer;
  * Creates the target Namespace, official Dagster HelmRepository, and Dagster
  * HelmRelease. Status is derived only from owned Flux Helm resources.
  */
-export const dagsterBootstrap = kubernetesComposition(
+export const dagsterBootstrap = lazyComposition(() => kubernetesComposition(
   {
     name: 'dagster-bootstrap',
     kind: 'DagsterBootstrap',
@@ -100,7 +101,7 @@ export const dagsterBootstrap = kubernetesComposition(
       },
     };
   }
-);
+));
 
 function buildHelmValues(spec: DagsterBootstrapSchemaConfig) {
   return mapDagsterConfigToHelmValues(buildMapperConfig(spec));

--- a/src/factories/dagster/compositions/dagster-helm-repository.ts
+++ b/src/factories/dagster/compositions/dagster-helm-repository.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { Cel } from '../../../core/references/cel.js';
 import { dagsterHelmRepository } from '../resources/helm.js';
 import {
@@ -19,7 +20,7 @@ import {
  * shared HelmRepository is owned outside any single instance's ApplySet and
  * every instance's HelmRelease references it by the same `sourceRef`.
  */
-export const dagsterHelmRepositoryBootstrap = kubernetesComposition(
+export const dagsterHelmRepositoryBootstrap = lazyComposition(() => kubernetesComposition(
   {
     name: 'dagster-helm-repository',
     kind: 'DagsterHelmRepository',
@@ -41,4 +42,4 @@ export const dagsterHelmRepositoryBootstrap = kubernetesComposition(
       ),
     };
   }
-);
+));

--- a/src/factories/external-dns/compositions/external-dns-bootstrap.ts
+++ b/src/factories/external-dns/compositions/external-dns-bootstrap.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { Cel } from '../../../core/references/cel.js';
 import { getInnerCelPath } from '../../../core/serialization/cel-references.js';
@@ -172,7 +173,7 @@ function buildHelmValues(config: ExternalDnsHelmValues): ExternalDnsHelmValueInp
  * });
  * ```
  */
-export const externalDnsBootstrap = kubernetesComposition(
+export const externalDnsBootstrap = lazyComposition(() => kubernetesComposition(
   {
     name: 'external-dns-bootstrap',
     // apiVersion defaults to 'v1alpha1' and Kro adds kro.run group automatically
@@ -297,4 +298,4 @@ export const externalDnsBootstrap = kubernetesComposition(
       },
     };
   }
-);
+));

--- a/src/factories/inngest/compositions/inngest-bootstrap.ts
+++ b/src/factories/inngest/compositions/inngest-bootstrap.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { Cel } from '../../../core/references/cel.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
@@ -48,7 +49,7 @@ import { mapInngestConfigToHelmValues } from '../utils/helm-values-mapper.js';
  * });
  * ```
  */
-export const inngestBootstrap = kubernetesComposition(
+export const inngestBootstrap = lazyComposition(() => kubernetesComposition(
   {
     name: 'inngest-bootstrap',
     kind: 'InngestBootstrap',
@@ -124,4 +125,4 @@ export const inngestBootstrap = kubernetesComposition(
       version: resolvedVersion,
     };
   }
-);
+));

--- a/src/factories/ory/compositions/ory-identity-stack.ts
+++ b/src/factories/ory/compositions/ory-identity-stack.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import {
   isValuesMergeExpression,
   mergeValuesExpression,
@@ -343,7 +344,7 @@ function isSchemaSpec(value: unknown): boolean {
  * Creates the target namespace, official Ory Helm repository, Hydra/Kratos/Keto/Oathkeeper
  * HelmReleases, optional starter Maester resources, and status fields used by direct and KRO modes.
  */
-export const oryIdentityStack = kubernetesComposition(
+export const oryIdentityStack = lazyComposition(() => kubernetesComposition(
   {
     name: 'ory-identity-stack',
     kind: 'OryIdentityStack',
@@ -523,4 +524,4 @@ export const oryIdentityStack = kubernetesComposition(
       version: Cel.template('%s', resolvedVersion),
     };
   }
-);
+));

--- a/src/factories/ory/compositions/ory-platform-stack.ts
+++ b/src/factories/ory/compositions/ory-platform-stack.ts
@@ -1,5 +1,6 @@
 import { type Type, type } from 'arktype';
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { Cel } from '../../../core/references/cel.js';
 import { isKubernetesRef } from '../../../utils/type-guards.js';
 import { cluster } from '../../cnpg/resources/cluster.js';
@@ -348,7 +349,7 @@ function isSchemaSpec(value: unknown): boolean {
   );
 }
 
-export const oryPlatformStack = kubernetesComposition(
+export const oryPlatformStack = lazyComposition(() => kubernetesComposition(
   {
     name: 'ory-platform-stack',
     kind: 'OryPlatformStack',
@@ -683,4 +684,4 @@ export const oryPlatformStack = kubernetesComposition(
       endpoints: oryStatus.endpoints,
     };
   }
-);
+));

--- a/src/factories/pebble/compositions/pebble-bootstrap.ts
+++ b/src/factories/pebble/compositions/pebble-bootstrap.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { pebbleHelmRelease, pebbleHelmRepository } from '../resources/helm.js';
 import { PebbleBootstrapConfigSchema, PebbleBootstrapStatusSchema } from '../types.js';
@@ -44,7 +45,7 @@ import { createDefaultPebbleTestingValues } from '../utils/helm-values-mapper.js
  * });
  * ```
  */
-export const pebbleBootstrap = kubernetesComposition(
+export const pebbleBootstrap = lazyComposition(() => kubernetesComposition(
   {
     name: 'pebble-bootstrap',
     apiVersion: 'pebble.typekro.dev/v1alpha1',
@@ -112,4 +113,4 @@ export const pebbleBootstrap = kubernetesComposition(
       dnsServer: `${spec.name}-coredns.${spec.namespace || 'default'}.svc.cluster.local`,
     };
   }
-);
+));

--- a/src/factories/searxng/compositions/searxng-bootstrap.ts
+++ b/src/factories/searxng/compositions/searxng-bootstrap.ts
@@ -22,6 +22,7 @@
  */
 
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { TypeKroError } from '../../../core/errors.js';
 import { getIncludeWhen, setIncludeWhen } from '../../../core/metadata/resource-metadata.js';
 import { Cel } from '../../../core/references/cel.js';
@@ -111,6 +112,7 @@ function withKroInstanceValidation(
   });
 }
 
+function buildSearxngBootstrap() {
 const searxngBootstrapComposition = kubernetesComposition(
   {
     name: 'searxng-bootstrap',
@@ -467,4 +469,9 @@ Object.defineProperty(searxngBootstrapComposition, 'factory', {
   configurable: true,
 });
 
-export const searxngBootstrap = searxngBootstrapComposition;
+  return searxngBootstrapComposition;
+}
+
+// Wrapped lazily so importing this module does not eagerly serialize the
+// SearxNG resource graph (and so reading `.factory` above runs only on use).
+export const searxngBootstrap = lazyComposition(buildSearxngBootstrap);

--- a/src/factories/valkey/compositions/valkey-bootstrap.ts
+++ b/src/factories/valkey/compositions/valkey-bootstrap.ts
@@ -1,4 +1,5 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { setMetadataField } from '../../../core/metadata/index.js';
 import { Cel } from '../../../core/references/cel.js';
@@ -56,7 +57,7 @@ function stripChartSuffix(version: string): string {
  * });
  * ```
  */
-export const valkeyBootstrap = kubernetesComposition(
+export const valkeyBootstrap = lazyComposition(() => kubernetesComposition(
   {
     name: 'valkey-bootstrap',
     kind: 'ValkeyBootstrap',
@@ -248,4 +249,4 @@ export const valkeyBootstrap = kubernetesComposition(
       version: appVersion,
     };
   }
-);
+));

--- a/src/factories/webapp/compositions/web-app-with-processing.ts
+++ b/src/factories/webapp/compositions/web-app-with-processing.ts
@@ -1,5 +1,6 @@
 import type { V1EnvFromSource } from '@kubernetes/client-node';
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { lazyComposition } from '../../../core/composition/lazy-composition.js';
 import { singleton } from '../../../core/singleton/singleton.js';
 import { isKubernetesRef } from '../../../utils/type-guards.js';
 import { cnpgBootstrap } from '../../cnpg/compositions/cnpg-bootstrap.js';
@@ -97,7 +98,7 @@ import {
  * });
  * ```
  */
-export const webAppWithProcessing = kubernetesComposition(
+export const webAppWithProcessing = lazyComposition(() => kubernetesComposition(
   {
     name: 'web-app-with-processing',
     kind: 'WebAppWithProcessing',
@@ -407,4 +408,4 @@ export const webAppWithProcessing = kubernetesComposition(
       },
     };
   }
-);
+));

--- a/test/core/lazy-composition.test.ts
+++ b/test/core/lazy-composition.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for lazyComposition — deferred factory resource-graph serialization.
+ *
+ * Background: `kubernetesComposition(...)` executes (and serializes) eagerly.
+ * Built-in factory modules declare their composition at module scope, and the
+ * factory barrel (`src/factories/index.ts`) re-exports every one of them — so
+ * importing any single factory used to serialize the ENTIRE catalog. None of
+ * those graphs are deployed; it was pure wasted work + log noise.
+ *
+ * `lazyComposition(() => kubernetesComposition(...))` defers a single
+ * composition's construction behind a memoized thunk that only runs on first
+ * use. These tests assert:
+ *   1. The build thunk is NOT invoked at wrap time (the core fix).
+ *   2. The thunk runs at most once and is memoized.
+ *   3. The wrapped value transparently behaves like the real composition
+ *      (callable, property access, public surface).
+ *   4. Built-in factories that ARE used still build + work identically.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { type } from 'arktype';
+
+import { Cel, kubernetesComposition, simple } from '../../src/index.js';
+import { lazyComposition } from '../../src/core/composition/lazy-composition.js';
+
+const SpecSchema = type({ name: 'string', image: 'string', replicas: 'number%1' });
+const StatusSchema = type({ ready: 'boolean', readyReplicas: 'number%1' });
+
+const definition = {
+  name: 'lazy-test-webapp',
+  apiVersion: 'example.com/v1alpha1',
+  kind: 'LazyWebApp',
+  spec: SpecSchema,
+  status: StatusSchema,
+} as const;
+
+function makeRealComposition() {
+  return kubernetesComposition(definition, (spec) => {
+    const deployment = simple.Deployment({
+      name: spec.name,
+      image: spec.image,
+      replicas: spec.replicas,
+      id: 'lazyTestDeployment',
+    });
+    return {
+      ready: Cel.expr<boolean>(deployment.status.readyReplicas, ' > 0'),
+      readyReplicas: deployment.status.readyReplicas,
+    };
+  });
+}
+
+describe('lazyComposition', () => {
+  it('does NOT invoke the build thunk at wrap time', () => {
+    let builds = 0;
+    lazyComposition(() => {
+      builds++;
+      return makeRealComposition();
+    });
+
+    // The wrap itself must be free of serialization — this is the bug fix.
+    expect(builds).toBe(0);
+  });
+
+  it('builds exactly once, on first use, and memoizes', () => {
+    let builds = 0;
+    const lazy = lazyComposition(() => {
+      builds++;
+      return makeRealComposition();
+    });
+
+    expect(builds).toBe(0);
+
+    // First property read triggers materialization.
+    expect(lazy.name).toBe('lazy-test-webapp');
+    expect(builds).toBe(1);
+
+    // Subsequent reads reuse the memoized composition.
+    void lazy.resources;
+    void lazy.factory;
+    expect(builds).toBe(1);
+  });
+
+  it('exposes the real composition public surface transparently', () => {
+    const lazy = lazyComposition(() => makeRealComposition());
+
+    expect(lazy.name).toBe('lazy-test-webapp');
+    expect(Array.isArray(lazy.resources)).toBe(true);
+    expect(lazy.resources.length).toBeGreaterThan(0);
+    expect(typeof lazy.factory).toBe('function');
+
+    // Enumeration and brand checks must work through the proxy.
+    expect(Object.keys(lazy)).toContain('name');
+  });
+
+  it('is callable with a spec, building lazily', () => {
+    let builds = 0;
+    const lazy = lazyComposition(() => {
+      builds++;
+      return makeRealComposition();
+    });
+
+    expect(builds).toBe(0);
+    const instance = lazy({ name: 'app', image: 'nginx', replicas: 2 });
+    expect(builds).toBe(1);
+    expect(instance).toBeDefined();
+  });
+
+  it('produces a factory that can serialize to YAML (used factory still works)', () => {
+    const lazy = lazyComposition(() => makeRealComposition());
+    const factory = lazy.factory('kro');
+    const yaml = factory.toYaml();
+    expect(yaml).toContain('LazyWebApp');
+  });
+});
+
+describe('built-in factory laziness', () => {
+  it('spies prove an unused lazy factory is never built, but a used one is', () => {
+    // This mirrors the real catalog problem at the unit level: two factories
+    // are declared, only one is "used". The unused one must never build.
+    let usedBuilds = 0;
+    let unusedBuilds = 0;
+
+    const used = lazyComposition(() => {
+      usedBuilds++;
+      return makeRealComposition();
+    });
+    // Not bound: like an un-touched factory in the barrel — created, never used.
+    lazyComposition(() => {
+      unusedBuilds++;
+      return makeRealComposition();
+    });
+
+    // Declaring both (as the barrel does for the whole catalog) serializes
+    // nothing.
+    expect(usedBuilds).toBe(0);
+    expect(unusedBuilds).toBe(0);
+
+    // Use only one.
+    used.factory('kro').toYaml();
+
+    expect(usedBuilds).toBe(1);
+    // The unused factory was never touched -> never serialized.
+    expect(unusedBuilds).toBe(0);
+  });
+
+  it('exposes built-in dagsterBootstrap as a working lazy composition', async () => {
+    const { dagsterBootstrap } = await import(
+      '../../src/factories/dagster/compositions/dagster-bootstrap.js'
+    );
+    expect(dagsterBootstrap.name).toBe('dagster-bootstrap');
+    const factory = dagsterBootstrap.factory('kro');
+    const yaml = factory.toYaml();
+    expect(yaml).toContain('DagsterBootstrap');
+  });
+});


### PR DESCRIPTION
## Problem
Using a single factory (e.g. `dagsterBootstrap.factory('kro')`) serializes typekro's **entire built-in factory catalog** — `apisix`, `ory` (60+ serialization passes!), `cilium`, `cert-manager`, `external-dns`, `pebble`, etc. — none of which the consumer instantiates. Pure wasted CEL-analysis work plus log spam (`resource-graph-serialization … CEL expression optimizations applied`) on every converge. The factories are only serialized, never deployed.

## Root cause
Every built-in factory declares its composition at **module scope** (`export const xBootstrap = kubernetesComposition(...)`), and `kubernetesComposition(...)` executes **eagerly** (runs the full `toResourceGraph` → CEL analysis/optimization pipeline). The factory barrel (`src/factories/index.ts`) `export *`s every factory, so importing *any* one (or the top-level entry) imports + serializes the *whole* catalog.

## Fix
Add `lazyComposition(build)` — a memoized thunk wrapped in a transparent Proxy that runs `build()` (and thus serialization) only on first use (property read / call / enumeration). Wrap the 14 built-in factory modules. `kubernetesComposition` itself is **unchanged** — it stays eager when called, preserving the documented direct-call contract (and the 18 existing tests that assert eager execution / construction-time errors / context capture). Laziness lives at the factory-module boundary, exactly where the catalog-serialization waste originates.

## Tests
New `test/core/lazy-composition.test.ts`: the build thunk is not invoked at wrap time, builds exactly once + memoizes, exposes a transparent public surface, and an unused lazy factory is never built while a used one is. Full unit suite: **4385 pass / 0 fail**; the dagster / apisix / ory / searxng factory tests pass (no regression for used factories); `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
