### PR TITLE
feat(dagster): daemon liveness probe (auto-recover a hung daemon); + serializer no-op-conditional collapse + externalRef dynamic-name typing

### DIFF
--- a/src/core/references/external-refs.ts
+++ b/src/core/references/external-refs.ts
@@ -18,6 +18,7 @@ import { getResourceId } from '../metadata/index.js';
 import { createResource } from '../proxy/create-resource.js';
 import { registerFactory } from '../resources/factory-registry.js';
 import type { Enhanced, KubernetesResource } from '../types.js';
+import type { RefOrValue } from '../types/references.js';
 
 // Self-register so the composition analyzer recognizes `externalRef(...)` calls
 // in the AST. The kind/apiVersion are placeholders — externalRef creates resources
@@ -42,8 +43,14 @@ export interface ExternalRefConfig {
   apiVersion: string;
   kind: string;
   metadata: {
-    name: string;
-    namespace?: string;
+    /**
+     * The referenced resource's name. Accepts a plain string OR a CEL expression / schema ref
+     * (`RefOrValue<string>`) — a DYNAMIC, per-instance name (e.g. `Cel.expr('schema.spec.name + "-x"')`
+     * or `Cel.template('%s-x', spec.name)`) is the common case when observing a resource whose name is
+     * derived from the spec. Pass `id` when the name is dynamic (KRO needs a stable resource id).
+     */
+    name: RefOrValue<string>;
+    namespace?: RefOrValue<string>;
   };
   /** Explicit resource ID for composition tracking. Required when name is dynamic. */
   id?: string;
@@ -87,8 +94,8 @@ export function externalRef<TSpec extends object, TStatus extends object>(
 ): Enhanced<TSpec, TStatus> {
   let apiVersion: string;
   let resolvedKind: string;
-  let resolvedName: string;
-  let resolvedNamespace: string | undefined;
+  let resolvedName: RefOrValue<string>;
+  let resolvedNamespace: RefOrValue<string> | undefined;
 
   if (typeof configOrApiVersion === 'object') {
     // Object-form: externalRef({ apiVersion, kind, metadata: { name, namespace } })
@@ -115,8 +122,10 @@ export function externalRef<TSpec extends object, TStatus extends object>(
     apiVersion,
     kind: resolvedKind,
     metadata: {
-      name: resolvedName,
-      ...(resolvedNamespace && { namespace: resolvedNamespace }),
+      // ObjectMeta types name/namespace as `string`, but a dynamic ref/CEL expression is valid here —
+      // serialization resolves it per-instance. Bridge the public RefOrValue<string> to the meta type.
+      name: resolvedName as string,
+      ...(resolvedNamespace && { namespace: resolvedNamespace as string }),
     },
     spec: {} as TSpec,
     status: {} as TStatus,

--- a/src/core/serialization/core.ts
+++ b/src/core/serialization/core.ts
@@ -1580,10 +1580,21 @@ function buildCelConditional(
   resourceIds?: ReadonlySet<string>,
   omitFields?: ReadonlySet<string>
 ): string {
-  const field = pickConditionField(proxyValue, hybridValue, overriddenFields);
   const proxyRepr = celValueRepr(proxyValue, nestedStatusCel, resourceIds, omitFields);
   const hybridRepr = celValueRepr(hybridValue, nestedStatusCel, resourceIds, omitFields);
 
+  // No-op conditional collapse: `has(X) ? V : V` ≡ V. The proxy and hybrid passes can diverge
+  // structurally (so walkAndConditionalize routes a leaf here) yet render to an IDENTICAL CEL
+  // expression — e.g. a resource field built from a CEL expression (`schema.spec.name + "-suffix"`)
+  // that sits alongside an unrelated `spec.x || default` binding. There is no real branch to guard,
+  // and pickConditionField() would otherwise attach the wrong field's has() guard via its
+  // first-overridden-field fallback — producing misleading output, and structurally INVALID output
+  // when the repr carries `${...}` (nested template). Emit the expression directly, with no guard.
+  if (proxyRepr === hybridRepr) {
+    return `\${${proxyRepr}}`;
+  }
+
+  const field = pickConditionField(proxyValue, hybridValue, overriddenFields);
   const explicitCondition = overrideConditions.get(field);
   if (explicitCondition) {
     return `\${${explicitCondition} ? ${celBranchRepr(proxyRepr)} : ${celBranchRepr(hybridRepr)}}`;

--- a/src/factories/dagster/compositions/dagster-bootstrap.ts
+++ b/src/factories/dagster/compositions/dagster-bootstrap.ts
@@ -1,7 +1,10 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { Cel } from '../../../core/references/cel.js';
+import { externalRef } from '../../../core/references/external-refs.js';
 import { singleton } from '../../../core/singleton/singleton.js';
+import type { TypeKroValueTreeObject } from '../../../core/types/common.js';
+import { isKubernetesRef } from '../../../utils/type-guards.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
 import {
   DEFAULT_DAGSTER_REPO_NAME,
@@ -18,6 +21,35 @@ import { mapDagsterConfigToHelmValues } from '../utils/helm-values-mapper.js';
 import { dagsterHelmRepositoryBootstrap } from './dagster-helm-repository.js';
 
 type DagsterBootstrapSchemaConfig = typeof DagsterBootstrapConfigSchema.infer;
+
+/** HelmRelease Ready-condition CEL, by the release resource id. */
+const HELM_RELEASE_READY_CEL =
+  'dagsterHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "True")';
+
+/**
+ * Conservative default liveness probe for the Dagster daemon.
+ *
+ * When the daemon loses its DB connection it can hang ("too many retries for DB
+ * connection") WITHOUT the container exiting, so k8s never restarts it (seen in
+ * production after a node reschedule). The chart ships no daemon liveness probe,
+ * so we add the dagster-canonical exec check. Thresholds are deliberately loose
+ * to avoid flapping during a slow startup or transient DB blip.
+ */
+const DEFAULT_DAEMON_LIVENESS_PROBE: TypeKroValueTreeObject = {
+  exec: { command: ['dagster-daemon', 'liveness-check'] },
+  initialDelaySeconds: 120,
+  periodSeconds: 60,
+  timeoutSeconds: 10,
+  failureThreshold: 5,
+};
+
+/**
+ * The default liveness probe as a CEL map literal (cel-go / KRO syntax) for the
+ * KRO-mode fallback expression. Kept in sync with DEFAULT_DAEMON_LIVENESS_PROBE.
+ */
+const DEFAULT_DAEMON_LIVENESS_PROBE_CEL =
+  '{"exec": {"command": ["dagster-daemon", "liveness-check"]}, ' +
+  '"initialDelaySeconds": 120, "periodSeconds": 60, "timeoutSeconds": 10, "failureThreshold": 5}';
 
 /**
  * High-level Dagster bootstrap composition.
@@ -36,6 +68,42 @@ export const dagsterBootstrap = kubernetesComposition(
     const resolvedNamespace = spec.namespace || 'dagster';
     const resolvedVersion = spec.version || DEFAULT_DAGSTER_VERSION;
     const helmValues = buildHelmValues(spec);
+
+    // Readiness must reflect a REAL workload, not just Flux's HelmRelease Ready
+    // condition. We observe the chart's webserver Deployment via externalRef and
+    // fold its readiness into `ready`.
+    //
+    // SCOPE NOTE — webserver only, on purpose. The daemon and bundled postgres
+    // are deployed only conditionally (daemon.enabled, external-vs-bundled pg),
+    // and that condition is PER-INSTANCE. But:
+    //   1. KRO status CEL cannot reference schema.spec (probed live, kro 0.9.2),
+    //      so a daemon/postgres readiness term cannot be re-gated per instance.
+    //   2. The KRO RGD is built once from a schema proxy and shared by every
+    //      instance, so the build-time spec can't decide per-instance presence.
+    //   3. A conditional `externalRef(...)` call is hoisted by the composition
+    //      analyzer into a broken placeholder resource (kind: ExternalRef), so it
+    //      can't be cleanly omitted either.
+    // Requiring a daemon/postgres that a given instance disabled would make
+    // `ready` hang forever. The webserver is the one workload the chart ALWAYS
+    // creates for every instance, so observing it is both honest and hang-safe.
+    // Daemon/postgres therefore stay on the HelmRelease signal (see components).
+    const WEBSERVER_ID = 'dagsterWebserverDeployment';
+
+    // Webserver Deployment name. We build this as ONE CEL expression that mirrors
+    // the chart's `dagster.fullname` template exactly (incl. the `contains` rule)
+    // rather than computing it from `spec.*` in JS: in KRO mode `spec.name` is a
+    // proxy, so a JS template-literal (`${spec.name}-...`) leaks raw ref markers
+    // and a JS-side trunc mangles the embedded template. CEL evaluates it at
+    // instance time against the real release name. Verified live: release
+    // `dagster` → `dagster-dagster-webserver`.
+    //   fullname = fullnameOverride
+    //            ? fullnameOverride
+    //            : name.contains(chartName) ? name : name + "-" + chartName
+    //   chartName = nameOverride ?? "dagster"
+    //   webserver = fullname + "-dagster-webserver"
+    // (No trunc(63): foundry release names are short; the fullname-derived name
+    // stays well under the 63-char object-name cap.)
+    const webserverName = webserverNameCel();
 
     const _dagsterNamespace = namespace({
       metadata: {
@@ -73,14 +141,34 @@ export const dagsterBootstrap = kubernetesComposition(
       id: 'dagsterHelmRelease',
     });
 
+    // Unconditional externalRef (no `if` guard) so the analyzer emits a real
+    // externalRef entry, not a placeholder stub. The webserver is always present.
+    externalRef({
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: { name: webserverName as unknown as string, namespace: resolvedNamespace },
+      id: WEBSERVER_ID,
+    });
+
     const helmRepositoryReady = _dagsterHelmRepository.status.ready;
     const helmReleaseReady = Cel.expr<boolean>(
       _dagsterHelmRelease.status.conditions,
       '.exists(c, c.type == "Ready" && c.status == "True")'
     );
 
+    // Null-safe webserver readiness. KRO CEL supports has(); guarding the status
+    // path makes the term evaluate to `false` (never an eval error) before the
+    // observed Deployment exists during install.
+    const webserverReady = Cel.expr<boolean>(deploymentReadyCel(WEBSERVER_ID));
+
+    // `ready` = HelmRelease Ready AND the webserver Deployment is up. Both terms
+    // reference resources always present for every instance, so this never hangs.
+    const ready = Cel.expr<boolean>(
+      `(${HELM_RELEASE_READY_CEL}) && (${deploymentReadyCel(WEBSERVER_ID)})`
+    );
+
     return {
-      ready: helmReleaseReady,
+      ready,
       phase: Cel.expr<'Ready' | 'Installing' | 'Failed'>(
         'dagsterHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "False") ' +
           '? "Failed" : dagsterHelmRelease.status.conditions.exists(c, c.type == "Ready" && ' +
@@ -94,13 +182,39 @@ export const dagsterBootstrap = kubernetesComposition(
       components: {
         helmRepository: helmRepositoryReady,
         helmRelease: helmReleaseReady,
-        webserver: helmReleaseReady,
+        // Honest: reflects the actual webserver Deployment.
+        webserver: webserverReady,
+        // daemon/postgres/userDeployments stay on the HelmRelease signal — see
+        // the SCOPE NOTE above for why per-instance-conditional workloads can't
+        // be observed hang-safely in a shared KRO RGD.
+        // TODO: per-code-location user deployments could be observed too (one
+        // Deployment per `userDeployments.deployments[*].name`); their names are
+        // user-driven, so left as the HelmRelease signal for now.
         daemon: helmReleaseReady,
         userDeployments: helmReleaseReady,
       },
     };
   }
 );
+
+/** Null-safe Deployment readiness CEL referencing an observed resource by id. */
+function deploymentReadyCel(id: string): string {
+  return `has(${id}.status) && has(${id}.status.availableReplicas) && ${id}.status.availableReplicas >= 1`;
+}
+
+/**
+ * Webserver Deployment name as a CEL expression mirroring the chart's
+ * `dagster.fullname` template. Built as a CEL string (not JS interpolation of
+ * the schema proxy) so it resolves correctly at KRO instance time.
+ */
+function webserverNameCel() {
+  const chartName = 'has(schema.spec.nameOverride) ? schema.spec.nameOverride : "dagster"';
+  const fullname =
+    'has(schema.spec.fullnameOverride) ? schema.spec.fullnameOverride : ' +
+    `(schema.spec.name.contains(${chartName}) ? schema.spec.name : ` +
+    `schema.spec.name + "-" + (${chartName}))`;
+  return Cel.expr<string>(`(${fullname}) + "-dagster-webserver"`);
+}
 
 function buildHelmValues(spec: DagsterBootstrapSchemaConfig) {
   return mapDagsterConfigToHelmValues(buildMapperConfig(spec));
@@ -117,7 +231,7 @@ function buildMapperConfig(spec: DagsterBootstrapSchemaConfig): DagsterBootstrap
     spec.rbacEnabled !== undefined && { rbacEnabled: spec.rbacEnabled },
     spec.imagePullSecrets !== undefined && { imagePullSecrets: spec.imagePullSecrets },
     spec.webserver !== undefined && { webserver: spec.webserver },
-    spec.daemon !== undefined && { daemon: spec.daemon },
+    { daemon: resolveDaemonConfig(spec.daemon) },
     spec.userDeployments !== undefined && { userDeployments: spec.userDeployments },
     spec.postgresql !== undefined && { postgresql: spec.postgresql },
     spec.runLauncher !== undefined && { runLauncher: spec.runLauncher },
@@ -130,4 +244,47 @@ function buildMapperConfig(spec: DagsterBootstrapSchemaConfig): DagsterBootstrap
     spec.global !== undefined && { global: spec.global },
     spec.values !== undefined && { values: spec.values }
   ) as DagsterBootstrapConfig;
+}
+
+/**
+ * Apply the default daemon liveness probe when the daemon is enabled and the
+ * user supplied none. A user-supplied `daemon.livenessProbe` always wins, and
+ * the default is never applied when the daemon is disabled.
+ *
+ * Two modes:
+ *  - Direct mode (concrete spec): `daemon.livenessProbe` is a real value, so we
+ *    inject the default object only when it is genuinely absent (undefined).
+ *  - KRO mode (schema proxy): `daemon` / `daemon.livenessProbe` are KubernetesRefs
+ *    that are never `undefined` at build time and resolve per instance. We can't
+ *    branch in JS, so we emit a CEL fallback into the (schema-ref-allowed) chart
+ *    values: `has(schema.spec.daemon.livenessProbe) ? <user> : <default>`. The
+ *    default is a CEL map literal that cel-go (KRO) evaluates at instance time.
+ */
+function resolveDaemonConfig(
+  daemon: DagsterBootstrapSchemaConfig['daemon']
+): DagsterBootstrapConfig['daemon'] {
+  // Daemon explicitly disabled (concrete false) → never inject a probe.
+  if (daemon?.enabled === false) return daemon as DagsterBootstrapConfig['daemon'];
+
+  const probe: unknown = daemon?.livenessProbe;
+
+  // KRO mode: probe field is a schema proxy. Emit a CEL fallback so a user probe
+  // wins per instance and the default applies otherwise.
+  if (isKubernetesRef(probe) || isKubernetesRef(daemon)) {
+    return {
+      ...((daemon ?? {}) as object),
+      livenessProbe: Cel.expr<TypeKroValueTreeObject>(
+        `has(schema.spec.daemon) && has(schema.spec.daemon.livenessProbe) ? ` +
+          `schema.spec.daemon.livenessProbe : ${DEFAULT_DAEMON_LIVENESS_PROBE_CEL}`
+      ) as unknown as TypeKroValueTreeObject,
+    } as DagsterBootstrapConfig['daemon'];
+  }
+
+  // Direct mode: concrete value present → user wins; absent → inject default.
+  if (probe !== undefined) return daemon as DagsterBootstrapConfig['daemon'];
+
+  return {
+    ...(daemon ?? {}),
+    livenessProbe: DEFAULT_DAEMON_LIVENESS_PROBE,
+  } as DagsterBootstrapConfig['daemon'];
 }

--- a/src/factories/dagster/compositions/dagster-bootstrap.ts
+++ b/src/factories/dagster/compositions/dagster-bootstrap.ts
@@ -89,21 +89,29 @@ export const dagsterBootstrap = kubernetesComposition(
     // Daemon/postgres therefore stay on the HelmRelease signal (see components).
     const WEBSERVER_ID = 'dagsterWebserverDeployment';
 
-    // Webserver Deployment name. We build this as ONE CEL expression that mirrors
-    // the chart's `dagster.fullname` template exactly (incl. the `contains` rule)
-    // rather than computing it from `spec.*` in JS: in KRO mode `spec.name` is a
-    // proxy, so a JS template-literal (`${spec.name}-...`) leaks raw ref markers
-    // and a JS-side trunc mangles the embedded template. CEL evaluates it at
-    // instance time against the real release name. Verified live: release
-    // `dagster` → `dagster-dagster-webserver`.
-    //   fullname = fullnameOverride
-    //            ? fullnameOverride
-    //            : name.contains(chartName) ? name : name + "-" + chartName
-    //   chartName = nameOverride ?? "dagster"
-    //   webserver = fullname + "-dagster-webserver"
-    // (No trunc(63): foundry release names are short; the fullname-derived name
-    // stays well under the 63-char object-name cap.)
-    const webserverName = webserverNameCel();
+    // Webserver Deployment name. The chart's `dagster.webserver.fullname` is
+    //   {{ .Release.Name }}-{{ default "webserver" .Values.dagsterWebserver.nameOverride }}
+    // and the chart DEFAULTS `dagsterWebserver.nameOverride` to "dagster-webserver"
+    // (values.yaml), so the Deployment is `<Release.Name>-dagster-webserver`. The Flux
+    // release name is this composition's `spec.name` (the HelmRelease is created with
+    // `name: spec.name`, no releaseName/targetNamespace prefix — confirmed live: postgres
+    // is `<spec.name>-postgresql`, not namespace-prefixed). So the name is simply
+    // `${spec.name}-dagster-webserver`.
+    //
+    // IMPORTANT: the webserver helper uses `.Release.Name` DIRECTLY — NOT `dagster.fullname`
+    // (the global-override-aware helper the daemon/postgres helpers use). Folding in
+    // fullname/`contains`/nameOverride logic here is WRONG: for a release name that doesn't
+    // contain "dagster", `dagster.fullname` becomes `<name>-dagster`, yielding
+    // `<name>-dagster-dagster-webserver` — a Deployment that doesn't exist, so `ready` would
+    // hang forever. typekro's webserver spec exposes no per-webserver nameOverride, so the
+    // chart default ("dagster-webserver") always applies.
+    //
+    // NB: written as a Cel.expr string, not Cel.template, because of a serializer quirk — the
+    // externalRef `name` gets swept into the hybrid `has(spec.X) ? _ : _` conditional emitted for a
+    // nearby `||` binding (e.g. `spec.version || DEFAULT`). With Cel.expr both branches are an
+    // identical valid sub-expression (a harmless no-op guard); with Cel.template the branches carry
+    // `${...}` and nest illegally. (Tracked separately as a JS→CEL serialization bug to fix upstream.)
+    const webserverName = Cel.expr<string>('schema.spec.name + "-dagster-webserver"');
 
     const _dagsterNamespace = namespace({
       metadata: {
@@ -146,7 +154,7 @@ export const dagsterBootstrap = kubernetesComposition(
     externalRef({
       apiVersion: 'apps/v1',
       kind: 'Deployment',
-      metadata: { name: webserverName as unknown as string, namespace: resolvedNamespace },
+      metadata: { name: webserverName, namespace: resolvedNamespace },
       id: WEBSERVER_ID,
     });
 
@@ -207,14 +215,6 @@ function deploymentReadyCel(id: string): string {
  * `dagster.fullname` template. Built as a CEL string (not JS interpolation of
  * the schema proxy) so it resolves correctly at KRO instance time.
  */
-function webserverNameCel() {
-  const chartName = 'has(schema.spec.nameOverride) ? schema.spec.nameOverride : "dagster"';
-  const fullname =
-    'has(schema.spec.fullnameOverride) ? schema.spec.fullnameOverride : ' +
-    `(schema.spec.name.contains(${chartName}) ? schema.spec.name : ` +
-    `schema.spec.name + "-" + (${chartName}))`;
-  return Cel.expr<string>(`(${fullname}) + "-dagster-webserver"`);
-}
 
 function buildHelmValues(spec: DagsterBootstrapSchemaConfig) {
   return mapDagsterConfigToHelmValues(buildMapperConfig(spec));

--- a/src/factories/dagster/compositions/dagster-bootstrap.ts
+++ b/src/factories/dagster/compositions/dagster-bootstrap.ts
@@ -1,7 +1,6 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
 import { Cel } from '../../../core/references/cel.js';
-import { externalRef } from '../../../core/references/external-refs.js';
 import { singleton } from '../../../core/singleton/singleton.js';
 import type { TypeKroValueTreeObject } from '../../../core/types/common.js';
 import { isKubernetesRef } from '../../../utils/type-guards.js';
@@ -21,10 +20,6 @@ import { mapDagsterConfigToHelmValues } from '../utils/helm-values-mapper.js';
 import { dagsterHelmRepositoryBootstrap } from './dagster-helm-repository.js';
 
 type DagsterBootstrapSchemaConfig = typeof DagsterBootstrapConfigSchema.infer;
-
-/** HelmRelease Ready-condition CEL, by the release resource id. */
-const HELM_RELEASE_READY_CEL =
-  'dagsterHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "True")';
 
 /**
  * Conservative default liveness probe for the Dagster daemon.
@@ -69,50 +64,17 @@ export const dagsterBootstrap = kubernetesComposition(
     const resolvedVersion = spec.version || DEFAULT_DAGSTER_VERSION;
     const helmValues = buildHelmValues(spec);
 
-    // Readiness must reflect a REAL workload, not just Flux's HelmRelease Ready
-    // condition. We observe the chart's webserver Deployment via externalRef and
-    // fold its readiness into `ready`.
+    // Readiness is the Flux HelmRelease Ready condition. The HelmRelease does not set
+    // `disableWait`, so helm-controller waits for the release's workloads (webserver, daemon,
+    // bundled postgres) to become ready before it reports Ready — i.e. `helmReleaseReady` is
+    // already workload-aware, and the consuming layer gates its converge on this status.
     //
-    // SCOPE NOTE — webserver only, on purpose. The daemon and bundled postgres
-    // are deployed only conditionally (daemon.enabled, external-vs-bundled pg),
-    // and that condition is PER-INSTANCE. But:
-    //   1. KRO status CEL cannot reference schema.spec (probed live, kro 0.9.2),
-    //      so a daemon/postgres readiness term cannot be re-gated per instance.
-    //   2. The KRO RGD is built once from a schema proxy and shared by every
-    //      instance, so the build-time spec can't decide per-instance presence.
-    //   3. A conditional `externalRef(...)` call is hoisted by the composition
-    //      analyzer into a broken placeholder resource (kind: ExternalRef), so it
-    //      can't be cleanly omitted either.
-    // Requiring a daemon/postgres that a given instance disabled would make
-    // `ready` hang forever. The webserver is the one workload the chart ALWAYS
-    // creates for every instance, so observing it is both honest and hang-safe.
-    // Daemon/postgres therefore stay on the HelmRelease signal (see components).
-    const WEBSERVER_ID = 'dagsterWebserverDeployment';
-
-    // Webserver Deployment name. The chart's `dagster.webserver.fullname` is
-    //   {{ .Release.Name }}-{{ default "webserver" .Values.dagsterWebserver.nameOverride }}
-    // and the chart DEFAULTS `dagsterWebserver.nameOverride` to "dagster-webserver"
-    // (values.yaml), so the Deployment is `<Release.Name>-dagster-webserver`. The Flux
-    // release name is this composition's `spec.name` (the HelmRelease is created with
-    // `name: spec.name`, no releaseName/targetNamespace prefix — confirmed live: postgres
-    // is `<spec.name>-postgresql`, not namespace-prefixed). So the name is simply
-    // `${spec.name}-dagster-webserver`.
-    //
-    // IMPORTANT: the webserver helper uses `.Release.Name` DIRECTLY — NOT `dagster.fullname`
-    // (the global-override-aware helper the daemon/postgres helpers use). Folding in
-    // fullname/`contains`/nameOverride logic here is WRONG: for a release name that doesn't
-    // contain "dagster", `dagster.fullname` becomes `<name>-dagster`, yielding
-    // `<name>-dagster-dagster-webserver` — a Deployment that doesn't exist, so `ready` would
-    // hang forever. typekro's webserver spec exposes no per-webserver nameOverride, so the
-    // chart default ("dagster-webserver") always applies.
-    //
-    // NB: written as a Cel.expr string, not Cel.template, because of a serializer quirk — the
-    // externalRef `name` gets swept into the hybrid `has(spec.X) ? _ : _` conditional emitted for a
-    // nearby `||` binding (e.g. `spec.version || DEFAULT`). With Cel.expr both branches are an
-    // identical valid sub-expression (a harmless no-op guard); with Cel.template the branches carry
-    // `${...}` and nest illegally. (Tracked separately as a JS→CEL serialization bug to fix upstream.)
-    const webserverName = Cel.expr<string>('schema.spec.name + "-dagster-webserver"');
-
+    // We deliberately do NOT observe the individual Deployments via externalRef. KRO's externalRef
+    // is name-keyed (no label selector), and the chart's per-workload names are a fragile function
+    // of `.Release.Name` + per-component `nameOverride`s (settable via raw `values`); reconstructing
+    // them in CEL risks pinning `ready` to false forever on a name mismatch — for no signal beyond
+    // the wait-gated HelmRelease. Per-instance daemon/postgres health (which a shared, schema-proxy
+    // RGD can't conditionalize anyway) is covered post-deploy by the deploying layer's readiness gate.
     const _dagsterNamespace = namespace({
       metadata: {
         name: resolvedNamespace,
@@ -149,34 +111,14 @@ export const dagsterBootstrap = kubernetesComposition(
       id: 'dagsterHelmRelease',
     });
 
-    // Unconditional externalRef (no `if` guard) so the analyzer emits a real
-    // externalRef entry, not a placeholder stub. The webserver is always present.
-    externalRef({
-      apiVersion: 'apps/v1',
-      kind: 'Deployment',
-      metadata: { name: webserverName, namespace: resolvedNamespace },
-      id: WEBSERVER_ID,
-    });
-
     const helmRepositoryReady = _dagsterHelmRepository.status.ready;
     const helmReleaseReady = Cel.expr<boolean>(
       _dagsterHelmRelease.status.conditions,
       '.exists(c, c.type == "Ready" && c.status == "True")'
     );
 
-    // Null-safe webserver readiness. KRO CEL supports has(); guarding the status
-    // path makes the term evaluate to `false` (never an eval error) before the
-    // observed Deployment exists during install.
-    const webserverReady = Cel.expr<boolean>(deploymentReadyCel(WEBSERVER_ID));
-
-    // `ready` = HelmRelease Ready AND the webserver Deployment is up. Both terms
-    // reference resources always present for every instance, so this never hangs.
-    const ready = Cel.expr<boolean>(
-      `(${HELM_RELEASE_READY_CEL}) && (${deploymentReadyCel(WEBSERVER_ID)})`
-    );
-
     return {
-      ready,
+      ready: helmReleaseReady,
       phase: Cel.expr<'Ready' | 'Installing' | 'Failed'>(
         'dagsterHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "False") ' +
           '? "Failed" : dagsterHelmRelease.status.conditions.exists(c, c.type == "Ready" && ' +
@@ -187,34 +129,18 @@ export const dagsterBootstrap = kubernetesComposition(
         '.exists(c, c.type == "Ready" && c.status == "False")'
       ),
       version: resolvedVersion,
+      // Component readiness reflects the wait-gated HelmRelease (a Ready release means its
+      // workloads are ready). Per-workload observation was removed — see the readiness note above.
       components: {
         helmRepository: helmRepositoryReady,
         helmRelease: helmReleaseReady,
-        // Honest: reflects the actual webserver Deployment.
-        webserver: webserverReady,
-        // daemon/postgres/userDeployments stay on the HelmRelease signal — see
-        // the SCOPE NOTE above for why per-instance-conditional workloads can't
-        // be observed hang-safely in a shared KRO RGD.
-        // TODO: per-code-location user deployments could be observed too (one
-        // Deployment per `userDeployments.deployments[*].name`); their names are
-        // user-driven, so left as the HelmRelease signal for now.
+        webserver: helmReleaseReady,
         daemon: helmReleaseReady,
         userDeployments: helmReleaseReady,
       },
     };
   }
 );
-
-/** Null-safe Deployment readiness CEL referencing an observed resource by id. */
-function deploymentReadyCel(id: string): string {
-  return `has(${id}.status) && has(${id}.status.availableReplicas) && ${id}.status.availableReplicas >= 1`;
-}
-
-/**
- * Webserver Deployment name as a CEL expression mirroring the chart's
- * `dagster.fullname` template. Built as a CEL string (not JS interpolation of
- * the schema proxy) so it resolves correctly at KRO instance time.
- */
 
 function buildHelmValues(spec: DagsterBootstrapSchemaConfig) {
   return mapDagsterConfigToHelmValues(buildMapperConfig(spec));

--- a/src/factories/dagster/types.ts
+++ b/src/factories/dagster/types.ts
@@ -28,17 +28,17 @@ import { type } from 'arktype';
 import type { ValuesMergeExpression } from '../../core/aspects/values-merge.js';
 import type { TypeKroError } from '../../core/errors.js';
 import type {
+  TypeKroChartValue,
+  TypeKroValueTree,
+  TypeKroValueTreeObject,
+} from '../../core/types/common.js';
+import type {
   Composable,
   DirectResourceFactory,
   Enhanced,
   KroResourceFactory,
   PublicFactoryOptions,
 } from '../../core/types/index.js';
-import type {
-  TypeKroChartValue,
-  TypeKroValueTree,
-  TypeKroValueTreeObject,
-} from '../../core/types/common.js';
 import type { HelmRepositorySpec, HelmRepositoryStatus } from '../helm/helm-repository.js';
 import type { HelmReleaseSpec, HelmReleaseStatus } from '../helm/types.js';
 
@@ -227,6 +227,9 @@ const daemonSchemaShape = {
   'runRetries?': objectMapSchema,
   'sensors?': objectMapSchema,
   'schedules?': objectMapSchema,
+  'readinessProbe?': objectMapSchema,
+  'livenessProbe?': objectMapSchema,
+  'startupProbe?': objectMapSchema,
 } as const;
 
 const userDeploymentSchema = type({
@@ -258,8 +261,10 @@ const userDeploymentSchema = type({
   'deploymentStrategy?': objectMapSchema,
   'service?': { 'annotations?': 'Record<string, string>' },
 }).narrow((deployment, ctx) => {
-  const hasGrpcArgs = Array.isArray(deployment.dagsterApiGrpcArgs) && deployment.dagsterApiGrpcArgs.length > 0;
-  const hasCodeServerArgs = Array.isArray(deployment.codeServerArgs) && deployment.codeServerArgs.length > 0;
+  const hasGrpcArgs =
+    Array.isArray(deployment.dagsterApiGrpcArgs) && deployment.dagsterApiGrpcArgs.length > 0;
+  const hasCodeServerArgs =
+    Array.isArray(deployment.codeServerArgs) && deployment.codeServerArgs.length > 0;
 
   if (hasGrpcArgs !== hasCodeServerArgs) return true;
 
@@ -618,6 +623,10 @@ export interface DagsterDaemonConfig extends DagsterPodConfig {
   sensors?: TypeKroValueTreeObject;
   /** Schedule evaluation convenience config. */
   schedules?: TypeKroValueTreeObject;
+  /** Startup/readiness/liveness probe overrides for the daemon container. */
+  readinessProbe?: TypeKroValueTreeObject;
+  livenessProbe?: TypeKroValueTreeObject;
+  startupProbe?: TypeKroValueTreeObject;
 }
 
 /** One Dagster user-code deployment served through gRPC or code-server. */
@@ -1096,16 +1105,20 @@ export type DagsterUtilitySignature<
 };
 
 /** Direct resource factory with explicit Dagster operation error shape. */
-export type DagsterDirectFactoryWithErrors<TSpec extends object, TStatus extends object> =
-  DirectResourceFactory<TSpec, TStatus> & {
-    readonly errorType?: DagsterOperationError;
-  };
+export type DagsterDirectFactoryWithErrors<
+  TSpec extends object,
+  TStatus extends object,
+> = DirectResourceFactory<TSpec, TStatus> & {
+  readonly errorType?: DagsterOperationError;
+};
 
 /** KRO resource factory with explicit Dagster operation error shape. */
-export type DagsterKroFactoryWithErrors<TSpec extends object, TStatus extends object> =
-  KroResourceFactory<TSpec, TStatus> & {
-    readonly errorType?: DagsterOperationError;
-  };
+export type DagsterKroFactoryWithErrors<
+  TSpec extends object,
+  TStatus extends object,
+> = KroResourceFactory<TSpec, TStatus> & {
+  readonly errorType?: DagsterOperationError;
+};
 
 /** Public Dagster factory and composition error boundary map. */
 export interface DagsterFactoryErrorBoundary {

--- a/src/factories/dagster/utils/helm-values-mapper.ts
+++ b/src/factories/dagster/utils/helm-values-mapper.ts
@@ -17,9 +17,9 @@ import type { TypeKroValueTree, TypeKroValueTreeObject } from '../../../core/typ
 import { isCelExpression, isKubernetesRef } from '../../../utils/type-guards.js';
 import type {
   DagsterBootstrapConfig,
-  DagsterConfigValidationResult,
   DagsterConfigurationErrorCode,
   DagsterConfigurationIssue,
+  DagsterConfigValidationResult,
   DagsterHelmValues,
   DagsterImageConfig,
   DagsterMappedHelmValues,
@@ -59,7 +59,9 @@ export class DagsterConfigurationValidationError extends TypeKroError {
 }
 
 /** Validate cross-field Dagster config rules that ArkType cannot express alone. */
-export function validateDagsterConfig(config: DagsterBootstrapConfig): DagsterConfigValidationResult {
+export function validateDagsterConfig(
+  config: DagsterBootstrapConfig
+): DagsterConfigValidationResult {
   const issues: DagsterConfigurationIssue[] = [];
 
   validateUserDeployments(config, issues);
@@ -128,8 +130,7 @@ function validateUserDeployments(
         code: 'DAGSTER_REQUIRED_CONFIG_MISSING',
         path: `userDeployments.deployments[${index}]`,
         component: 'userDeployments',
-        message:
-          'Each typed Dagster user deployment must set exactly one server argument field.',
+        message: 'Each typed Dagster user deployment must set exactly one server argument field.',
       });
     }
   });
@@ -149,7 +150,8 @@ function validateRunLauncher(
     !!config.redis?.brokerUrl ||
     !!config.redis?.backendUrl;
   const hasSecret = !!config.global?.celeryConfigSecretName;
-  const hasRawCeleryConfig = hasRawPath(config.values, 'runLauncher') || hasRawPath(config.values, 'redis');
+  const hasRawCeleryConfig =
+    hasRawPath(config.values, 'runLauncher') || hasRawPath(config.values, 'redis');
 
   if (!hasRabbitmq && !hasRedis && !hasSecret && !hasRawCeleryConfig) {
     issues.push({
@@ -277,12 +279,21 @@ function mapDaemonConfig(
   setIfDefined(mapped, 'runRetries', copyDefinedObject(daemon.runRetries));
   setIfDefined(mapped, 'sensors', copyDefinedObject(daemon.sensors));
   setIfDefined(mapped, 'schedules', copyDefinedObject(daemon.schedules));
+  // Forward probe overrides to the chart. The webserver path forwards these too;
+  // omitting them here silently dropped any user-supplied daemon probe so a hung
+  // daemon (e.g. "too many retries for DB connection") would never be restarted.
+  setIfDefined(mapped, 'readinessProbe', copyDefinedObject(daemon.readinessProbe));
+  setIfDefined(mapped, 'livenessProbe', copyDefinedObject(daemon.livenessProbe));
+  setIfDefined(mapped, 'startupProbe', copyDefinedObject(daemon.startupProbe));
   mapPodConfig(mapped, daemon);
 
   return mapped;
 }
 
-function mapPodConfig(target: TypeKroValueTreeObject, podConfig: NonNullable<DagsterBootstrapConfig['webserver']>): void {
+function mapPodConfig(
+  target: TypeKroValueTreeObject,
+  podConfig: NonNullable<DagsterBootstrapConfig['webserver']>
+): void {
   setIfDefined(target, 'labels', podConfig.labels);
   setIfDefined(target, 'nodeSelector', podConfig.nodeSelector);
   setIfDefined(target, 'affinity', copyDefinedObject(podConfig.affinity));
@@ -303,7 +314,11 @@ function mapUserDeployments(config: DagsterBootstrapConfig): TypeKroValueTreeObj
 
   const mapped: TypeKroValueTreeObject = {};
   setIfDefined(mapped, 'enabled', userDeployments.enabled);
-  setIfDefined(mapped, 'enableSubchart', userDeployments.enableSubchart ?? userDeployments.enabled ?? false);
+  setIfDefined(
+    mapped,
+    'enableSubchart',
+    userDeployments.enableSubchart ?? userDeployments.enabled ?? false
+  );
   setIfDefined(mapped, 'imagePullSecrets', copyDefinedArray(userDeployments.imagePullSecrets));
 
   const deployments = userDeployments.deployments;
@@ -374,7 +389,11 @@ function mapRunLauncher(config: DagsterBootstrapConfig): TypeKroValueTreeObject 
     'celeryK8sRunLauncher',
     copyDefinedObject(runLauncher.celeryK8sRunLauncher)
   );
-  setIfDefined(launcherConfig, 'customRunLauncher', copyDefinedObject(runLauncher.customRunLauncher));
+  setIfDefined(
+    launcherConfig,
+    'customRunLauncher',
+    copyDefinedObject(runLauncher.customRunLauncher)
+  );
 
   if (Object.keys(launcherConfig).length > 0) {
     mapped.config = launcherConfig;
@@ -425,10 +444,7 @@ function mapRedis(config: DagsterBootstrapConfig): DagsterRuntimeValueTree | und
   return mergeSubValues(mapped, redis.values);
 }
 
-function mergeSubValues(
-  mapped: TypeKroValueTreeObject,
-  values: unknown
-): DagsterRuntimeValueTree {
+function mergeSubValues(mapped: TypeKroValueTreeObject, values: unknown): DagsterRuntimeValueTree {
   if (values === undefined) return mapped;
   if (isKubernetesRef(values) || isCelExpression(values) || isValuesMergeExpression(values)) {
     return mergeValuesExpression(mapped, values);
@@ -443,7 +459,8 @@ function mergeSubValues(
 }
 
 function isEmittableValue(value: DagsterRuntimeValueTree): boolean {
-  if (isValuesMergeExpression(value) || isKubernetesRef(value) || isCelExpression(value)) return true;
+  if (isValuesMergeExpression(value) || isKubernetesRef(value) || isCelExpression(value))
+    return true;
   return !isMergeObject(value) || Object.keys(value).length > 0;
 }
 
@@ -513,7 +530,11 @@ function deepMerge(target: TypeKroValueTreeObject, source: TypeKroValueTreeObjec
   }
 }
 
-function mergeValue(key: string, baseValue: unknown, overlayValue: unknown): DagsterRuntimeValueTree {
+function mergeValue(
+  key: string,
+  baseValue: unknown,
+  overlayValue: unknown
+): DagsterRuntimeValueTree {
   if (baseValue === undefined) return overlayValue as DagsterRuntimeValueTree;
   if (overlayValue === undefined) return baseValue as DagsterRuntimeValueTree;
 
@@ -545,7 +566,11 @@ function mergeRawValuesLast(
   rawValues: unknown
 ): DagsterMappedHelmValues {
   if (rawValues === undefined) return baseValues;
-  if (isKubernetesRef(rawValues) || isCelExpression(rawValues) || isValuesMergeExpression(rawValues)) {
+  if (
+    isKubernetesRef(rawValues) ||
+    isCelExpression(rawValues) ||
+    isValuesMergeExpression(rawValues)
+  ) {
     return createDagsterValuesMerge(baseValues, rawValues);
   }
 
@@ -561,7 +586,11 @@ function createDagsterValuesMerge(
   baseValues: DagsterHelmValues,
   rawValues: unknown
 ): ValuesMergeExpression {
-  if (!isKubernetesRef(rawValues) && !isCelExpression(rawValues) && !isValuesMergeExpression(rawValues)) {
+  if (
+    !isKubernetesRef(rawValues) &&
+    !isCelExpression(rawValues) &&
+    !isValuesMergeExpression(rawValues)
+  ) {
     throw new DagsterConfigurationValidationError(
       'DAGSTER_INVALID_CONFIG',
       'DagsterConfigurationError DAGSTER_INVALID_CONFIG: values',
@@ -570,7 +599,8 @@ function createDagsterValuesMerge(
           {
             code: 'DAGSTER_INVALID_CONFIG',
             path: 'values',
-            message: 'Graph-aware raw values merge requires a KubernetesRef, CEL expression, or values merge expression.',
+            message:
+              'Graph-aware raw values merge requires a KubernetesRef, CEL expression, or values merge expression.',
           },
         ],
       }

--- a/test/core/composition/hybrid-spec.test.ts
+++ b/test/core/composition/hybrid-spec.test.ts
@@ -5,6 +5,8 @@
 import { describe, it, expect } from 'bun:test';
 import { type } from 'arktype';
 import { kubernetesComposition } from '../../../src/core/composition/imperative.js';
+import { Cel } from '../../../src/core/references/cel.js';
+import { externalRef } from '../../../src/core/references/external-refs.js';
 
 describe('Hybrid Spec in Composition Functions', () => {
   const TestSpecSchema = type({
@@ -108,5 +110,43 @@ describe('Hybrid Spec in Composition Functions', () => {
 
     expect(testComposition).toBeDefined();
     expect(testComposition.name).toBe('nested-hybrid-test');
+  });
+
+  it('collapses a no-op has() conditional instead of guarding an unrelated `||` field', () => {
+    // Regression: when a composition has an optional field with a `||` default (here `version`)
+    // AND a separate resource field built from a CEL expression over a DIFFERENT field (`name`),
+    // the proxy/hybrid serialization passes diverge structurally on that leaf but render to the
+    // IDENTICAL CEL. The serializer used to emit `has(schema.spec.version) ? <expr> : <expr>` —
+    // a no-op guard keyed on the WRONG field (pickConditionField's first-overridden fallback),
+    // misleading and, for `${...}`-bearing reprs, structurally invalid. It must now emit `<expr>`.
+    const Spec = type({ name: 'string', 'version?': 'string' });
+    const Status = type({ ready: 'boolean', version: 'string' });
+    const comp = kubernetesComposition(
+      {
+        name: 'noop-conditional-collapse',
+        apiVersion: 'test.example.com/v1alpha1',
+        kind: 'NoopCollapse',
+        spec: Spec,
+        status: Status,
+      },
+      (spec) => {
+        const version = spec.version || 'latest'; // unrelated `||` default → an "overridden field"
+        externalRef({
+          apiVersion: 'apps/v1',
+          kind: 'Deployment',
+          metadata: { name: Cel.expr<string>('schema.spec.name + "-webserver"') },
+          id: 'observed',
+        });
+        return {
+          ready: Cel.expr<boolean>('has(observed.status) && observed.status.availableReplicas >= 1'),
+          version,
+        };
+      }
+    );
+
+    const yaml = comp.toYaml();
+    // The observed Deployment name is the clean expression — no guard, no identical-branch ternary.
+    expect(yaml).toContain('${schema.spec.name + "-webserver"}');
+    expect(yaml).not.toContain('has(schema.spec.version) ? schema.spec.name');
   });
 });

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { load } from 'js-yaml';
 import {
   dagsterBootstrap,
   dagsterHelmRepositoryBootstrap,
@@ -89,9 +90,15 @@ describe('Dagster bootstrap composition', () => {
     expect(yaml).toContain('kind: HelmRepository');
     expect(yaml).toContain('chart: dagster');
     expect(yaml).toContain('1.13.8');
-    expect(yaml).toContain('ready: ${dagsterHelmRelease.status.conditions');
+    // Honest readiness: `ready` now combines the HelmRelease Ready condition AND
+    // the observed webserver Deployment status (null-safe via has()).
+    expect(yaml).toContain('ready: ${(dagsterHelmRelease.status.conditions');
+    expect(yaml).toContain('dagsterWebserverDeployment.status.availableReplicas');
     expect(yaml).toContain('phase: "${dagsterHelmRelease.status.conditions');
-    expect(yaml).not.toContain('kind: Deployment');
+    // The webserver is OBSERVED via externalRef (apps/v1 Deployment), not owned —
+    // so a `kind: Deployment` externalRef is expected, but no owned Deployment
+    // template (the chart owns the real workloads).
+    expect(yaml).toContain('kind: Deployment');
     expect(yaml).not.toContain('kind: Pod');
   });
 
@@ -237,5 +244,154 @@ describe('Dagster bootstrap composition', () => {
     expect(yaml).toContain('busybox');
     expect(yaml).not.toContain('undefined');
     expect(yaml).not.toContain('[object Object]');
+  });
+});
+
+describe('Dagster bootstrap honest readiness', () => {
+  // The webserver is the one workload the chart ALWAYS deploys for every
+  // instance, so it is observed via externalRef and folded into `ready`.
+  it('Observe the webserver Deployment via externalRef and reference its status in ready', () => {
+    const yaml = dagsterBootstrap.toYaml();
+
+    // The webserver is referenced as an apps/v1 Deployment externalRef (observed,
+    // not owned — there is no Deployment *template* in the RGD).
+    expect(yaml).toContain('id: dagsterWebserverDeployment');
+    expect(yaml).toContain('apiVersion: apps/v1');
+    expect(yaml).toContain('kind: Deployment');
+
+    // The webserver name mirrors the chart's `dagster.fullname` template as a CEL
+    // expression (resolves at instance time), with no leaked ref markers.
+    expect(yaml).toContain('-dagster-webserver');
+    expect(yaml).toContain('schema.spec.name.contains(');
+    expect(yaml).not.toContain('__KUBERNETES_REF__');
+
+    // `ready` is the HelmRelease Ready condition AND the (null-safe) webserver
+    // Deployment status. has() guards mean it is `false`, never an eval error,
+    // before the Deployment exists during install.
+    expect(yaml).toContain('ready: ${(dagsterHelmRelease.status.conditions');
+    expect(yaml).toContain('has(dagsterWebserverDeployment.status)');
+    expect(yaml).toContain('has(dagsterWebserverDeployment.status.availableReplicas)');
+    expect(yaml).toContain('dagsterWebserverDeployment.status.availableReplicas >= 1');
+  });
+
+  // Hang-safety: a workload that an instance does NOT deploy must never appear in
+  // `ready`. The daemon (conditionally deployed) and the postgres StatefulSet
+  // (only when bundled) are deliberately NOT observed in the shared KRO RGD — KRO
+  // status CEL cannot reference schema.spec to re-gate them per instance, so
+  // requiring them would hang any instance that disables the daemon or uses an
+  // external DB. They stay on the HelmRelease signal.
+  it('Do NOT observe or require the daemon or postgres (no-hang for disabled/external)', () => {
+    const yaml = dagsterBootstrap.toYaml();
+
+    // No externalRef observation for daemon or postgres.
+    expect(yaml).not.toContain('dagsterDaemonDeployment');
+    expect(yaml).not.toContain('dagsterPostgresStatefulSet');
+    // ...so `ready` cannot reference them and cannot hang on an absent workload.
+    expect(yaml).not.toContain('Daemon.status');
+    expect(yaml).not.toContain('Postgres.status');
+    expect(yaml).not.toContain('kind: StatefulSet');
+
+    // No conditional externalRef placeholder leaked into the RGD.
+    expect(yaml).not.toContain('kind: ExternalRef');
+
+    // daemon/userDeployments components fall back to the HelmRelease signal.
+    expect(yaml).toContain('daemon: ${dagsterHelmRelease.status.conditions');
+    expect(yaml).toContain('userDeployments: ${dagsterHelmRelease.status.conditions');
+  });
+
+  it('Resolve the webserver name CEL to the live-verified value for release "dagster"', () => {
+    // Mirror of the emitted CEL fullname rule, validated against the live cluster
+    // observation: release `dagster` (chart `dagster`) → `dagster-dagster-webserver`.
+    const webserverName = (
+      name: string,
+      nameOverride?: string,
+      fullnameOverride?: string
+    ): string => {
+      const chartName = nameOverride ?? 'dagster';
+      const fullname =
+        fullnameOverride ?? (name.includes(chartName) ? name : `${name}-${chartName}`);
+      return `${fullname}-dagster-webserver`;
+    };
+
+    expect(webserverName('dagster')).toBe('dagster-dagster-webserver');
+    expect(webserverName('analytics')).toBe('analytics-dagster-dagster-webserver');
+    expect(webserverName('x', undefined, 'foo')).toBe('foo-dagster-webserver');
+    expect(webserverName('ds-prod', 'ds')).toBe('ds-prod-dagster-webserver');
+  });
+
+  it('Keep phase/failed/version unchanged', () => {
+    const yaml = dagsterBootstrap.toYaml();
+    expect(yaml).toContain('phase: "${dagsterHelmRelease.status.conditions');
+    expect(yaml).toContain('failed: ${dagsterHelmRelease.status.conditions');
+    // `version` is a static/client-hydrated status field, so the RGD schema types
+    // it (not the literal value); the default value still flows through templates.
+    expect(yaml).toContain('version: string');
+    expect(yaml).toContain('1.13.8');
+  });
+});
+
+describe('Dagster bootstrap default daemon liveness probe', () => {
+  async function daemonValues(spec: object): Promise<Record<string, unknown> | undefined> {
+    const factory = dagsterBootstrap.factory('direct', { namespace: 'd' });
+    const yaml = await factory.toYaml(spec as never);
+    const docs = yaml
+      .split(/^---$/m)
+      .map((doc) => doc.trim())
+      .filter(Boolean)
+      .map((doc) => load(doc) as Record<string, unknown>);
+    const helmRelease = docs.find((doc) => doc?.kind === 'HelmRelease');
+    const values = (helmRelease?.spec as { values?: Record<string, unknown> } | undefined)?.values;
+    return values?.dagsterDaemon as Record<string, unknown> | undefined;
+  }
+
+  // When the daemon loses its DB connection it can hang without exiting; the chart
+  // ships no daemon liveness probe, so we add a conservative dagster-canonical one
+  // so k8s restarts it.
+  it('Apply a conservative default liveness probe when the daemon is enabled and none is supplied', async () => {
+    const daemon = await daemonValues({
+      name: 'analytics',
+      namespace: 'd',
+      postgresql: { enabled: true },
+    });
+    expect(daemon?.livenessProbe).toEqual({
+      exec: { command: ['dagster-daemon', 'liveness-check'] },
+      initialDelaySeconds: 120,
+      periodSeconds: 60,
+      timeoutSeconds: 10,
+      failureThreshold: 5,
+    });
+  });
+
+  it('Let a user-supplied daemon livenessProbe override the default', async () => {
+    const userProbe = { httpGet: { path: '/healthz', port: 3070 }, periodSeconds: 15 };
+    const daemon = await daemonValues({
+      name: 'analytics',
+      namespace: 'd',
+      postgresql: { enabled: true },
+      daemon: { livenessProbe: userProbe },
+    });
+    expect(daemon?.livenessProbe).toEqual(userProbe);
+  });
+
+  it('Never inject the default liveness probe when the daemon is disabled', async () => {
+    const daemon = await daemonValues({
+      name: 'analytics',
+      namespace: 'd',
+      postgresql: { enabled: true },
+      daemon: { enabled: false },
+    });
+    expect(daemon?.livenessProbe).toBeUndefined();
+  });
+
+  // In KRO mode the spec is a proxy, so the default is emitted as a CEL fallback
+  // into the chart values: a user-supplied livenessProbe wins per instance, else
+  // the default exec probe applies. This keeps the production fix working on the
+  // primary (KRO) deploy path, not just direct mode.
+  it('Emit the default daemon liveness probe as a CEL fallback in the KRO RGD', () => {
+    const yaml = dagsterBootstrap.toYaml();
+    expect(yaml).toContain('has(schema.spec.daemon.livenessProbe)');
+    expect(yaml).toContain('schema.spec.daemon.livenessProbe :');
+    expect(yaml).toContain('dagster-daemon');
+    expect(yaml).toContain('liveness-check');
   });
 });

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -100,6 +100,16 @@ describe('Dagster bootstrap composition', () => {
     // template (the chart owns the real workloads).
     expect(yaml).toContain('kind: Deployment');
     expect(yaml).not.toContain('kind: Pod');
+    // The observed webserver Deployment is named from the chart's `.Release.Name` (= spec.name)
+    // + the chart-default `-dagster-webserver` suffix. Pin that derivation so a regression to the
+    // WRONG base — `dagster.fullname` (the global-override-aware helper, which appends `-dagster`
+    // for a release name not containing "dagster" and would observe a nonexistent Deployment,
+    // hanging `ready` forever) — fails loudly.
+    expect(yaml).toContain('schema.spec.name + "-dagster-webserver"');
+    // The buggy derivation used `dagster.fullname`'s `contains(...)` logic in the name. That doesn't
+    // belong in the webserver name; its presence is the regression. (We can't assert on `fullnameOverride`
+    // here — it legitimately appears in the HelmRelease values passthrough, unrelated to the name.)
+    expect(yaml).not.toContain('.contains(');
   });
 
   it('Own the shared HelmRepository in the singleton composition', () => {
@@ -259,10 +269,14 @@ describe('Dagster bootstrap honest readiness', () => {
     expect(yaml).toContain('apiVersion: apps/v1');
     expect(yaml).toContain('kind: Deployment');
 
-    // The webserver name mirrors the chart's `dagster.fullname` template as a CEL
-    // expression (resolves at instance time), with no leaked ref markers.
-    expect(yaml).toContain('-dagster-webserver');
-    expect(yaml).toContain('schema.spec.name.contains(');
+    // The webserver name is `<Release.Name>-dagster-webserver`, and the chart's Release.Name is the
+    // composition's `spec.name` — so the externalRef name resolves (at instance time) to a clean CEL
+    // expression over `spec.name`, with NO leaked ref markers and NO spurious has()-guard wrapper.
+    // It must NOT use the chart's `dagster.fullname`/`contains` logic (that helper is for the daemon/
+    // postgres names; using it for the webserver would observe a nonexistent Deployment — see the
+    // composition comment).
+    expect(yaml).toContain('${schema.spec.name + "-dagster-webserver"}');
+    expect(yaml).not.toContain('schema.spec.name.contains(');
     expect(yaml).not.toContain('__KUBERNETES_REF__');
 
     // `ready` is the HelmRelease Ready condition AND the (null-safe) webserver

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -90,26 +90,14 @@ describe('Dagster bootstrap composition', () => {
     expect(yaml).toContain('kind: HelmRepository');
     expect(yaml).toContain('chart: dagster');
     expect(yaml).toContain('1.13.8');
-    // Honest readiness: `ready` now combines the HelmRelease Ready condition AND
-    // the observed webserver Deployment status (null-safe via has()).
-    expect(yaml).toContain('ready: ${(dagsterHelmRelease.status.conditions');
-    expect(yaml).toContain('dagsterWebserverDeployment.status.availableReplicas');
+    // Readiness is the wait-gated HelmRelease Ready condition (helm-controller waits for the chart's
+    // workloads before reporting Ready). We do NOT observe individual workloads — no fragile,
+    // name-reconstructed Deployment externalRef, and therefore no owned/observed Deployment template.
+    expect(yaml).toContain('ready: ${dagsterHelmRelease.status.conditions');
     expect(yaml).toContain('phase: "${dagsterHelmRelease.status.conditions');
-    // The webserver is OBSERVED via externalRef (apps/v1 Deployment), not owned —
-    // so a `kind: Deployment` externalRef is expected, but no owned Deployment
-    // template (the chart owns the real workloads).
-    expect(yaml).toContain('kind: Deployment');
+    expect(yaml).not.toContain('kind: Deployment');
     expect(yaml).not.toContain('kind: Pod');
-    // The observed webserver Deployment is named from the chart's `.Release.Name` (= spec.name)
-    // + the chart-default `-dagster-webserver` suffix. Pin that derivation so a regression to the
-    // WRONG base — `dagster.fullname` (the global-override-aware helper, which appends `-dagster`
-    // for a release name not containing "dagster" and would observe a nonexistent Deployment,
-    // hanging `ready` forever) — fails loudly.
-    expect(yaml).toContain('schema.spec.name + "-dagster-webserver"');
-    // The buggy derivation used `dagster.fullname`'s `contains(...)` logic in the name. That doesn't
-    // belong in the webserver name; its presence is the regression. (We can't assert on `fullnameOverride`
-    // here — it legitimately appears in the HelmRelease values passthrough, unrelated to the name.)
-    expect(yaml).not.toContain('.contains(');
+    expect(yaml).not.toContain('dagsterWebserverDeployment');
   });
 
   it('Own the shared HelmRepository in the singleton composition', () => {
@@ -257,35 +245,21 @@ describe('Dagster bootstrap composition', () => {
   });
 });
 
-describe('Dagster bootstrap honest readiness', () => {
-  // The webserver is the one workload the chart ALWAYS deploys for every
-  // instance, so it is observed via externalRef and folded into `ready`.
-  it('Observe the webserver Deployment via externalRef and reference its status in ready', () => {
+describe('Dagster bootstrap readiness', () => {
+  // Readiness is the wait-gated HelmRelease Ready condition: the HelmRelease does not disable wait,
+  // so helm-controller waits for the chart's workloads before it reports Ready. Individual workloads
+  // are deliberately NOT observed via externalRef — KRO externalRef is name-keyed and the chart's
+  // per-workload names depend fragilely on the release name + per-component nameOverrides, so
+  // reconstructing them risks pinning `ready` false forever for no signal beyond the HelmRelease.
+  it('Gates `ready` on the HelmRelease Ready condition, with no per-workload observation', () => {
     const yaml = dagsterBootstrap.toYaml();
 
-    // The webserver is referenced as an apps/v1 Deployment externalRef (observed,
-    // not owned — there is no Deployment *template* in the RGD).
-    expect(yaml).toContain('id: dagsterWebserverDeployment');
-    expect(yaml).toContain('apiVersion: apps/v1');
-    expect(yaml).toContain('kind: Deployment');
-
-    // The webserver name is `<Release.Name>-dagster-webserver`, and the chart's Release.Name is the
-    // composition's `spec.name` — so the externalRef name resolves (at instance time) to a clean CEL
-    // expression over `spec.name`, with NO leaked ref markers and NO spurious has()-guard wrapper.
-    // It must NOT use the chart's `dagster.fullname`/`contains` logic (that helper is for the daemon/
-    // postgres names; using it for the webserver would observe a nonexistent Deployment — see the
-    // composition comment).
-    expect(yaml).toContain('${schema.spec.name + "-dagster-webserver"}');
-    expect(yaml).not.toContain('schema.spec.name.contains(');
+    expect(yaml).toContain('ready: ${dagsterHelmRelease.status.conditions');
+    // No fragile workload observation: no Deployment/StatefulSet externalRef, no reconstructed names.
+    expect(yaml).not.toContain('dagsterWebserverDeployment');
+    expect(yaml).not.toContain('kind: Deployment');
+    expect(yaml).not.toContain('kind: StatefulSet');
     expect(yaml).not.toContain('__KUBERNETES_REF__');
-
-    // `ready` is the HelmRelease Ready condition AND the (null-safe) webserver
-    // Deployment status. has() guards mean it is `false`, never an eval error,
-    // before the Deployment exists during install.
-    expect(yaml).toContain('ready: ${(dagsterHelmRelease.status.conditions');
-    expect(yaml).toContain('has(dagsterWebserverDeployment.status)');
-    expect(yaml).toContain('has(dagsterWebserverDeployment.status.availableReplicas)');
-    expect(yaml).toContain('dagsterWebserverDeployment.status.availableReplicas >= 1');
   });
 
   // Hang-safety: a workload that an instance does NOT deploy must never appear in
@@ -311,26 +285,6 @@ describe('Dagster bootstrap honest readiness', () => {
     // daemon/userDeployments components fall back to the HelmRelease signal.
     expect(yaml).toContain('daemon: ${dagsterHelmRelease.status.conditions');
     expect(yaml).toContain('userDeployments: ${dagsterHelmRelease.status.conditions');
-  });
-
-  it('Resolve the webserver name CEL to the live-verified value for release "dagster"', () => {
-    // Mirror of the emitted CEL fullname rule, validated against the live cluster
-    // observation: release `dagster` (chart `dagster`) → `dagster-dagster-webserver`.
-    const webserverName = (
-      name: string,
-      nameOverride?: string,
-      fullnameOverride?: string
-    ): string => {
-      const chartName = nameOverride ?? 'dagster';
-      const fullname =
-        fullnameOverride ?? (name.includes(chartName) ? name : `${name}-${chartName}`);
-      return `${fullname}-dagster-webserver`;
-    };
-
-    expect(webserverName('dagster')).toBe('dagster-dagster-webserver');
-    expect(webserverName('analytics')).toBe('analytics-dagster-dagster-webserver');
-    expect(webserverName('x', undefined, 'foo')).toBe('foo-dagster-webserver');
-    expect(webserverName('ds-prod', 'ds')).toBe('ds-prod-dagster-webserver');
   });
 
   it('Keep phase/failed/version unchanged', () => {

--- a/test/factories/dagster/values-mapper.test.ts
+++ b/test/factories/dagster/values-mapper.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it } from 'bun:test';
-import {
-  CEL_EXPRESSION_BRAND,
-  KUBERNETES_REF_BRAND,
-} from '../../../src/core/constants/brands.js';
 import { isValuesMergeExpression } from '../../../src/core/aspects/values-merge.js';
-import {
-  mapDagsterConfigToHelmValues,
-  validateDagsterConfig,
-} from '../../../src/factories/dagster/utils/helm-values-mapper.js';
+import { CEL_EXPRESSION_BRAND, KUBERNETES_REF_BRAND } from '../../../src/core/constants/brands.js';
 import type {
   CelExpression,
   KubernetesRef,
@@ -18,6 +11,10 @@ import type {
   DagsterHelmValues,
   DagsterMappedHelmValues,
 } from '../../../src/factories/dagster/types.js';
+import {
+  mapDagsterConfigToHelmValues,
+  validateDagsterConfig,
+} from '../../../src/factories/dagster/utils/helm-values-mapper.js';
 
 const minimalConfig: DagsterBootstrapConfig = {
   name: 'analytics',
@@ -73,24 +70,26 @@ describe('Dagster Helm values mapper', () => {
   });
 
   it('Preserve explicit user deployment port and image pull policy overrides', () => {
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      userDeployments: {
-        enabled: true,
-        deployments: [
-          {
-            name: 'analytics-repo',
-            image: {
-              repository: 'ghcr.io/acme/dagster-analytics',
-              tag: '2026.06.01',
-              pullPolicy: 'Always',
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        userDeployments: {
+          enabled: true,
+          deployments: [
+            {
+              name: 'analytics-repo',
+              image: {
+                repository: 'ghcr.io/acme/dagster-analytics',
+                tag: '2026.06.01',
+                pullPolicy: 'Always',
+              },
+              codeServerArgs: ['-m', 'analytics.definitions'],
+              port: 4040,
             },
-            codeServerArgs: ['-m', 'analytics.definitions'],
-            port: 4040,
-          },
-        ],
-      },
-    }));
+          ],
+        },
+      })
+    );
     const userDeployments = values['dagster-user-deployments'] as {
       deployments?: Array<{ image?: { pullPolicy?: string }; port?: number }>;
     };
@@ -100,53 +99,55 @@ describe('Dagster Helm values mapper', () => {
   });
 
   it('Map common Dagster chart convenience fields', () => {
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      webserver: {
-        replicaCount: 2,
-        pathPrefix: '/dagster',
-        service: { type: 'ClusterIP', port: 8080 },
-        logFormat: 'json',
-      },
-      daemon: {
-        enabled: true,
-        heartbeatTolerance: 120,
-        runRetries: { enabled: true, maxRetries: 2 },
-      },
-      postgresql: {
-        enabled: false,
-        host: 'dagster-postgres.postgres.svc.cluster.local',
-        username: 'dagster',
-        database: 'dagster',
-        passwordSecretName: 'dagster-postgres',
-        servicePort: 5432,
-      },
-      runLauncher: {
-        type: 'K8sRunLauncher',
-        k8sRunLauncher: {
-          jobNamespace: 'dagster-runs',
-          envSecrets: [{ name: 'dagster-run-env' }],
-          resources: { requests: { cpu: '250m', memory: '512Mi' } },
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        webserver: {
+          replicaCount: 2,
+          pathPrefix: '/dagster',
+          service: { type: 'ClusterIP', port: 8080 },
+          logFormat: 'json',
         },
-      },
-      ingress: {
-        enabled: true,
-        ingressClassName: 'nginx',
-        dagsterWebserver: {
-          host: 'dagster.example.com',
-          path: '/',
-          tls: { enabled: true, secretName: 'dagster-tls' },
+        daemon: {
+          enabled: true,
+          heartbeatTolerance: 120,
+          runRetries: { enabled: true, maxRetries: 2 },
         },
-      },
-      computeLogManager: {
-        type: 'S3ComputeLogManager',
-        config: { bucket: 'dagster-compute-logs', prefix: 'runs' },
-      },
-      nameOverride: 'dagster-short',
-      fullnameOverride: 'dagster-analytics',
-      rbacEnabled: true,
-      imagePullSecrets: [{ name: 'dagster-registry' }],
-    }));
+        postgresql: {
+          enabled: false,
+          host: 'dagster-postgres.postgres.svc.cluster.local',
+          username: 'dagster',
+          database: 'dagster',
+          passwordSecretName: 'dagster-postgres',
+          servicePort: 5432,
+        },
+        runLauncher: {
+          type: 'K8sRunLauncher',
+          k8sRunLauncher: {
+            jobNamespace: 'dagster-runs',
+            envSecrets: [{ name: 'dagster-run-env' }],
+            resources: { requests: { cpu: '250m', memory: '512Mi' } },
+          },
+        },
+        ingress: {
+          enabled: true,
+          ingressClassName: 'nginx',
+          dagsterWebserver: {
+            host: 'dagster.example.com',
+            path: '/',
+            tls: { enabled: true, secretName: 'dagster-tls' },
+          },
+        },
+        computeLogManager: {
+          type: 'S3ComputeLogManager',
+          config: { bucket: 'dagster-compute-logs', prefix: 'runs' },
+        },
+        nameOverride: 'dagster-short',
+        fullnameOverride: 'dagster-analytics',
+        rbacEnabled: true,
+        imagePullSecrets: [{ name: 'dagster-registry' }],
+      })
+    );
 
     expect(values.nameOverride).toBe('dagster-short');
     expect(values.fullnameOverride).toBe('dagster-analytics');
@@ -197,11 +198,13 @@ describe('Dagster Helm values mapper', () => {
   });
 
   it('Exclude bootstrap-only fields from Helm values', () => {
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      version: '1.13.8',
-      serviceAccountName: 'dagster-runtime',
-    }));
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        version: '1.13.8',
+        serviceAccountName: 'dagster-runtime',
+      })
+    );
 
     expect('name' in values).toBe(false);
     expect('namespace' in values).toBe(false);
@@ -210,17 +213,19 @@ describe('Dagster Helm values mapper', () => {
   });
 
   it('Pass serviceAccount (annotations/create/name) through the raw values surface (IRSA)', () => {
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      serviceAccountName: 'dbt',
-      values: {
-        serviceAccount: {
-          create: true,
-          name: 'dbt',
-          annotations: { 'eks.amazonaws.com/role-arn': 'arn:aws:iam::123:role/dbt-data' },
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        serviceAccountName: 'dbt',
+        values: {
+          serviceAccount: {
+            create: true,
+            name: 'dbt',
+            annotations: { 'eks.amazonaws.com/role-arn': 'arn:aws:iam::123:role/dbt-data' },
+          },
         },
-      },
-    }));
+      })
+    );
 
     expect(values.serviceAccount).toEqual({
       create: true,
@@ -230,14 +235,16 @@ describe('Dagster Helm values mapper', () => {
   });
 
   it('Merge raw values last while preserving typed values at unrelated paths', () => {
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      webserver: { replicaCount: 1, pathPrefix: '/typed' },
-      values: {
-        dagsterWebserver: { replicaCount: 3 },
-        busybox: { image: { repository: 'busybox', tag: '1.36' } },
-      },
-    }));
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        webserver: { replicaCount: 1, pathPrefix: '/typed' },
+        values: {
+          dagsterWebserver: { replicaCount: 3 },
+          busybox: { image: { repository: 'busybox', tag: '1.36' } },
+        },
+      })
+    );
 
     expect(values.dagsterWebserver).toMatchObject({
       replicaCount: 3,
@@ -249,31 +256,33 @@ describe('Dagster Helm values mapper', () => {
   });
 
   it('Replace arrays and override primitive raw values during deep merge', () => {
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      userDeployments: {
-        enabled: true,
-        deployments: [
-          {
-            name: 'typed-repo',
-            image: { repository: 'ghcr.io/acme/typed', tag: '1' },
-            dagsterApiGrpcArgs: ['-m', 'typed.repo'],
-          },
-        ],
-      },
-      values: {
-        rbacEnabled: false,
-        'dagster-user-deployments': {
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        userDeployments: {
+          enabled: true,
           deployments: [
             {
-              name: 'raw-repo',
-              image: { repository: 'ghcr.io/acme/raw', tag: '2' },
-              codeServerArgs: ['-m', 'raw.repo'],
+              name: 'typed-repo',
+              image: { repository: 'ghcr.io/acme/typed', tag: '1' },
+              dagsterApiGrpcArgs: ['-m', 'typed.repo'],
             },
           ],
         },
-      },
-    }));
+        values: {
+          rbacEnabled: false,
+          'dagster-user-deployments': {
+            deployments: [
+              {
+                name: 'raw-repo',
+                image: { repository: 'ghcr.io/acme/raw', tag: '2' },
+                codeServerArgs: ['-m', 'raw.repo'],
+              },
+            ],
+          },
+        },
+      })
+    );
     const userDeployments = values['dagster-user-deployments'] as {
       deployments?: Array<{ name?: string; image?: { repository?: string } }>;
     };
@@ -285,22 +294,24 @@ describe('Dagster Helm values mapper', () => {
   });
 
   it('Merge RabbitMQ and Redis raw sub-values into official chart blocks', () => {
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      global: { celeryConfigSecretName: 'dagster-celery-config' },
-      runLauncher: { type: 'CeleryK8sRunLauncher' },
-      rabbitmq: {
-        enabled: true,
-        username: 'dagster',
-        servicePort: 5672,
-        values: { persistence: { enabled: true } },
-      },
-      redis: {
-        enabled: true,
-        brokerDbNumber: 0,
-        values: { master: { persistence: { enabled: true } } },
-      },
-    }));
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        global: { celeryConfigSecretName: 'dagster-celery-config' },
+        runLauncher: { type: 'CeleryK8sRunLauncher' },
+        rabbitmq: {
+          enabled: true,
+          username: 'dagster',
+          servicePort: 5672,
+          values: { persistence: { enabled: true } },
+        },
+        redis: {
+          enabled: true,
+          brokerDbNumber: 0,
+          values: { master: { persistence: { enabled: true } } },
+        },
+      })
+    );
 
     expect(values.generateCeleryConfigSecret).toBe(false);
     expect(values.global).toMatchObject({ celeryConfigSecretName: 'dagster-celery-config' });
@@ -320,26 +331,30 @@ describe('Dagster Helm values mapper', () => {
   });
 
   it('Preserve global chart fields unless top-level conveniences override them', () => {
-    const globalOnly = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      global: {
-        serviceAccountName: 'global-service-account',
-        postgresqlSecretName: 'global-postgresql-secret',
-      },
-    }));
-    const topLevelOverride = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      serviceAccountName: 'top-level-service-account',
-      global: {
-        serviceAccountName: 'global-service-account',
-        postgresqlSecretName: 'global-postgresql-secret',
-      },
-      postgresql: {
-        enabled: false,
-        host: 'dagster-postgres.postgres.svc.cluster.local',
-        passwordSecretName: 'top-level-postgresql-secret',
-      },
-    }));
+    const globalOnly = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        global: {
+          serviceAccountName: 'global-service-account',
+          postgresqlSecretName: 'global-postgresql-secret',
+        },
+      })
+    );
+    const topLevelOverride = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        serviceAccountName: 'top-level-service-account',
+        global: {
+          serviceAccountName: 'global-service-account',
+          postgresqlSecretName: 'global-postgresql-secret',
+        },
+        postgresql: {
+          enabled: false,
+          host: 'dagster-postgres.postgres.svc.cluster.local',
+          passwordSecretName: 'top-level-postgresql-secret',
+        },
+      })
+    );
 
     expect(globalOnly.global).toMatchObject({
       serviceAccountName: 'global-service-account',
@@ -352,16 +367,18 @@ describe('Dagster Helm values mapper', () => {
   });
 
   it('Map RabbitMQ credentials to the official nested chart path', () => {
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      global: { celeryConfigSecretName: 'dagster-celery-config' },
-      runLauncher: { type: 'CeleryK8sRunLauncher' },
-      rabbitmq: {
-        enabled: true,
-        username: 'dagster-user',
-        password: 'dagster-password',
-      },
-    }));
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        global: { celeryConfigSecretName: 'dagster-celery-config' },
+        runLauncher: { type: 'CeleryK8sRunLauncher' },
+        rabbitmq: {
+          enabled: true,
+          username: 'dagster-user',
+          password: 'dagster-password',
+        },
+      })
+    );
 
     expect(values.rabbitmq).toMatchObject({
       enabled: true,
@@ -391,14 +408,16 @@ describe('Dagster Helm values mapper', () => {
       fieldPath: 'status.values',
     } satisfies KubernetesRef<TypeKroValueTreeObject>;
 
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      global: { celeryConfigSecretName: 'dagster-celery-config' },
-      runLauncher: { type: 'CeleryK8sRunLauncher' },
-      postgresql: { enabled: true, values: postgresqlValues },
-      rabbitmq: { enabled: true, values: rabbitmqValues },
-      redis: { enabled: true, values: redisValues },
-    }));
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        global: { celeryConfigSecretName: 'dagster-celery-config' },
+        runLauncher: { type: 'CeleryK8sRunLauncher' },
+        postgresql: { enabled: true, values: postgresqlValues },
+        rabbitmq: { enabled: true, values: rabbitmqValues },
+        redis: { enabled: true, values: redisValues },
+      })
+    );
 
     expect(isValuesMergeExpression(values.postgresql)).toBe(true);
     expect(isValuesMergeExpression(values.rabbitmq)).toBe(true);
@@ -419,16 +438,16 @@ describe('Dagster Helm values mapper', () => {
       expression: 'schema.spec.ingress.host',
     } satisfies CelExpression<string>;
 
-    const values = concreteValues(mapDagsterConfigToHelmValues({
-      ...minimalConfig,
-      values: {
-        global: { postgresqlSecretName: secretName },
-        ingress: { dagsterWebserver: { host: hostname } },
-      },
-    }));
-    const ingress = values.ingress as
-      | { dagsterWebserver?: { host?: unknown } }
-      | undefined;
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        values: {
+          global: { postgresqlSecretName: secretName },
+          ingress: { dagsterWebserver: { host: hostname } },
+        },
+      })
+    );
+    const ingress = values.ingress as { dagsterWebserver?: { host?: unknown } } | undefined;
 
     expect(values.global?.postgresqlSecretName).toBe(secretName);
     expect(ingress?.dagsterWebserver?.host).toBe(hostname);
@@ -439,9 +458,7 @@ describe('Dagster Helm values mapper', () => {
       ...minimalConfig,
       userDeployments: {
         enabled: true,
-        deployments: [
-          { name: 'broken', image: { repository: 'ghcr.io/acme/broken', tag: '1' } },
-        ],
+        deployments: [{ name: 'broken', image: { repository: 'ghcr.io/acme/broken', tag: '1' } }],
       },
     });
     const conflictingArgs = validateDagsterConfig({
@@ -518,5 +535,32 @@ describe('Dagster Helm values mapper', () => {
         },
       })
     ).toThrow(/DAGSTER_REQUIRED_CONFIG_MISSING|DagsterConfigurationError/);
+  });
+
+  // Regression: mapDaemonConfig previously dropped probe fields, so a hung daemon
+  // (e.g. "too many retries for DB connection") was never restarted by k8s.
+  it('Forward daemon readiness/liveness/startup probes to chart values', () => {
+    const livenessProbe = {
+      exec: { command: ['dagster-daemon', 'liveness-check'] },
+      periodSeconds: 60,
+    };
+    const readinessProbe = { exec: { command: ['true'] }, periodSeconds: 30 };
+    const startupProbe = { exec: { command: ['true'] }, failureThreshold: 10 };
+
+    const values = concreteValues(
+      mapDagsterConfigToHelmValues({
+        ...minimalConfig,
+        daemon: { enabled: true, livenessProbe, readinessProbe, startupProbe },
+      })
+    );
+    const daemon = values.dagsterDaemon as {
+      livenessProbe?: unknown;
+      readinessProbe?: unknown;
+      startupProbe?: unknown;
+    };
+
+    expect(daemon.livenessProbe).toEqual(livenessProbe);
+    expect(daemon.readinessProbe).toEqual(readinessProbe);
+    expect(daemon.startupProbe).toEqual(startupProbe);
   });
 });


### PR DESCRIPTION
## Summary

Dagster daemon self-recovery, plus two general fixes the work surfaced in the JS→CEL serializer and the `externalRef` API. (Squash-merges to a clean three-change diff — the readiness exploration nets out to "no change to the readiness mechanism".)

## 1. Daemon liveness probe (the load-bearing fix)
A hung dagster daemon (e.g. "too many retries for DB connection" after a node reschedule) never exits, so k8s never restarts it — it sits dead until a human intervenes (hit in production). The `daemonSchemaShape` inherited the probe fields but `mapDaemonConfig` silently **dropped** them (only the webserver path forwarded probes). Now forwarded, plus a conservative, overridable default when the daemon is enabled: `exec: ["dagster-daemon","liveness-check"]`, `initialDelay 120s / period 60s / failureThreshold 5` (concrete value in direct mode; a `has(...) ? user : default` CEL fallback in KRO mode).

## 2. Readiness stays the wait-gated HelmRelease signal (no fragile workload observation)
The HelmRelease doesn't set `disableWait`, so Flux's helm-controller already waits for the chart's workloads (webserver/daemon/postgres) before reporting `Ready` — `helmReleaseReady` is workload-aware, and the consuming layer gates its converge on it. So `ready`/`components` derive from that.

We explicitly do **not** observe individual workloads via `externalRef`: KRO `externalRef` is name-keyed (no label selector), and the chart's per-workload names are a fragile function of `.Release.Name` + per-component `nameOverride` (settable via raw `values`) — a reconstructed name that's even slightly off pins `ready` to `false` forever. (A shared, schema-proxy RGD also can't conditionalize per-instance presence of an optional daemon / external DB.) Per-instance daemon/postgres health belongs in the deploying layer's post-deploy readiness gate, which has a real kube client.

## 3. Serializer: collapse no-op `has(X) ? V : V` conditionals
When the proxy/hybrid serialization passes diverge structurally on a leaf but render to an **identical** CEL expression (a resource field built from a CEL expr alongside an unrelated `spec.x || default`), `pickConditionField`'s first-overridden-field fallback attached the **wrong** field's `has()` guard — misleading, and structurally **invalid** (nested `${}`) for template reprs. `has(X) ? V : V ≡ V`, so emit `V` directly. Unit test added (fails without the fix, proven via revert).

## 4. `externalRef`: accept dynamic names without a cast
`metadata.name`/`namespace` were typed `string`, forcing `as unknown as string` for a per-instance CEL name — though `id`'s doc already advertised dynamic names. Widened to `RefOrValue<string>` (backward-compatible; plain string still accepted); the bridge is absorbed in the library.

## Gates
Full unit suite green (4387/0); `tsc --noEmit` + `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
