### PR TITLE
feat: support KRO prerequisite resources

### DIFF
--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -95,6 +95,27 @@ import {
   singletonSpecFingerprintAnnotationValue,
 } from './singleton-owner-drift.js';
 
+const CLUSTER_SCOPED_PREREQUISITE_KINDS = new Set([
+  'admissionregistration.k8s.io/v1/MutatingWebhookConfiguration',
+  'admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy',
+  'admissionregistration.k8s.io/v1/ValidatingAdmissionPolicyBinding',
+  'admissionregistration.k8s.io/v1/ValidatingWebhookConfiguration',
+  'apiextensions.k8s.io/v1/CustomResourceDefinition',
+  'apiregistration.k8s.io/v1/APIService',
+  'flowcontrol.apiserver.k8s.io/v1/FlowSchema',
+  'flowcontrol.apiserver.k8s.io/v1/PriorityLevelConfiguration',
+  'rbac.authorization.k8s.io/v1/ClusterRole',
+  'rbac.authorization.k8s.io/v1/ClusterRoleBinding',
+  'scheduling.k8s.io/v1/PriorityClass',
+  'storage.k8s.io/v1/CSIDriver',
+  'storage.k8s.io/v1/CSINode',
+  'storage.k8s.io/v1/StorageClass',
+  'storage.k8s.io/v1/VolumeAttachment',
+  'v1/Namespace',
+  'v1/Node',
+  'v1/PersistentVolume',
+]);
+
 /**
  * Decide whether the RGD/CRD should be preserved after a `deleteInstance`
  * call, i.e., whether other instances still depend on it.
@@ -1790,7 +1811,7 @@ export class KroResourceFactoryImpl<
 
     copyResourceMetadata(resource as object, deployable);
 
-    if (this.prerequisiteCRDName(resource)) {
+    if (this.isClusterScopedPrerequisite(resource)) {
       setMetadataField(deployable, 'scope', 'cluster');
       delete (deployable.metadata as Record<string, unknown>).namespace;
     }
@@ -1820,6 +1841,10 @@ export class KroResourceFactoryImpl<
       return undefined;
     }
     return resource.metadata?.name;
+  }
+
+  private isClusterScopedPrerequisite(resource: KubernetesResource): boolean {
+    return CLUSTER_SCOPED_PREREQUISITE_KINDS.has(`${resource.apiVersion}/${resource.kind}`);
   }
 
   /**

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -41,7 +41,8 @@ import { getComponentLogger } from '../logging/index.js';
 // Dependency inversion: kroCustomResource, resourceGraphDefinition, and
 // alchemy bridge are injected via FactoryOptions providers (Phase 3.5)
 // instead of dynamic import() from higher layers.
-import { getMetadataField, setMetadataField } from '../metadata/index.js';
+import { copyResourceMetadata, getMetadataField, setMetadataField } from '../metadata/index.js';
+import { ensureReadinessEvaluator } from '../readiness/index.js';
 import { createSchemaProxy, DeploymentMode } from '../references/index.js';
 import { isStaticExpression } from '../serialization/cel-references.js';
 import { applyTernaryConditionalsToResources } from '../serialization/kro-post-processing.js';
@@ -1219,6 +1220,8 @@ export class KroResourceFactoryImpl<
     spec: TSpec,
     opts?: { instanceNameOverride?: string; singletonSpecFingerprint?: string }
   ): Promise<AlchemyResourceDeclaration[]> {
+    this.assertNoKroPrerequisitesForDeclarative('toAlchemyResources()');
+
     const kubeConfigOptions = this.extractKubeConfigOptionsForAlchemy();
     const kroDeletion = this.createAlchemyKroDeletionOptions();
 
@@ -1436,6 +1439,8 @@ export class KroResourceFactoryImpl<
    * Implementation of overloaded toYaml method
    */
   toYaml(spec?: TSpec): string {
+    this.assertNoKroPrerequisitesForDeclarative('toYaml()');
+
     if (spec) {
       validateSpec(spec, this.schemaDefinition, {
         kind: this.schemaDefinition.kind,
@@ -1734,15 +1739,16 @@ export class KroResourceFactoryImpl<
       resource: KubernetesResource,
       options: { waitForReady?: boolean } = {}
     ): Promise<DeployedResource> => {
-      const deployed = await deploymentEngine.deployResource(
-        this.toPrerequisiteDeployable(resource),
-        {
-          mode: 'direct',
-          namespace: this.namespace,
-          waitForReady: options.waitForReady ?? false,
-          timeout,
-        }
-      );
+      const deployable = this.toPrerequisiteDeployable(resource);
+      const resourceToDeploy = options.waitForReady
+        ? ensureReadinessEvaluator(deployable)
+        : deployable;
+      const deployed = await deploymentEngine.deployResource(resourceToDeploy, {
+        mode: 'direct',
+        namespace: this.namespace,
+        waitForReady: options.waitForReady ?? false,
+        timeout,
+      });
 
       const crdName = this.prerequisiteCRDName(resource);
       if (crdName) {
@@ -1774,13 +1780,36 @@ export class KroResourceFactoryImpl<
     resource: KubernetesResource
   ): DeployableK8sResource<Enhanced<unknown, unknown>> {
     const name = resource.metadata?.name ?? 'unnamed';
-    return {
+    const deployable = {
       ...resource,
       id: resource.id ?? `${resource.kind}-${name}`,
       metadata: {
         ...resource.metadata,
       },
     } as DeployableK8sResource<Enhanced<unknown, unknown>>;
+
+    copyResourceMetadata(resource as object, deployable);
+
+    if (this.prerequisiteCRDName(resource)) {
+      setMetadataField(deployable, 'scope', 'cluster');
+      delete (deployable.metadata as Record<string, unknown>).namespace;
+    }
+
+    return deployable;
+  }
+
+  private assertNoKroPrerequisitesForDeclarative(apiName: string): void {
+    const prerequisites = this.factoryOptions.kroPrerequisites;
+    if (!prerequisites?.resources?.length && !prerequisites?.beforeResourceGraphDefinition) {
+      return;
+    }
+
+    throw new TypeKroError(
+      `${apiName} does not support kroPrerequisites. ` +
+        'kroPrerequisites are deploy-only because prerequisite hooks require a live cluster and prerequisite resources must be applied before the ResourceGraphDefinition.',
+      'KRO_PREREQUISITES_DEPLOY_ONLY',
+      { factoryName: this.name, apiName }
+    );
   }
 
   private prerequisiteCRDName(resource: KubernetesResource): string | undefined {

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -8,6 +8,15 @@
 import * as k8s from '@kubernetes/client-node';
 import { compile as compileExpression } from 'angular-expressions';
 import * as yaml from 'js-yaml';
+// Alchemy v2 (declarative): `toAlchemyResources(spec)` emits these as the RGD + instance
+// declarations the caller feeds to `KroResource`. Imported from focused modules (NOT the
+// alchemy barrel) so the factory never statically pulls the `alchemy/Provider` runtime.
+import type { KroDeletionOptions } from '../../alchemy/kro-delete.js';
+import type {
+  AlchemyResourceDeclaration,
+  SerializableKubeConfigOptions,
+} from '../../alchemy/types.js';
+import { createAlchemyResourceId } from '../../alchemy/utilities.js';
 import { preserveNonEnumerableProperties } from '../../utils/helpers.js';
 import { isKubernetesRef } from '../../utils/type-guards.js';
 import { applyAspects } from '../aspects/apply.js';
@@ -29,12 +38,6 @@ import { applyAnalysisToResources } from '../expressions/composition/composition
 import type { KubernetesClientProvider } from '../kubernetes/client-provider.js';
 import { createBunCompatibleKubernetesObjectApi } from '../kubernetes/index.js';
 import { getComponentLogger } from '../logging/index.js';
-// Alchemy v2 (declarative): `toAlchemyResources(spec)` emits these as the RGD + instance
-// declarations the caller feeds to `KroResource`. Imported from focused modules (NOT the
-// alchemy barrel) so the factory never statically pulls the `alchemy/Provider` runtime.
-import type { KroDeletionOptions } from '../../alchemy/kro-delete.js';
-import type { AlchemyResourceDeclaration, SerializableKubeConfigOptions } from '../../alchemy/types.js';
-import { createAlchemyResourceId } from '../../alchemy/utilities.js';
 // Dependency inversion: kroCustomResource, resourceGraphDefinition, and
 // alchemy bridge are injected via FactoryOptions providers (Phase 3.5)
 // instead of dynamic import() from higher layers.
@@ -48,12 +51,14 @@ import { getSingletonResourceId } from '../singleton/singleton.js';
 import type { CelExpression, KubernetesRef } from '../types/common.js';
 import type {
   AppliedResource,
+  DeployedResource,
   DeploymentClosure,
   DeploymentContext,
   FactoryOptions,
   FactoryStatus,
   InternalResourceFactoryDeployOptions,
   KroCustomResourceProvider,
+  KroPrerequisiteContext,
   KroResourceFactory,
   ResourceGraphDefinitionProvider,
   RGDStatus,
@@ -561,7 +566,9 @@ export class KroResourceFactoryImpl<
     return definition.composition.factory('kro', {
       namespace: definition.registryNamespace,
       waitForReady: true,
-      ...(this.factoryOptions.timeout !== undefined ? { timeout: this.factoryOptions.timeout } : {}),
+      ...(this.factoryOptions.timeout !== undefined
+        ? { timeout: this.factoryOptions.timeout }
+        : {}),
       ...(this.factoryOptions.kubeConfig !== undefined
         ? { kubeConfig: this.factoryOptions.kubeConfig }
         : {}),
@@ -1226,10 +1233,15 @@ export class KroResourceFactoryImpl<
     for (const definition of this.discoverSingletonDefinitions(spec)) {
       const singletonFactory = this.singletonFactoryFor(definition);
       try {
-        const decls = await singletonFactory.toAlchemyResources(definition.spec as KroCompatibleType, {
-          instanceNameOverride: getSingletonInstanceName(definition.id),
-          singletonSpecFingerprint: singletonSpecFingerprintAnnotationValue(definition.specFingerprint),
-        });
+        const decls = await singletonFactory.toAlchemyResources(
+          definition.spec as KroCompatibleType,
+          {
+            instanceNameOverride: getSingletonInstanceName(definition.id),
+            singletonSpecFingerprint: singletonSpecFingerprintAnnotationValue(
+              definition.specFingerprint
+            ),
+          }
+        );
         singletonDeclarations.push(...decls);
         // `toAlchemyResources` returns the owner's OWN CR instance LAST (after any of ITS nested
         // singletons + its RGD), so the consumer must wait on `decls[last]` — using "first decl
@@ -1657,6 +1669,8 @@ export class KroResourceFactoryImpl<
     });
 
     try {
+      await this.applyKroPrerequisites(deploymentEngine);
+
       // Deploy RGD using DirectDeploymentEngine with readiness checking
       this.logger.info('Deploying RGD via engine', { rgdName: this.rgdName });
       await deploymentEngine.deployResource(deployableRGD, {
@@ -1707,6 +1721,76 @@ export class KroResourceFactoryImpl<
     } finally {
       await deploymentEngine.dispose();
     }
+  }
+
+  private async applyKroPrerequisites(deploymentEngine: DirectDeploymentEngine): Promise<void> {
+    const prerequisites = this.factoryOptions.kroPrerequisites;
+    if (!prerequisites?.resources?.length && !prerequisites?.beforeResourceGraphDefinition) {
+      return;
+    }
+
+    const timeout = this.factoryOptions.timeout || DEFAULT_RGD_TIMEOUT;
+    const deployResource = async (
+      resource: KubernetesResource,
+      options: { waitForReady?: boolean } = {}
+    ): Promise<DeployedResource> => {
+      const deployed = await deploymentEngine.deployResource(
+        this.toPrerequisiteDeployable(resource),
+        {
+          mode: 'direct',
+          namespace: this.namespace,
+          waitForReady: options.waitForReady ?? false,
+          timeout,
+        }
+      );
+
+      const crdName = this.prerequisiteCRDName(resource);
+      if (crdName) {
+        await deploymentEngine.waitForCRDReady(crdName, timeout);
+      }
+
+      return deployed;
+    };
+
+    for (const resource of prerequisites.resources ?? []) {
+      await deployResource(resource);
+    }
+
+    if (prerequisites.beforeResourceGraphDefinition) {
+      const context: KroPrerequisiteContext = {
+        kubernetesApi: deploymentEngine.getKubernetesApi(),
+        kubeConfig: this.getKubeConfig(),
+        namespace: this.namespace,
+        timeout,
+        deployResource,
+        waitForCRDReady: (crdName, waitTimeout = timeout) =>
+          deploymentEngine.waitForCRDReady(crdName, waitTimeout),
+      };
+      await prerequisites.beforeResourceGraphDefinition(context);
+    }
+  }
+
+  private toPrerequisiteDeployable(
+    resource: KubernetesResource
+  ): DeployableK8sResource<Enhanced<unknown, unknown>> {
+    const name = resource.metadata?.name ?? 'unnamed';
+    return {
+      ...resource,
+      id: resource.id ?? `${resource.kind}-${name}`,
+      metadata: {
+        ...resource.metadata,
+      },
+    } as DeployableK8sResource<Enhanced<unknown, unknown>>;
+  }
+
+  private prerequisiteCRDName(resource: KubernetesResource): string | undefined {
+    if (
+      resource.apiVersion !== 'apiextensions.k8s.io/v1' ||
+      resource.kind !== 'CustomResourceDefinition'
+    ) {
+      return undefined;
+    }
+    return resource.metadata?.name;
   }
 
   /**

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -1897,15 +1897,17 @@ export class KroResourceFactoryImpl<
     kubeConfigOptions: SerializableKubeConfigOptions
   ): AlchemyResourceDeclaration[] {
     const timeout = this.factoryOptions.timeout;
-    return (this.factoryOptions.kroPrerequisites?.resources ?? []).map((resource) => {
+    const declarations: AlchemyResourceDeclaration[] = [];
+    for (const resource of this.factoryOptions.kroPrerequisites?.resources ?? []) {
       const normalized = this.normalizePrerequisiteResource(resource, {
         attachFallbackReadiness: true,
       });
       const namespaceForId =
         getMetadataField(normalized, 'scope') === 'cluster' ? undefined : this.namespace;
-      return {
+      const previousDeclaration = declarations.at(-1);
+      declarations.push({
         id: createAlchemyResourceId(normalized, namespaceForId),
-        dependsOn: [],
+        dependsOn: previousDeclaration ? [previousDeclaration.id] : [],
         props: {
           resource: normalized,
           resourceId: normalized.id,
@@ -1917,8 +1919,9 @@ export class KroResourceFactoryImpl<
             ...(timeout !== undefined && { timeout }),
           },
         },
-      };
-    });
+      });
+    }
+    return declarations;
   }
 
   private assertNoKroPrerequisiteHookForDeclarative(apiName: string): void {

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -41,8 +41,14 @@ import { getComponentLogger } from '../logging/index.js';
 // Dependency inversion: kroCustomResource, resourceGraphDefinition, and
 // alchemy bridge are injected via FactoryOptions providers (Phase 3.5)
 // instead of dynamic import() from higher layers.
-import { copyResourceMetadata, getMetadataField, setMetadataField } from '../metadata/index.js';
-import { ensureReadinessEvaluator } from '../readiness/index.js';
+import {
+  copyResourceMetadata,
+  getMetadataField,
+  getReadinessEvaluator,
+  setMetadataField,
+  setReadinessEvaluator,
+} from '../metadata/index.js';
+import { createAlwaysReadyEvaluator, ensureReadinessEvaluator } from '../readiness/index.js';
 import { createSchemaProxy, DeploymentMode } from '../references/index.js';
 import { isStaticExpression } from '../serialization/cel-references.js';
 import { applyTernaryConditionalsToResources } from '../serialization/kro-post-processing.js';
@@ -61,6 +67,7 @@ import type {
   KroCustomResourceProvider,
   KroPrerequisiteContext,
   KroResourceFactory,
+  PrerequisiteResource,
   ResourceGraphDefinitionProvider,
   RGDStatus,
   SingletonDefinitionRecord,
@@ -107,6 +114,7 @@ const CLUSTER_SCOPED_PREREQUISITE_KINDS = new Set([
   'rbac.authorization.k8s.io/v1/ClusterRole',
   'rbac.authorization.k8s.io/v1/ClusterRoleBinding',
   'scheduling.k8s.io/v1/PriorityClass',
+  'node.k8s.io/v1/RuntimeClass',
   'storage.k8s.io/v1/CSIDriver',
   'storage.k8s.io/v1/CSINode',
   'storage.k8s.io/v1/StorageClass',
@@ -1241,10 +1249,12 @@ export class KroResourceFactoryImpl<
     spec: TSpec,
     opts?: { instanceNameOverride?: string; singletonSpecFingerprint?: string }
   ): Promise<AlchemyResourceDeclaration[]> {
-    this.assertNoKroPrerequisitesForDeclarative('toAlchemyResources()');
+    this.assertNoKroPrerequisiteHookForDeclarative('toAlchemyResources()');
 
     const kubeConfigOptions = this.extractKubeConfigOptionsForAlchemy();
     const kroDeletion = this.createAlchemyKroDeletionOptions();
+    const prerequisiteDeclarations = this.prerequisiteAlchemyDeclarations(kubeConfigOptions);
+    const prerequisiteIds = prerequisiteDeclarations.map((decl) => decl.id);
 
     // 0. Singleton owners. The imperative `deploy()` ensures shared singleton owners (each its own
     // RGD + instance, in its registry namespace) via `ensureSingletonOwners` BEFORE the main
@@ -1288,7 +1298,7 @@ export class KroResourceFactoryImpl<
     const rgdId = createAlchemyResourceId(rgdEnhanced, this.namespace);
     const rgdDeclaration: AlchemyResourceDeclaration = {
       id: rgdId,
-      dependsOn: [],
+      dependsOn: prerequisiteIds,
       props: {
         resource: rgdEnhanced as Enhanced<unknown, unknown>,
         namespace: this.namespace,
@@ -1331,7 +1341,12 @@ export class KroResourceFactoryImpl<
       },
     };
 
-    return [...singletonDeclarations, rgdDeclaration, instanceDeclaration];
+    return [
+      ...prerequisiteDeclarations,
+      ...singletonDeclarations,
+      rgdDeclaration,
+      instanceDeclaration,
+    ];
   }
 
   /** Serialize the factory's cluster connection so an alchemy resource can reconnect after rehydration. */
@@ -1460,7 +1475,7 @@ export class KroResourceFactoryImpl<
    * Implementation of overloaded toYaml method
    */
   toYaml(spec?: TSpec): string {
-    this.assertNoKroPrerequisitesForDeclarative('toYaml()');
+    this.assertNoKroPrerequisiteHookForDeclarative('toYaml()');
 
     if (spec) {
       validateSpec(spec, this.schemaDefinition, {
@@ -1483,9 +1498,9 @@ export class KroResourceFactoryImpl<
     }
 
     const rgdYaml = this.buildRgdYaml();
-    return this.singletonDefinitions.length === 0
-      ? rgdYaml
-      : joinYamlDocuments(singletonRgdYamls(this.singletonDefinitions), rgdYaml);
+    const prerequisiteYamls = this.prerequisiteResourceYamls();
+    const leadingYamls = [...prerequisiteYamls, ...singletonRgdYamls(this.singletonDefinitions)];
+    return leadingYamls.length === 0 ? rgdYaml : joinYamlDocuments(leadingYamls, rgdYaml);
   }
 
   /**
@@ -1757,10 +1772,12 @@ export class KroResourceFactoryImpl<
 
     const timeout = this.factoryOptions.timeout || DEFAULT_RGD_TIMEOUT;
     const deployResource = async (
-      resource: KubernetesResource,
+      resource: PrerequisiteResource,
       options: { waitForReady?: boolean } = {}
     ): Promise<DeployedResource> => {
-      const deployable = this.toPrerequisiteDeployable(resource);
+      const deployable = this.normalizePrerequisiteResource(resource, {
+        ensureReadiness: options.waitForReady ?? false,
+      });
       const resourceToDeploy = options.waitForReady
         ? ensureReadinessEvaluator(deployable)
         : deployable;
@@ -1797,8 +1814,9 @@ export class KroResourceFactoryImpl<
     }
   }
 
-  private toPrerequisiteDeployable(
-    resource: KubernetesResource
+  private normalizePrerequisiteResource(
+    resource: PrerequisiteResource,
+    options: { ensureReadiness?: boolean; attachFallbackReadiness?: boolean } = {}
   ): DeployableK8sResource<Enhanced<unknown, unknown>> {
     const name = resource.metadata?.name ?? 'unnamed';
     const deployable = {
@@ -1810,24 +1828,108 @@ export class KroResourceFactoryImpl<
     } as DeployableK8sResource<Enhanced<unknown, unknown>>;
 
     copyResourceMetadata(resource as object, deployable);
+    delete (deployable as unknown as Record<string, unknown>).scope;
 
-    if (this.isClusterScopedPrerequisite(resource)) {
+    const scope = this.prerequisiteScope(resource);
+    if (scope === 'cluster') {
       setMetadataField(deployable, 'scope', 'cluster');
       delete (deployable.metadata as Record<string, unknown>).namespace;
+    } else if (!deployable.metadata.namespace) {
+      deployable.metadata.namespace = this.namespace;
+    }
+
+    if (this.prerequisiteCRDName(resource) && !getReadinessEvaluator(deployable)) {
+      setReadinessEvaluator(deployable, (liveResource: unknown) => {
+        const conditions =
+          (liveResource as { status?: { conditions?: Array<{ type?: string; status?: string }> } })
+            .status?.conditions ?? [];
+        const established = conditions.find((condition) => condition.type === 'Established');
+        const namesAccepted = conditions.find((condition) => condition.type === 'NamesAccepted');
+        const ready = established?.status === 'True' && namesAccepted?.status === 'True';
+        return ready
+          ? {
+              ready: true,
+              message: 'CustomResourceDefinition is established and names are accepted',
+            }
+          : {
+              ready: false,
+              reason: 'ConditionsNotMet',
+              message: 'CustomResourceDefinition is not established and names accepted yet',
+              details: { conditions },
+            };
+      });
+    } else if (options.attachFallbackReadiness && !getReadinessEvaluator(deployable)) {
+      setReadinessEvaluator(deployable, createAlwaysReadyEvaluator(resource.kind));
+    }
+
+    if (options.ensureReadiness) {
+      return ensureReadinessEvaluator(deployable);
     }
 
     return deployable;
   }
 
-  private assertNoKroPrerequisitesForDeclarative(apiName: string): void {
+  private prerequisiteResourceYamls(): string[] {
+    return (this.factoryOptions.kroPrerequisites?.resources ?? []).map((resource) =>
+      yaml
+        .dump(this.toSerializablePrerequisiteResource(resource), {
+          lineWidth: -1,
+          noRefs: true,
+          sortKeys: false,
+        })
+        .trimEnd()
+    );
+  }
+
+  private toSerializablePrerequisiteResource(
+    resource: PrerequisiteResource
+  ): Record<string, unknown> {
+    const normalized = this.normalizePrerequisiteResource(resource);
+    const toJSON = normalized.toJSON;
+    const jsonResource = typeof toJSON === 'function' ? toJSON.call(normalized) : normalized;
+    const serialized = JSON.parse(JSON.stringify(jsonResource)) as Record<string, unknown>;
+    delete serialized.id;
+    delete serialized.scope;
+    return serialized;
+  }
+
+  private prerequisiteAlchemyDeclarations(
+    kubeConfigOptions: SerializableKubeConfigOptions
+  ): AlchemyResourceDeclaration[] {
+    const timeout = this.factoryOptions.timeout;
+    return (this.factoryOptions.kroPrerequisites?.resources ?? []).map((resource) => {
+      const normalized = this.normalizePrerequisiteResource(resource, {
+        attachFallbackReadiness: true,
+      });
+      const namespaceForId =
+        getMetadataField(normalized, 'scope') === 'cluster' ? undefined : this.namespace;
+      return {
+        id: createAlchemyResourceId(normalized, namespaceForId),
+        dependsOn: [],
+        props: {
+          resource: normalized,
+          resourceId: normalized.id,
+          namespace: this.namespace,
+          deploymentStrategy: 'direct' as const,
+          kubeConfigOptions,
+          options: {
+            waitForReady: this.prerequisiteCRDName(resource) !== undefined,
+            ...(timeout !== undefined && { timeout }),
+          },
+        },
+      };
+    });
+  }
+
+  private assertNoKroPrerequisiteHookForDeclarative(apiName: string): void {
     const prerequisites = this.factoryOptions.kroPrerequisites;
-    if (!prerequisites?.resources?.length && !prerequisites?.beforeResourceGraphDefinition) {
+    if (!prerequisites?.beforeResourceGraphDefinition) {
       return;
     }
 
     throw new TypeKroError(
-      `${apiName} does not support kroPrerequisites. ` +
-        'kroPrerequisites are deploy-only because prerequisite hooks require a live cluster and prerequisite resources must be applied before the ResourceGraphDefinition.',
+      `${apiName} does not support kroPrerequisites.beforeResourceGraphDefinition. ` +
+        'Prerequisite hooks are deploy-only because they require a live cluster; use kroPrerequisites.resources for declarative prerequisite resources.',
       'KRO_PREREQUISITES_DEPLOY_ONLY',
       { factoryName: this.name, apiName }
     );
@@ -1845,6 +1947,14 @@ export class KroResourceFactoryImpl<
 
   private isClusterScopedPrerequisite(resource: KubernetesResource): boolean {
     return CLUSTER_SCOPED_PREREQUISITE_KINDS.has(`${resource.apiVersion}/${resource.kind}`);
+  }
+
+  private prerequisiteScope(resource: PrerequisiteResource): 'cluster' | 'namespaced' | undefined {
+    return (
+      getMetadataField(resource as object, 'scope') ??
+      (resource as { scope?: 'cluster' | 'namespaced' }).scope ??
+      (this.isClusterScopedPrerequisite(resource) ? 'cluster' : undefined)
+    );
   }
 
   /**

--- a/src/core/types/deployment.ts
+++ b/src/core/types/deployment.ts
@@ -566,18 +566,23 @@ export interface KroPrerequisiteContext {
   readonly timeout: number;
   /** Apply a prerequisite resource through TypeKro's deployment engine. */
   deployResource(
-    resource: KubernetesResource,
+    resource: PrerequisiteResource,
     options?: { waitForReady?: boolean }
   ): Promise<DeployedResource>;
   /** Wait for a CRD to become Established. */
   waitForCRDReady(crdName: string, timeout?: number): Promise<void>;
 }
 
+/** Resource applied before a KRO ResourceGraphDefinition. */
+export type PrerequisiteResource =
+  | Enhanced<unknown, unknown>
+  | (KubernetesResource & { scope?: 'cluster' | 'namespaced' });
+
 /** Public KRO prerequisite deployment options. */
 export interface KroPrerequisiteOptions {
-  /** Resources to apply before the KRO ResourceGraphDefinition is deployed. */
-  readonly resources?: readonly KubernetesResource[];
-  /** Advanced hook for custom prerequisite work before the RGD is deployed. */
+  /** Resources to apply or emit before the KRO ResourceGraphDefinition is deployed. */
+  readonly resources?: readonly PrerequisiteResource[];
+  /** Advanced deploy-only hook for custom prerequisite work before the RGD is deployed. */
   readonly beforeResourceGraphDefinition?: (
     context: KroPrerequisiteContext
   ) => Promise<void> | void;

--- a/src/core/types/deployment.ts
+++ b/src/core/types/deployment.ts
@@ -3,6 +3,7 @@
  */
 
 import type { KubeConfig, KubernetesObjectApi } from '@kubernetes/client-node';
+import type { AlchemyResourceDeclaration } from '../../alchemy/types.js';
 import {
   CALLABLE_COMPOSITION_BRAND,
   NESTED_COMPOSITION_BRAND,
@@ -14,7 +15,6 @@ import type { HttpTimeoutConfig } from '../kubernetes/index.js';
 import type { KubernetesRef } from './common.js';
 import type { Composable } from './composable.js';
 import type { DeployableK8sResource, Enhanced, KubernetesResource } from './kubernetes.js';
-import type { AlchemyResourceDeclaration } from '../../alchemy/types.js';
 import type { InferType, KroCompatibleType, SchemaProxy } from './schema.js';
 
 /**
@@ -554,6 +554,35 @@ export interface SingletonDefinitionRecord<
   readonly spec: TSpec;
 }
 
+/** Context passed to KRO prerequisite hooks before the ResourceGraphDefinition is deployed. */
+export interface KroPrerequisiteContext {
+  /** Configured Kubernetes Object API used by this factory deployment. */
+  readonly kubernetesApi: KubernetesObjectApi;
+  /** Configured KubeConfig used by this factory deployment. */
+  readonly kubeConfig: KubeConfig;
+  /** Factory namespace. */
+  readonly namespace: string;
+  /** Timeout budget in milliseconds for prerequisite deployment operations. */
+  readonly timeout: number;
+  /** Apply a prerequisite resource through TypeKro's deployment engine. */
+  deployResource(
+    resource: KubernetesResource,
+    options?: { waitForReady?: boolean }
+  ): Promise<DeployedResource>;
+  /** Wait for a CRD to become Established. */
+  waitForCRDReady(crdName: string, timeout?: number): Promise<void>;
+}
+
+/** Public KRO prerequisite deployment options. */
+export interface KroPrerequisiteOptions {
+  /** Resources to apply before the KRO ResourceGraphDefinition is deployed. */
+  readonly resources?: readonly KubernetesResource[];
+  /** Advanced hook for custom prerequisite work before the RGD is deployed. */
+  readonly beforeResourceGraphDefinition?: (
+    context: KroPrerequisiteContext
+  ) => Promise<void> | void;
+}
+
 /**
  * Options passed to `deploy()` on a `TypedResourceGraph`.
  *
@@ -577,6 +606,9 @@ export interface PublicFactoryOptions extends BaseDeploymentConfig {
 
   /** Deployment closures for direct-mode factories */
   closures?: Record<string, DeploymentClosure>;
+
+  /** KRO-only resources or hook to run before the ResourceGraphDefinition is deployed. */
+  kroPrerequisites?: KroPrerequisiteOptions;
 
   /**
    * SECURITY WARNING: Only set to true in non-production environments.

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -11,19 +11,22 @@
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
 import * as yaml from 'js-yaml';
+import { getCurrentCompositionContext } from '../../src/core/composition/context.js';
 import { DirectDeploymentEngine } from '../../src/core/deployment/engine.js';
 import { createKroResourceFactory } from '../../src/core/deployment/kro-factory.js';
 import { waitForKroInstanceReady } from '../../src/core/deployment/kro-readiness.js';
 import { singletonSpecFingerprintAnnotationValue } from '../../src/core/deployment/singleton-owner-drift.js';
-import { getCurrentCompositionContext } from '../../src/core/composition/context.js';
 import { ValidationError } from '../../src/core/errors.js';
-import type { KroResourceFactory } from '../../src/core/types/deployment.js';
-import type { SingletonDefinitionRecord } from '../../src/core/types/deployment.js';
+import { getSingletonResourceId } from '../../src/core/singleton/singleton.js';
+import type {
+  KroPrerequisiteContext,
+  KroResourceFactory,
+  SingletonDefinitionRecord,
+} from '../../src/core/types/deployment.js';
 import type { KubernetesResource } from '../../src/core/types/kubernetes.js';
 import type { SchemaDefinition } from '../../src/core/types/serialization.js';
-import { getSingletonResourceId } from '../../src/core/singleton/singleton.js';
-import { kubernetesComposition, singleton } from '../../src/index.js';
 import { Deployment } from '../../src/factories/simple/index.js';
+import { kubernetesComposition, singleton } from '../../src/index.js';
 import { CEL_EXPRESSION_BRAND, KUBERNETES_REF_BRAND } from '../../src/shared/brands.js';
 
 // ---------------------------------------------------------------------------
@@ -60,6 +63,127 @@ describe('Kro readiness polling', () => {
         rgdName: 'example',
       })
     ).rejects.toThrow('Timeout waiting for Kro instance stale-ready');
+  });
+});
+
+describe('KroResourceFactory: prerequisite deployment', () => {
+  it('applies configured prerequisite resources before RGD deployment and waits for CRDs', async () => {
+    const crd: KubernetesResource = {
+      apiVersion: 'apiextensions.k8s.io/v1',
+      kind: 'CustomResourceDefinition',
+      metadata: { name: 'widgets.example.com' },
+      spec: {
+        group: 'example.com',
+        names: { kind: 'Widget', plural: 'widgets' },
+        scope: 'Namespaced',
+        versions: [
+          {
+            name: 'v1',
+            served: true,
+            storage: true,
+            schema: { openAPIV3Schema: { type: 'object' } },
+          },
+        ],
+      },
+    };
+    const configMap: KubernetesResource = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'bootstrap', namespace: 'apps' },
+      data: { ready: 'true' },
+    };
+    const factory = makeFactory('prereqApp', {
+      namespace: 'apps',
+      kroPrerequisites: { resources: [crd, configMap] },
+    });
+    const deployedResources: KubernetesResource[] = [];
+    const waitedCRDs: string[] = [];
+    const engine = {
+      deployResource: async (
+        resource: KubernetesResource & { id?: string },
+        options: Record<string, unknown>
+      ) => {
+        deployedResources.push(resource);
+        expect(options).toMatchObject({ mode: 'direct', namespace: 'apps', waitForReady: false });
+        return {
+          id: resource.id ?? 'unknown',
+          kind: resource.kind,
+          name: resource.metadata.name ?? 'unknown',
+          namespace: resource.metadata.namespace ?? 'default',
+          manifest: resource,
+          status: 'deployed' as const,
+          deployedAt: new Date(0),
+        };
+      },
+      waitForCRDReady: async (name: string) => {
+        waitedCRDs.push(name);
+      },
+      getKubernetesApi: () => ({}),
+    };
+
+    const applyKroPrerequisites = getPrivateMethod(factory, 'applyKroPrerequisites') as (
+      deploymentEngine: DirectDeploymentEngine
+    ) => Promise<void>;
+
+    await applyKroPrerequisites(engine as unknown as DirectDeploymentEngine);
+
+    expect(deployedResources.map((resource) => resource.kind)).toEqual([
+      'CustomResourceDefinition',
+      'ConfigMap',
+    ]);
+    expect(deployedResources[0]?.id).toBe('CustomResourceDefinition-widgets.example.com');
+    expect(waitedCRDs).toEqual(['widgets.example.com']);
+  });
+
+  it('passes deployment helpers to beforeResourceGraphDefinition hooks', async () => {
+    const hookResource: KubernetesResource = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'hook-bootstrap', namespace: 'apps' },
+      data: { ready: 'true' },
+    };
+    const calls: string[] = [];
+    const factory = makeFactory('hookPrereqApp', {
+      namespace: 'apps',
+      timeout: 1234,
+      kroPrerequisites: {
+        beforeResourceGraphDefinition: async (context: KroPrerequisiteContext) => {
+          expect(context.namespace).toBe('apps');
+          expect(context.timeout).toBe(1234);
+          await context.deployResource(hookResource, { waitForReady: true });
+          await context.waitForCRDReady('widgets.example.com');
+        },
+      },
+    });
+    (factory as unknown as Record<string, unknown>).getKubeConfig = () => ({
+      currentContext: 'test',
+    });
+    const engine = {
+      deployResource: async (resource: KubernetesResource, options: Record<string, unknown>) => {
+        calls.push(`deploy:${resource.kind}:${String(options.waitForReady)}`);
+        return {
+          id: resource.id ?? 'hook-resource',
+          kind: resource.kind,
+          name: resource.metadata.name ?? 'unknown',
+          namespace: resource.metadata.namespace ?? 'default',
+          manifest: resource,
+          status: 'deployed' as const,
+          deployedAt: new Date(0),
+        };
+      },
+      waitForCRDReady: async (name: string, timeout?: number) => {
+        calls.push(`wait:${name}:${String(timeout)}`);
+      },
+      getKubernetesApi: () => ({ marker: 'api' }),
+    };
+
+    const applyKroPrerequisites = getPrivateMethod(factory, 'applyKroPrerequisites') as (
+      deploymentEngine: DirectDeploymentEngine
+    ) => Promise<void>;
+
+    await applyKroPrerequisites(engine as unknown as DirectDeploymentEngine);
+
+    expect(calls).toEqual(['deploy:ConfigMap:true', 'wait:widgets.example.com:1234']);
   });
 });
 
@@ -732,9 +856,9 @@ describe('KroResourceFactory: toAlchemyResources (alchemy v2)', () => {
       { name: 'web', replicas: 1 },
       { instanceNameOverride: 'custom-instance' }
     );
-    expect(
-      (decls[1]!.props.resource as { metadata?: { name?: string } }).metadata?.name
-    ).toBe('custom-instance');
+    expect((decls[1]!.props.resource as { metadata?: { name?: string } }).metadata?.name).toBe(
+      'custom-instance'
+    );
   });
 
   it('emits singleton owner declarations (RGD + instance) before the consumer, not skipped', async () => {
@@ -825,7 +949,8 @@ describe('KroResourceFactory: toAlchemyResources (alchemy v2)', () => {
     );
     const decls = await factory.toAlchemyResources({ name: 'web', replicas: 1 });
 
-    const byKind = (k: string) => decls.find((d) => (d.props.resource as { kind?: string }).kind === k)!;
+    const byKind = (k: string) =>
+      decls.find((d) => (d.props.resource as { kind?: string }).kind === k)!;
     const deeperInstance = byKind('DeeperOp');
     const midInstance = byKind('MidOp');
     const consumerInstance = decls[decls.length - 1]!;

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -17,6 +17,7 @@ import { createKroResourceFactory } from '../../src/core/deployment/kro-factory.
 import { waitForKroInstanceReady } from '../../src/core/deployment/kro-readiness.js';
 import { singletonSpecFingerprintAnnotationValue } from '../../src/core/deployment/singleton-owner-drift.js';
 import { ValidationError } from '../../src/core/errors.js';
+import { getMetadataField, getReadinessEvaluator } from '../../src/core/metadata/index.js';
 import { getSingletonResourceId } from '../../src/core/singleton/singleton.js';
 import type {
   KroPrerequisiteContext,
@@ -25,7 +26,7 @@ import type {
 } from '../../src/core/types/deployment.js';
 import type { KubernetesResource } from '../../src/core/types/kubernetes.js';
 import type { SchemaDefinition } from '../../src/core/types/serialization.js';
-import { Deployment } from '../../src/factories/simple/index.js';
+import { ConfigMap, Deployment } from '../../src/factories/simple/index.js';
 import { kubernetesComposition, singleton } from '../../src/index.js';
 import { CEL_EXPRESSION_BRAND, KUBERNETES_REF_BRAND } from '../../src/shared/brands.js';
 
@@ -132,16 +133,17 @@ describe('KroResourceFactory: prerequisite deployment', () => {
       'ConfigMap',
     ]);
     expect(deployedResources[0]?.id).toBe('CustomResourceDefinition-widgets.example.com');
+    expect(getMetadataField(deployedResources[0]!, 'scope')).toBe('cluster');
+    expect(deployedResources[0]?.metadata.namespace).toBeUndefined();
     expect(waitedCRDs).toEqual(['widgets.example.com']);
   });
 
   it('passes deployment helpers to beforeResourceGraphDefinition hooks', async () => {
-    const hookResource: KubernetesResource = {
-      apiVersion: 'v1',
-      kind: 'ConfigMap',
-      metadata: { name: 'hook-bootstrap', namespace: 'apps' },
+    const hookResource = ConfigMap({
+      name: 'hook-bootstrap',
+      namespace: 'apps',
       data: { ready: 'true' },
-    };
+    });
     const calls: string[] = [];
     const factory = makeFactory('hookPrereqApp', {
       namespace: 'apps',
@@ -160,6 +162,7 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     });
     const engine = {
       deployResource: async (resource: KubernetesResource, options: Record<string, unknown>) => {
+        expect(typeof getReadinessEvaluator(resource)).toBe('function');
         calls.push(`deploy:${resource.kind}:${String(options.waitForReady)}`);
         return {
           id: resource.id ?? 'hook-resource',
@@ -184,6 +187,28 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     await applyKroPrerequisites(engine as unknown as DirectDeploymentEngine);
 
     expect(calls).toEqual(['deploy:ConfigMap:true', 'wait:widgets.example.com:1234']);
+  });
+
+  it('rejects declarative output when kroPrerequisites are configured', async () => {
+    const factory = makeFactory('declarativePrereqApp', {
+      kroPrerequisites: {
+        resources: [
+          {
+            apiVersion: 'apiextensions.k8s.io/v1',
+            kind: 'CustomResourceDefinition',
+            metadata: { name: 'widgets.example.com' },
+          },
+        ],
+      },
+    });
+
+    expect(() => factory.toYaml()).toThrow('toYaml() does not support kroPrerequisites');
+    expect(() => factory.toYaml({ name: 'web', replicas: 1 })).toThrow(
+      'toYaml() does not support kroPrerequisites'
+    );
+    await expect(factory.toAlchemyResources({ name: 'web', replicas: 1 })).rejects.toThrow(
+      'toAlchemyResources() does not support kroPrerequisites'
+    );
   });
 });
 

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -280,7 +280,7 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     expect(docs[1]?.metadata?.namespace).toBe('default');
   });
 
-  it('emits resource prerequisites as Alchemy declarations that the RGD depends on', async () => {
+  it('emits resource prerequisites as ordered Alchemy declarations that the RGD depends on', async () => {
     const factory = makeFactory('alchemyPrereqApp', {
       namespace: 'apps',
       kroPrerequisites: {
@@ -321,6 +321,8 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     expect(getMetadataField(decls[0]!.props.resource, 'scope')).toBe('cluster');
     expect((decls[0]?.props.resource as KubernetesResource).metadata.namespace).toBeUndefined();
     expect((decls[1]?.props.resource as KubernetesResource).metadata.namespace).toBe('apps');
+    expect(decls[0]?.dependsOn).toEqual([]);
+    expect(decls[1]?.dependsOn).toEqual([decls[0]!.id]);
     expect(decls[2]?.dependsOn).toEqual([decls[0]!.id, decls[1]!.id]);
     expect(decls[3]?.dependsOn).toContain(decls[2]!.id);
   });

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -189,6 +189,65 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     expect(calls).toEqual(['deploy:ConfigMap:true', 'wait:widgets.example.com:1234']);
   });
 
+  it('treats common raw cluster-scoped prerequisite manifests as cluster-scoped', async () => {
+    const namespace: KubernetesResource = {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: { name: 'apps', namespace: 'should-be-stripped' },
+    };
+    const clusterRole: KubernetesResource = {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: { name: 'bootstrap-reader', namespace: 'should-be-stripped' },
+      rules: [],
+    };
+    const storageClass: KubernetesResource = {
+      apiVersion: 'storage.k8s.io/v1',
+      kind: 'StorageClass',
+      metadata: { name: 'fast', namespace: 'should-be-stripped' },
+      provisioner: 'example.com/provisioner',
+    };
+    const serviceAccount: KubernetesResource = {
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
+      metadata: { name: 'bootstrap', namespace: 'apps' },
+    };
+    const factory = makeFactory('rawClusterPrereqApp', {
+      namespace: 'apps',
+      kroPrerequisites: { resources: [namespace, clusterRole, storageClass, serviceAccount] },
+    });
+    const deployedResources: KubernetesResource[] = [];
+    const engine = {
+      deployResource: async (resource: KubernetesResource & { id?: string }) => {
+        deployedResources.push(resource);
+        return {
+          id: resource.id ?? 'unknown',
+          kind: resource.kind,
+          name: resource.metadata.name ?? 'unknown',
+          namespace: resource.metadata.namespace ?? 'default',
+          manifest: resource,
+          status: 'deployed' as const,
+          deployedAt: new Date(0),
+        };
+      },
+      waitForCRDReady: async () => {},
+      getKubernetesApi: () => ({}),
+    };
+
+    const applyKroPrerequisites = getPrivateMethod(factory, 'applyKroPrerequisites') as (
+      deploymentEngine: DirectDeploymentEngine
+    ) => Promise<void>;
+
+    await applyKroPrerequisites(engine as unknown as DirectDeploymentEngine);
+
+    for (const resource of deployedResources.slice(0, 3)) {
+      expect(getMetadataField(resource, 'scope')).toBe('cluster');
+      expect(resource.metadata.namespace).toBeUndefined();
+    }
+    expect(getMetadataField(deployedResources[3]!, 'scope')).toBeUndefined();
+    expect(deployedResources[3]?.metadata.namespace).toBe('apps');
+  });
+
   it('rejects declarative output when kroPrerequisites are configured', async () => {
     const factory = makeFactory('declarativePrereqApp', {
       kroPrerequisites: {

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -248,7 +248,7 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     expect(deployedResources[3]?.metadata.namespace).toBe('apps');
   });
 
-  it('rejects declarative output when kroPrerequisites are configured', async () => {
+  it('emits resource prerequisites before the RGD in YAML output', () => {
     const factory = makeFactory('declarativePrereqApp', {
       kroPrerequisites: {
         resources: [
@@ -257,16 +257,86 @@ describe('KroResourceFactory: prerequisite deployment', () => {
             kind: 'CustomResourceDefinition',
             metadata: { name: 'widgets.example.com' },
           },
+          {
+            apiVersion: 'v1',
+            kind: 'ConfigMap',
+            metadata: { name: 'bootstrap' },
+            data: { ready: 'true' },
+          },
         ],
       },
     });
 
-    expect(() => factory.toYaml()).toThrow('toYaml() does not support kroPrerequisites');
-    expect(() => factory.toYaml({ name: 'web', replicas: 1 })).toThrow(
-      'toYaml() does not support kroPrerequisites'
+    const docs = yaml.loadAll(factory.toYaml()) as Array<{
+      kind?: string;
+      metadata?: { name?: string; namespace?: string };
+    }>;
+    expect(docs.map((doc) => doc.kind)).toEqual([
+      'CustomResourceDefinition',
+      'ConfigMap',
+      'ResourceGraphDefinition',
+    ]);
+    expect(docs[0]?.metadata?.namespace).toBeUndefined();
+    expect(docs[1]?.metadata?.namespace).toBe('default');
+  });
+
+  it('emits resource prerequisites as Alchemy declarations that the RGD depends on', async () => {
+    const factory = makeFactory('alchemyPrereqApp', {
+      namespace: 'apps',
+      kroPrerequisites: {
+        resources: [
+          {
+            apiVersion: 'apiextensions.k8s.io/v1',
+            kind: 'CustomResourceDefinition',
+            metadata: { name: 'widgets.example.com' },
+          },
+          {
+            apiVersion: 'v1',
+            kind: 'ConfigMap',
+            metadata: { name: 'bootstrap' },
+            data: { ready: 'true' },
+          },
+        ],
+      },
+    });
+    (factory as unknown as Record<string, unknown>).getKubeConfig = () => ({
+      getCurrentCluster: () => ({
+        name: 'test-cluster',
+        server: 'https://example.invalid',
+        skipTLSVerify: false,
+      }),
+      getCurrentUser: () => ({ name: 'admin', token: 'tok' }),
+      getCurrentContext: () => 'ctx',
+    });
+
+    const decls = await factory.toAlchemyResources({ name: 'web', replicas: 1 });
+    expect(decls.map((decl) => (decl.props.resource as { kind?: string }).kind)).toEqual([
+      'CustomResourceDefinition',
+      'ConfigMap',
+      'ResourceGraphDefinition',
+      'TestApp',
+    ]);
+    expect(decls[0]?.props.deploymentStrategy).toBe('direct');
+    expect(decls[0]?.props.options?.waitForReady).toBe(true);
+    expect(getMetadataField(decls[0]!.props.resource, 'scope')).toBe('cluster');
+    expect((decls[0]?.props.resource as KubernetesResource).metadata.namespace).toBeUndefined();
+    expect((decls[1]?.props.resource as KubernetesResource).metadata.namespace).toBe('apps');
+    expect(decls[2]?.dependsOn).toEqual([decls[0]!.id, decls[1]!.id]);
+    expect(decls[3]?.dependsOn).toContain(decls[2]!.id);
+  });
+
+  it('rejects declarative output only when the live prerequisite hook is configured', async () => {
+    const factory = makeFactory('hookDeclarativePrereqApp', {
+      kroPrerequisites: {
+        beforeResourceGraphDefinition: () => {},
+      },
+    });
+
+    expect(() => factory.toYaml()).toThrow(
+      'toYaml() does not support kroPrerequisites.beforeResourceGraphDefinition'
     );
     await expect(factory.toAlchemyResources({ name: 'web', replicas: 1 })).rejects.toThrow(
-      'toAlchemyResources() does not support kroPrerequisites'
+      'toAlchemyResources() does not support kroPrerequisites.beforeResourceGraphDefinition'
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add public KRO prerequisite factory options for resources and a beforeResourceGraphDefinition hook
- Apply prerequisite resources before KRO ResourceGraphDefinition deployment in both direct and Alchemy KRO paths
- Wait for prerequisite CRDs to become Established before submitting the RGD

## Validation
- bun test test/core/kro-factory-characterization.test.ts --timeout 10000
- bun run typecheck:lib
- bun run typecheck:tests
- bunx biome check src/core/types/deployment.ts src/core/deployment/kro-factory.ts test/core/kro-factory-characterization.test.ts
- commit hook ran broader unit suite: 4376 pass, 12 skip, 1 todo, 0 fail