### PR TITLE
Refine resource scope metadata for KRO prerequisites

### DIFF
--- a/docs/api/valkey/index.md
+++ b/docs/api/valkey/index.md
@@ -139,7 +139,7 @@ import { valkeyBootstrap } from 'typekro/valkey';
 // 'kro' = KRO mode — creates a ResourceGraphDefinition for continuous reconciliation
 // 'direct' = Direct mode — applies resources immediately without KRO controller
 const factory = valkeyBootstrap.factory('kro', {
-  namespace: 'valkey-operator-system',  // Namespace for the ResourceGraphDefinition
+  namespace: 'valkey-operator-system',  // Namespace for the KRO instance and workloads
   waitForReady: true,
 });
 

--- a/src/alchemy/deployers.ts
+++ b/src/alchemy/deployers.ts
@@ -13,7 +13,6 @@ import {
   applyResourceScopeMetadata,
   copyResourceMetadata,
   getReadinessEvaluator,
-  setMetadataField,
 } from '../core/metadata/index.js';
 import { ensureReadinessEvaluator } from '../core/readiness/index.js';
 import { generateDeterministicResourceId, getResourceId } from '../core/resources/id.js';
@@ -22,28 +21,6 @@ import type { DeployableK8sResource, Enhanced } from '../core/types/kubernetes.j
 import type { TypeKroDeployer } from './types.js';
 
 const logger = getComponentLogger('deployers');
-
-const LEGACY_ALCHEMY_CLUSTER_SCOPED_RESOURCES = new Set([
-  'admissionregistration.k8s.io/v1/MutatingWebhookConfiguration',
-  'admissionregistration.k8s.io/v1/ValidatingWebhookConfiguration',
-  'apiregistration.k8s.io/v1/APIService',
-  'apiextensions.k8s.io/v1/CustomResourceDefinition',
-  'certificates.k8s.io/v1/CertificateSigningRequest',
-  'kro.run/v1alpha1/ResourceGraphDefinition',
-  'networking.k8s.io/v1/IngressClass',
-  'node.k8s.io/v1/RuntimeClass',
-  'rbac.authorization.k8s.io/v1/ClusterRole',
-  'rbac.authorization.k8s.io/v1/ClusterRoleBinding',
-  'scheduling.k8s.io/v1/PriorityClass',
-  'storage.k8s.io/v1/CSIDriver',
-  'storage.k8s.io/v1/CSINode',
-  'storage.k8s.io/v1/StorageClass',
-  'storage.k8s.io/v1/VolumeAttachment',
-  'v1/ComponentStatus',
-  'v1/Namespace',
-  'v1/Node',
-  'v1/PersistentVolume',
-]);
 
 export class ResourceGraphDefinitionDeletionDeferredError extends Error {
   constructor(rgdName: string) {
@@ -84,16 +61,9 @@ function isKroManagedDeletionMode(
   );
 }
 
-function legacyAlchemyClusterScopeForDelete(resource: Enhanced<any, any>): 'cluster' | undefined {
-  return LEGACY_ALCHEMY_CLUSTER_SCOPED_RESOURCES.has(`${resource.apiVersion}/${resource.kind}`)
-    ? 'cluster'
-    : undefined;
-}
-
 function applyAlchemyResourceScopeMetadata(resource: Enhanced<any, any>): 'cluster' | 'namespaced' | undefined {
-  const scope = applyResourceScopeMetadata(resource) ?? legacyAlchemyClusterScopeForDelete(resource);
+  const scope = applyResourceScopeMetadata(resource);
   if (scope === 'cluster') {
-    setMetadataField(resource, 'scope', 'cluster');
     delete (resource.metadata as Record<string, unknown> | undefined)?.namespace;
   }
   return scope;

--- a/src/alchemy/deployers.ts
+++ b/src/alchemy/deployers.ts
@@ -10,8 +10,8 @@ import { DependencyGraph } from '../core/dependencies/index.js';
 import { ResourceDeploymentError } from '../core/deployment/errors.js';
 import { getComponentLogger } from '../core/logging/index.js';
 import {
+  applyResourceScopeMetadata,
   copyResourceMetadata,
-  getMetadataField,
   getReadinessEvaluator,
   setMetadataField,
 } from '../core/metadata/index.js';
@@ -23,23 +23,33 @@ import type { TypeKroDeployer } from './types.js';
 
 const logger = getComponentLogger('deployers');
 
-const CLUSTER_SCOPED_KINDS = new Set([
-  'Namespace',
-  'Node',
-  'PersistentVolume',
-  'StorageClass',
-  'CustomResourceDefinition',
-  'ResourceGraphDefinition',
-  'ClusterRole',
-  'ClusterRoleBinding',
-  'MutatingWebhookConfiguration',
-  'ValidatingWebhookConfiguration',
-  'APIService',
+const LEGACY_ALCHEMY_CLUSTER_SCOPED_RESOURCES = new Set([
+  'admissionregistration.k8s.io/v1/MutatingWebhookConfiguration',
+  'admissionregistration.k8s.io/v1/ValidatingWebhookConfiguration',
+  'apiregistration.k8s.io/v1/APIService',
+  'apiextensions.k8s.io/v1/CustomResourceDefinition',
+  'certificates.k8s.io/v1/CertificateSigningRequest',
+  'kro.run/v1alpha1/ResourceGraphDefinition',
+  'networking.k8s.io/v1/IngressClass',
+  'node.k8s.io/v1/RuntimeClass',
+  'rbac.authorization.k8s.io/v1/ClusterRole',
+  'rbac.authorization.k8s.io/v1/ClusterRoleBinding',
+  'scheduling.k8s.io/v1/PriorityClass',
+  'storage.k8s.io/v1/CSIDriver',
+  'storage.k8s.io/v1/CSINode',
+  'storage.k8s.io/v1/StorageClass',
+  'storage.k8s.io/v1/VolumeAttachment',
+  'v1/ComponentStatus',
+  'v1/Namespace',
+  'v1/Node',
+  'v1/PersistentVolume',
 ]);
 
 export class ResourceGraphDefinitionDeletionDeferredError extends Error {
   constructor(rgdName: string) {
-    super(`ResourceGraphDefinition deletion deferred because KRO instances still exist for ${rgdName}`);
+    super(
+      `ResourceGraphDefinition deletion deferred because KRO instances still exist for ${rgdName}`
+    );
     this.name = 'ResourceGraphDefinitionDeletionDeferredError';
   }
 }
@@ -62,15 +72,31 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function isKroManagedDeletionMode(resource: Enhanced<any, any>, options: DeploymentOptions): boolean {
+function isKroManagedDeletionMode(
+  resource: Enhanced<any, any>,
+  options: DeploymentOptions
+): boolean {
   return (
     resource.kind !== 'ResourceGraphDefinition' &&
-    (options.mode === 'kro' || options.mode === 'alchemy' || /(?:^|\.)kro\.run\//.test(resource.apiVersion ?? ''))
+    (options.mode === 'kro' ||
+      options.mode === 'alchemy' ||
+      /(?:^|\.)kro\.run\//.test(resource.apiVersion ?? ''))
   );
 }
 
-function isKnownClusterScopedResource(resource: Enhanced<any, any>): boolean {
-  return CLUSTER_SCOPED_KINDS.has(resource.kind || '');
+function legacyAlchemyClusterScopeForDelete(resource: Enhanced<any, any>): 'cluster' | undefined {
+  return LEGACY_ALCHEMY_CLUSTER_SCOPED_RESOURCES.has(`${resource.apiVersion}/${resource.kind}`)
+    ? 'cluster'
+    : undefined;
+}
+
+function applyAlchemyResourceScopeMetadata(resource: Enhanced<any, any>): 'cluster' | 'namespaced' | undefined {
+  const scope = applyResourceScopeMetadata(resource) ?? legacyAlchemyClusterScopeForDelete(resource);
+  if (scope === 'cluster') {
+    setMetadataField(resource, 'scope', 'cluster');
+    delete (resource.metadata as Record<string, unknown> | undefined)?.namespace;
+  }
+  return scope;
 }
 
 /**
@@ -126,6 +152,7 @@ export class DirectTypeKroDeployer implements TypeKroDeployer {
     // 2. Looks up the evaluator in the global ReadinessEvaluatorRegistry by kind
     // 3. Throws an error if no evaluator is found
     const resourceWithEvaluator = ensureReadinessEvaluator(resource);
+    applyAlchemyResourceScopeMetadata(resourceWithEvaluator);
 
     logger.debug('Ensured readiness evaluator for resource', {
       kind: resource.kind,
@@ -173,17 +200,17 @@ export class DirectTypeKroDeployer implements TypeKroDeployer {
     resource: T,
     options: DeploymentOptions
   ): Promise<void> {
-    if (getMetadataField(resource, 'scope') !== 'cluster' && isKnownClusterScopedResource(resource)) {
-      setMetadataField(resource, 'scope', 'cluster');
-    }
+    const scope = applyAlchemyResourceScopeMetadata(resource);
 
     // Create a DeployedResource for the deleteResource method
-    const isClusterScoped = getMetadataField(resource, 'scope') === 'cluster';
+    const isClusterScoped = scope === 'cluster';
     const deployedResource = {
       id: getResourceId(resource, 'unnamed'),
       kind: resource.kind || 'Unknown',
       name: resource.metadata?.name || 'unnamed',
-      namespace: isClusterScoped ? '' : resource.metadata?.namespace || options.namespace || 'default',
+      namespace: isClusterScoped
+        ? ''
+        : resource.metadata?.namespace || options.namespace || 'default',
       manifest: resource,
       status: 'deployed' as const,
       deployedAt: new Date(),
@@ -213,6 +240,8 @@ export class KroTypeKroDeployer implements TypeKroDeployer {
     options: DeploymentOptions,
     _seedResources?: import('../core/types/deployment.js').DeployedResource[] // KRO resolves refs via its controller; seed is direct-mode only.
   ): Promise<T> {
+    applyAlchemyResourceScopeMetadata(resource);
+
     const resourceId =
       resource.id ||
       generateDeterministicResourceId(
@@ -261,19 +290,26 @@ export class KroTypeKroDeployer implements TypeKroDeployer {
   ): Promise<void> {
     if (resource.kind === 'ResourceGraphDefinition') {
       if (this.deployerOptions.deleteInstance) {
-        const shouldSkip = await this.deployerOptions.shouldSkipRgdDelete?.(resource.metadata?.name || 'unnamed') ?? true;
+        const shouldSkip =
+          (await this.deployerOptions.shouldSkipRgdDelete?.(
+            resource.metadata?.name || 'unnamed'
+          )) ?? true;
         if (shouldSkip) {
           logger.debug('Deferring Alchemy RGD delete while KRO instances still exist', {
             name: resource.metadata?.name,
           });
-          throw new ResourceGraphDefinitionDeletionDeferredError(resource.metadata?.name || 'unnamed');
+          throw new ResourceGraphDefinitionDeletionDeferredError(
+            resource.metadata?.name || 'unnamed'
+          );
         }
 
         logger.debug('Deleting Alchemy RGD because no KRO instances exist', {
           name: resource.metadata?.name,
         });
         if (this.deployerOptions.deleteResourceGraphDefinition) {
-          await this.deployerOptions.deleteResourceGraphDefinition(resource.metadata?.name || 'unnamed');
+          await this.deployerOptions.deleteResourceGraphDefinition(
+            resource.metadata?.name || 'unnamed'
+          );
           return;
         }
       }
@@ -329,12 +365,15 @@ export class KroTypeKroDeployer implements TypeKroDeployer {
       await delay(2000);
     }
 
-    logger.warn('KRO resource deletion still in progress; preserving RGD/CRD for finalizer processing', {
-      kind: resource.kind,
-      name,
-      namespace,
-      timeout,
-    });
+    logger.warn(
+      'KRO resource deletion still in progress; preserving RGD/CRD for finalizer processing',
+      {
+        kind: resource.kind,
+        name,
+        namespace,
+        timeout,
+      }
+    );
     throw new ResourceDeploymentError(
       name,
       resource.kind || 'Unknown',

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -26,6 +26,7 @@ import { createKubernetesClientProvider } from '../core/kubernetes/client-provid
 import { getComponentLogger, type TypeKroLogger } from '../core/logging/index.js';
 import { CEL_EXPRESSION_BRAND } from '../core/constants/brands.js';
 import { createBunCompatibleKubernetesObjectApi } from '../core/kubernetes/index.js';
+import { getResourceScope, type ResourceScope } from '../core/metadata/index.js';
 import { SINGLETON_SPEC_FINGERPRINT_ANNOTATION } from '../core/deployment/resource-tagging.js';
 import { stableSerialize } from '../core/singleton/singleton.js';
 import type { DeployedResource, DeploymentOptions } from '../core/types/deployment.js';
@@ -610,8 +611,11 @@ async function _deployAndCreateResult<T extends Enhanced<unknown, unknown>>(
   //    structuredClone to throw "Cannot serialize unique symbol" errors.
   // 2. JSON round-trip strips symbols, functions, and undefined values — which is
   //    exactly the behavior we want for creating clean Alchemy state entries.
-  const cleanResource = JSON.parse(JSON.stringify(props.resource)) as T;
-  const cleanDeployedResource = JSON.parse(JSON.stringify(deployedResource)) as T;
+  const cleanResource = cloneResourceForAlchemyState(props.resource);
+  const cleanDeployedResource = cloneResourceForAlchemyState(
+    deployedResource as T,
+    getResourceScope(cleanResource)
+  );
 
   // Create the resource properties for Alchemy
   const resourceProperties: DeployedResourceProperties<T> = {
@@ -628,6 +632,27 @@ async function _deployAndCreateResult<T extends Enhanced<unknown, unknown>>(
 
   return { resourceProperties };
 }
+
+function cloneResourceForAlchemyState<T extends Enhanced<unknown, unknown>>(
+  resource: T,
+  fallbackScope?: ResourceScope
+): T {
+  const cleanResource = JSON.parse(JSON.stringify(resource)) as T & { scope?: ResourceScope };
+  const scope =
+    getResourceScope(resource as T & { scope?: ResourceScope }) ??
+    fallbackScope ??
+    cleanResource.scope;
+  if (scope) {
+    cleanResource.scope = scope;
+    if (scope === 'cluster') {
+      delete (cleanResource.metadata as Record<string, unknown> | undefined)?.namespace;
+    }
+  }
+  return cleanResource as T;
+}
+
+/** Internal test hook for Alchemy state serialization semantics. */
+export const cloneResourceForAlchemyStateForTest = cloneResourceForAlchemyState;
 
 export function buildAlchemyDeploymentOptions<T extends Enhanced<unknown, unknown>>(
   props: TypeKroResourceProps<T>

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -33,6 +33,7 @@ import {
   ensureError,
   ResourceGraphFactoryError,
   TypeKroError,
+  ValidationError,
 } from '../errors.js';
 import { applyAnalysisToResources } from '../expressions/composition/composition-analyzer.js';
 import type { KubernetesClientProvider } from '../kubernetes/client-provider.js';
@@ -45,6 +46,7 @@ import {
   copyResourceMetadata,
   getMetadataField,
   getReadinessEvaluator,
+  getResourceScope,
   setMetadataField,
   setReadinessEvaluator,
 } from '../metadata/index.js';
@@ -101,28 +103,6 @@ import {
   assertNoDeployedSingletonSpecDrift,
   singletonSpecFingerprintAnnotationValue,
 } from './singleton-owner-drift.js';
-
-const CLUSTER_SCOPED_PREREQUISITE_KINDS = new Set([
-  'admissionregistration.k8s.io/v1/MutatingWebhookConfiguration',
-  'admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy',
-  'admissionregistration.k8s.io/v1/ValidatingAdmissionPolicyBinding',
-  'admissionregistration.k8s.io/v1/ValidatingWebhookConfiguration',
-  'apiextensions.k8s.io/v1/CustomResourceDefinition',
-  'apiregistration.k8s.io/v1/APIService',
-  'flowcontrol.apiserver.k8s.io/v1/FlowSchema',
-  'flowcontrol.apiserver.k8s.io/v1/PriorityLevelConfiguration',
-  'rbac.authorization.k8s.io/v1/ClusterRole',
-  'rbac.authorization.k8s.io/v1/ClusterRoleBinding',
-  'scheduling.k8s.io/v1/PriorityClass',
-  'node.k8s.io/v1/RuntimeClass',
-  'storage.k8s.io/v1/CSIDriver',
-  'storage.k8s.io/v1/CSINode',
-  'storage.k8s.io/v1/StorageClass',
-  'storage.k8s.io/v1/VolumeAttachment',
-  'v1/Namespace',
-  'v1/Node',
-  'v1/PersistentVolume',
-]);
 
 /**
  * Decide whether the RGD/CRD should be preserved after a `deleteInstance`
@@ -1835,6 +1815,21 @@ export class KroResourceFactoryImpl<
       setMetadataField(deployable, 'scope', 'cluster');
       delete (deployable.metadata as Record<string, unknown>).namespace;
     } else if (!deployable.metadata.namespace) {
+      if (!this.canDefaultPrerequisiteNamespace(resource)) {
+        throw new ValidationError(
+          `KRO prerequisite ${resource.kind}/${name} must declare its scope or namespace. ` +
+            "Set scope: 'cluster' for cluster-scoped prerequisites, " +
+            "or set metadata.namespace / scope: 'namespaced' for namespaced raw prerequisites.",
+          resource.kind,
+          name,
+          'metadata.namespace',
+          [
+            "Use a TypeKro factory resource that carries scope metadata.",
+            "Set scope: 'cluster' on raw cluster-scoped prerequisites.",
+            "Set metadata.namespace or scope: 'namespaced' on raw namespaced prerequisites.",
+          ]
+        );
+      }
       deployable.metadata.namespace = this.namespace;
     }
 
@@ -1948,16 +1943,12 @@ export class KroResourceFactoryImpl<
     return resource.metadata?.name;
   }
 
-  private isClusterScopedPrerequisite(resource: KubernetesResource): boolean {
-    return CLUSTER_SCOPED_PREREQUISITE_KINDS.has(`${resource.apiVersion}/${resource.kind}`);
+  private prerequisiteScope(resource: PrerequisiteResource): 'cluster' | 'namespaced' | undefined {
+    return getResourceScope(resource as object & PrerequisiteResource);
   }
 
-  private prerequisiteScope(resource: PrerequisiteResource): 'cluster' | 'namespaced' | undefined {
-    return (
-      getMetadataField(resource as object, 'scope') ??
-      (resource as { scope?: 'cluster' | 'namespaced' }).scope ??
-      (this.isClusterScopedPrerequisite(resource) ? 'cluster' : undefined)
-    );
+  private canDefaultPrerequisiteNamespace(resource: PrerequisiteResource): boolean {
+    return this.prerequisiteScope(resource) === 'namespaced';
   }
 
   /**

--- a/src/core/deployment/resource-applier.ts
+++ b/src/core/deployment/resource-applier.ts
@@ -77,9 +77,11 @@ export class ResourceApplier {
     // Deep clone to remove any proxy wrappers that might cause serialization issues
     const cleanResource: Record<string, unknown> = JSON.parse(JSON.stringify(jsonResource));
 
-    // Strip internal TypeKro fields that should not be sent to Kubernetes
-    // The 'id' field is used internally for resource mapping but is not a valid K8s field
+    // Strip internal TypeKro fields that should not be sent to Kubernetes.
+    // These fields are used for local resource mapping/scope rehydration but
+    // are not valid top-level Kubernetes manifest fields.
     delete cleanResource.id;
+    delete cleanResource.scope;
 
     return cleanResource;
   }

--- a/src/core/deployment/strategies/kro-strategy.ts
+++ b/src/core/deployment/strategies/kro-strategy.ts
@@ -138,7 +138,6 @@ export class KroDeploymentStrategy<
       kind: 'ResourceGraphDefinition',
       metadata: {
         name: rgdName,
-        namespace: this.namespace,
       },
       spec: {
         schema: kroSchema,

--- a/src/core/metadata/index.ts
+++ b/src/core/metadata/index.ts
@@ -6,6 +6,7 @@
  * @module
  */
 export {
+  applyResourceScopeMetadata,
   clearResourceMetadata,
   copyResourceMetadata,
   getForEach,
@@ -15,10 +16,12 @@ export {
   getReadyWhen,
   getResourceId,
   getResourceMetadata,
+  getResourceScope,
   getTemplateOverrides,
   hasResourceMetadata,
   type ResourceMetadata,
   type ResourceMetadataKey,
+  type ResourceScope,
   setForEach,
   setIncludeWhen,
   setMetadataField,

--- a/src/core/metadata/resource-metadata.ts
+++ b/src/core/metadata/resource-metadata.ts
@@ -98,6 +98,28 @@ export interface ResourceMetadata {
 /** Keys of ResourceMetadata that are valid metadata field names */
 export type ResourceMetadataKey = keyof ResourceMetadata;
 
+export type ResourceScope = NonNullable<ResourceMetadata['scope']>;
+
+type ResourceScopeCandidate = {
+  scope?: ResourceScope;
+};
+
+export function getResourceScope<T extends WeakKey>(
+  resource: T & Partial<ResourceScopeCandidate>
+): ResourceScope | undefined {
+  return getMetadataField(resource, 'scope') ?? resource.scope;
+}
+
+export function applyResourceScopeMetadata<T extends WeakKey>(
+  resource: T
+): ResourceScope | undefined {
+  const scope = getResourceScope(resource as T & Partial<ResourceScopeCandidate>);
+  if (scope) {
+    setMetadataField(resource, 'scope', scope);
+  }
+  return scope;
+}
+
 // ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------

--- a/src/core/types/deployment.ts
+++ b/src/core/types/deployment.ts
@@ -573,7 +573,14 @@ export interface KroPrerequisiteContext {
   waitForCRDReady(crdName: string, timeout?: number): Promise<void>;
 }
 
-/** Resource applied before a KRO ResourceGraphDefinition. */
+/**
+ * Resource applied before a KRO ResourceGraphDefinition.
+ *
+ * Cluster-scoped factory resources carry TypeKro scope metadata automatically. Any prerequisite
+ * without an explicit namespace must be unambiguous: set `scope: 'cluster'` for cluster-scoped raw
+ * prerequisites, or provide `metadata.namespace` / `scope: 'namespaced'` for namespaced
+ * prerequisites that should use the factory namespace.
+ */
 export type PrerequisiteResource =
   | Enhanced<unknown, unknown>
   | (KubernetesResource & { scope?: 'cluster' | 'namespaced' });

--- a/src/factories/kro/kro-crd.ts
+++ b/src/factories/kro/kro-crd.ts
@@ -20,12 +20,15 @@ import { createResource } from '../shared.js';
 export function kroCustomResourceDefinition(
   crd: V1CustomResourceDefinition
 ): Enhanced<V1CustomResourceDefinitionSpec, V1CustomResourceDefinitionStatus> {
-  return createResource({
-    ...crd,
-    apiVersion: 'apiextensions.k8s.io/v1',
-    kind: 'CustomResourceDefinition',
-    metadata: crd.metadata ?? { name: 'unnamed-crd' },
-  }).withReadinessEvaluator((liveCRD: V1CustomResourceDefinition): ResourceStatus => {
+  return createResource(
+    {
+      ...crd,
+      apiVersion: 'apiextensions.k8s.io/v1',
+      kind: 'CustomResourceDefinition',
+      metadata: crd.metadata ?? { name: 'unnamed-crd' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator((liveCRD: V1CustomResourceDefinition): ResourceStatus => {
     try {
       const status = liveCRD.status;
       const conditions = status?.conditions || [];

--- a/src/factories/kro/resource-graph-definition.ts
+++ b/src/factories/kro/resource-graph-definition.ts
@@ -52,17 +52,19 @@ interface ResourceGraphDefinitionInput {
 export function resourceGraphDefinition(
   rgd: ResourceGraphDefinitionInput
 ): Enhanced<Record<string, unknown>, Record<string, unknown>> {
+  const { namespace: _namespace, ...metadata } = rgd.metadata ?? { name: 'unnamed-rgd' };
+
   // For RGDs, we need to preserve the original structure since they don't need magic proxy functionality
   const rgdResource = {
     ...rgd,
     apiVersion: 'kro.run/v1alpha1' as const,
     kind: 'ResourceGraphDefinition' as const,
-    metadata: rgd.metadata ?? { name: 'unnamed-rgd' },
+    metadata,
   };
 
-  return createResource<Record<string, unknown>, Record<string, unknown>>(
-    rgdResource
-  ).withReadinessEvaluator((liveRGD: RGDManifest): ResourceStatus => {
+  return createResource<Record<string, unknown>, Record<string, unknown>>(rgdResource, {
+    scope: 'cluster',
+  }).withReadinessEvaluator((liveRGD: RGDManifest): ResourceStatus => {
     // This robust readiness check ensures the Kro controller has fully processed the RGD.
     try {
       // Defensive checks for the live resource

--- a/src/factories/kubernetes/admission/mutating-webhook-configuration.ts
+++ b/src/factories/kubernetes/admission/mutating-webhook-configuration.ts
@@ -9,10 +9,13 @@ export type V1MutatingWebhookConfigurationWebhooks = NonNullable<
 export function mutatingWebhookConfiguration(
   resource: V1MutatingWebhookConfiguration & { id?: string }
 ) {
-  return createResource({
-    ...resource,
-    apiVersion: 'admissionregistration.k8s.io/v1',
-    kind: 'MutatingWebhookConfiguration',
-    metadata: resource.metadata ?? { name: 'unnamed-mutatingwebhook' },
-  }).withReadinessEvaluator(createAlwaysReadyEvaluator('MutatingWebhookConfiguration'));
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'admissionregistration.k8s.io/v1',
+      kind: 'MutatingWebhookConfiguration',
+      metadata: resource.metadata ?? { name: 'unnamed-mutatingwebhook' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator(createAlwaysReadyEvaluator('MutatingWebhookConfiguration'));
 }

--- a/src/factories/kubernetes/admission/validating-webhook-configuration.ts
+++ b/src/factories/kubernetes/admission/validating-webhook-configuration.ts
@@ -9,10 +9,13 @@ export type V1ValidatingWebhookConfigurationWebhooks = NonNullable<
 export function validatingWebhookConfiguration(
   resource: V1ValidatingWebhookConfiguration & { id?: string }
 ) {
-  return createResource({
-    ...resource,
-    apiVersion: 'admissionregistration.k8s.io/v1',
-    kind: 'ValidatingWebhookConfiguration',
-    metadata: resource.metadata ?? { name: 'unnamed-validatingwebhook' },
-  }).withReadinessEvaluator(createAlwaysReadyEvaluator('ValidatingWebhookConfiguration'));
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'admissionregistration.k8s.io/v1',
+      kind: 'ValidatingWebhookConfiguration',
+      metadata: resource.metadata ?? { name: 'unnamed-validatingwebhook' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator(createAlwaysReadyEvaluator('ValidatingWebhookConfiguration'));
 }

--- a/src/factories/kubernetes/certificates/certificate-signing-request.ts
+++ b/src/factories/kubernetes/certificates/certificate-signing-request.ts
@@ -8,12 +8,15 @@ export type V1CertificateSigningRequestStatus = NonNullable<V1CertificateSigning
 export function certificateSigningRequest(
   resource: V1CertificateSigningRequest & { id?: string }
 ): Enhanced<V1CertificateSigningRequestSpec, V1CertificateSigningRequestStatus> {
-  return createResource({
-    ...resource,
-    apiVersion: 'certificates.k8s.io/v1',
-    kind: 'CertificateSigningRequest',
-    metadata: resource.metadata ?? { name: 'unnamed-csr' },
-  }).withReadinessEvaluator((liveResource: V1CertificateSigningRequest) => {
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'certificates.k8s.io/v1',
+      kind: 'CertificateSigningRequest',
+      metadata: resource.metadata ?? { name: 'unnamed-csr' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator((liveResource: V1CertificateSigningRequest) => {
     const status = liveResource.status;
 
     if (!status) {

--- a/src/factories/kubernetes/core/component-status.ts
+++ b/src/factories/kubernetes/core/component-status.ts
@@ -5,12 +5,15 @@ import { createResource } from '../../shared.js';
 export function componentStatus(
   resource: V1ComponentStatus & { id?: string }
 ): Enhanced<object, unknown> {
-  return createResource({
-    ...resource,
-    apiVersion: 'v1',
-    kind: 'ComponentStatus',
-    metadata: resource.metadata ?? { name: 'unnamed-componentstatus' },
-  }).withReadinessEvaluator((liveResource: V1ComponentStatus) => {
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'v1',
+      kind: 'ComponentStatus',
+      metadata: resource.metadata ?? { name: 'unnamed-componentstatus' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator((liveResource: V1ComponentStatus) => {
     const conditions = liveResource.conditions || [];
     const healthyCondition = conditions.find((c) => c.type === 'Healthy');
 

--- a/src/factories/kubernetes/core/node.ts
+++ b/src/factories/kubernetes/core/node.ts
@@ -6,12 +6,15 @@ export type V1NodeSpec = NonNullable<V1Node['spec']>;
 export type V1NodeStatus = NonNullable<V1Node['status']>;
 
 export function node(resource: V1Node & { id?: string }): Enhanced<V1NodeSpec, V1NodeStatus> {
-  return createResource({
-    ...resource,
-    apiVersion: 'v1',
-    kind: 'Node',
-    metadata: resource.metadata ?? { name: 'unnamed-node' },
-  }).withReadinessEvaluator((liveResource: V1Node) => {
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'v1',
+      kind: 'Node',
+      metadata: resource.metadata ?? { name: 'unnamed-node' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator((liveResource: V1Node) => {
     const status = liveResource.status;
 
     if (!status) {

--- a/src/factories/kubernetes/extensions/custom-resource-definition.ts
+++ b/src/factories/kubernetes/extensions/custom-resource-definition.ts
@@ -8,12 +8,15 @@ export type V1CustomResourceDefinitionStatus = NonNullable<V1CustomResourceDefin
 export function customResourceDefinition(
   resource: V1CustomResourceDefinition & { id?: string }
 ): Enhanced<V1CustomResourceDefinitionSpec, V1CustomResourceDefinitionStatus> {
-  return createResource({
-    ...resource,
-    apiVersion: 'apiextensions.k8s.io/v1',
-    kind: 'CustomResourceDefinition',
-    metadata: resource.metadata ?? { name: 'unnamed-crd' },
-  }).withReadinessEvaluator((liveResource: V1CustomResourceDefinition) => {
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'apiextensions.k8s.io/v1',
+      kind: 'CustomResourceDefinition',
+      metadata: resource.metadata ?? { name: 'unnamed-crd' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator((liveResource: V1CustomResourceDefinition) => {
     const status = liveResource.status;
 
     if (!status) {

--- a/src/factories/kubernetes/networking/ingress-class.ts
+++ b/src/factories/kubernetes/networking/ingress-class.ts
@@ -8,10 +8,13 @@ export type V1IngressClassSpec = NonNullable<V1IngressClass['spec']>;
 export function ingressClass(
   resource: V1IngressClass & { id?: string }
 ): Enhanced<V1IngressClassSpec, unknown> {
-  return createResource({
-    ...resource,
-    apiVersion: 'networking.k8s.io/v1',
-    kind: 'IngressClass',
-    metadata: resource.metadata ?? { name: 'unnamed-ingressclass' },
-  }).withReadinessEvaluator(createAlwaysReadyEvaluator('IngressClass'));
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'IngressClass',
+      metadata: resource.metadata ?? { name: 'unnamed-ingressclass' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator(createAlwaysReadyEvaluator('IngressClass'));
 }

--- a/src/factories/kubernetes/scheduling/runtime-class.ts
+++ b/src/factories/kubernetes/scheduling/runtime-class.ts
@@ -5,10 +5,13 @@ import { createResource } from '../../shared.js';
 export type V1RuntimeClassHandler = V1RuntimeClass;
 
 export function runtimeClass(resource: V1RuntimeClass & { id?: string }) {
-  return createResource({
-    ...resource,
-    apiVersion: 'node.k8s.io/v1',
-    kind: 'RuntimeClass',
-    metadata: resource.metadata ?? { name: 'unnamed-runtimeclass' },
-  }).withReadinessEvaluator(createAlwaysReadyEvaluator('RuntimeClass'));
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'node.k8s.io/v1',
+      kind: 'RuntimeClass',
+      metadata: resource.metadata ?? { name: 'unnamed-runtimeclass' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator(createAlwaysReadyEvaluator('RuntimeClass'));
 }

--- a/src/factories/kubernetes/storage/csi-driver.ts
+++ b/src/factories/kubernetes/storage/csi-driver.ts
@@ -8,10 +8,13 @@ export type V1CSIDriverSpec = NonNullable<V1CSIDriver['spec']>;
 export function csiDriver(
   resource: V1CSIDriver & { id?: string }
 ): Enhanced<V1CSIDriverSpec, unknown> {
-  return createResource({
-    ...resource,
-    apiVersion: 'storage.k8s.io/v1',
-    kind: 'CSIDriver',
-    metadata: resource.metadata ?? { name: 'unnamed-csidriver' },
-  }).withReadinessEvaluator(createAlwaysReadyEvaluator('CSIDriver'));
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'storage.k8s.io/v1',
+      kind: 'CSIDriver',
+      metadata: resource.metadata ?? { name: 'unnamed-csidriver' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator(createAlwaysReadyEvaluator('CSIDriver'));
 }

--- a/src/factories/kubernetes/storage/csi-node.ts
+++ b/src/factories/kubernetes/storage/csi-node.ts
@@ -6,10 +6,13 @@ import { createResource } from '../../shared.js';
 export type V1CSINodeSpec = NonNullable<V1CSINode['spec']>;
 
 export function csiNode(resource: V1CSINode & { id?: string }): Enhanced<V1CSINodeSpec, unknown> {
-  return createResource({
-    ...resource,
-    apiVersion: 'storage.k8s.io/v1',
-    kind: 'CSINode',
-    metadata: resource.metadata ?? { name: 'unnamed-csinode' },
-  }).withReadinessEvaluator(createAlwaysReadyEvaluator('CSINode'));
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'storage.k8s.io/v1',
+      kind: 'CSINode',
+      metadata: resource.metadata ?? { name: 'unnamed-csinode' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator(createAlwaysReadyEvaluator('CSINode'));
 }

--- a/src/factories/kubernetes/storage/persistent-volume.ts
+++ b/src/factories/kubernetes/storage/persistent-volume.ts
@@ -9,12 +9,15 @@ export type V1PvStatus = NonNullable<V1PersistentVolume['status']>;
 export function persistentVolume(
   resource: V1PersistentVolume & { id?: string }
 ): Enhanced<V1PvSpec, V1PvStatus> {
-  return createResource({
-    ...resource,
-    apiVersion: 'v1',
-    kind: 'PersistentVolume',
-    metadata: resource.metadata ?? { name: 'unnamed-pv' },
-  }).withReadinessEvaluator((liveResource: V1PersistentVolume) => {
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'v1',
+      kind: 'PersistentVolume',
+      metadata: resource.metadata ?? { name: 'unnamed-pv' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator((liveResource: V1PersistentVolume) => {
     try {
       const status = liveResource.status;
 

--- a/src/factories/kubernetes/storage/volume-attachment.ts
+++ b/src/factories/kubernetes/storage/volume-attachment.ts
@@ -8,12 +8,15 @@ export type V1VolumeAttachmentStatus = NonNullable<V1VolumeAttachment['status']>
 export function volumeAttachment(
   resource: V1VolumeAttachment & { id?: string }
 ): Enhanced<V1VolumeAttachmentSpec, V1VolumeAttachmentStatus> {
-  return createResource({
-    ...resource,
-    apiVersion: 'storage.k8s.io/v1',
-    kind: 'VolumeAttachment',
-    metadata: resource.metadata ?? { name: 'unnamed-volumeattachment' },
-  }).withReadinessEvaluator((liveResource: V1VolumeAttachment): ResourceStatus => {
+  return createResource(
+    {
+      ...resource,
+      apiVersion: 'storage.k8s.io/v1',
+      kind: 'VolumeAttachment',
+      metadata: resource.metadata ?? { name: 'unnamed-volumeattachment' },
+    },
+    { scope: 'cluster' }
+  ).withReadinessEvaluator((liveResource: V1VolumeAttachment): ResourceStatus => {
     const attached = liveResource.status?.attached;
     if (attached === true) {
       return { ready: true, message: 'VolumeAttachment is attached' };

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -27,7 +27,15 @@ import type {
 import type { KubernetesResource } from '../../src/core/types/kubernetes.js';
 import type { SchemaDefinition } from '../../src/core/types/serialization.js';
 import { ConfigMap, Deployment } from '../../src/factories/simple/index.js';
-import { kubernetesComposition, singleton } from '../../src/index.js';
+import {
+  clusterRole,
+  createResource,
+  customResourceDefinition,
+  kubernetesComposition,
+  namespace,
+  singleton,
+  storageClass,
+} from '../../src/index.js';
 import { CEL_EXPRESSION_BRAND, KUBERNETES_REF_BRAND } from '../../src/shared/brands.js';
 
 // ---------------------------------------------------------------------------
@@ -69,9 +77,7 @@ describe('Kro readiness polling', () => {
 
 describe('KroResourceFactory: prerequisite deployment', () => {
   it('applies configured prerequisite resources before RGD deployment and waits for CRDs', async () => {
-    const crd: KubernetesResource = {
-      apiVersion: 'apiextensions.k8s.io/v1',
-      kind: 'CustomResourceDefinition',
+    const crd = customResourceDefinition({
       metadata: { name: 'widgets.example.com' },
       spec: {
         group: 'example.com',
@@ -86,7 +92,7 @@ describe('KroResourceFactory: prerequisite deployment', () => {
           },
         ],
       },
-    };
+    });
     const configMap: KubernetesResource = {
       apiVersion: 'v1',
       kind: 'ConfigMap',
@@ -132,7 +138,7 @@ describe('KroResourceFactory: prerequisite deployment', () => {
       'CustomResourceDefinition',
       'ConfigMap',
     ]);
-    expect(deployedResources[0]?.id).toBe('CustomResourceDefinition-widgets.example.com');
+    expect(deployedResources[0]?.id).toBe('customresourcedefinitionWidgets.example.com');
     expect(getMetadataField(deployedResources[0]!, 'scope')).toBe('cluster');
     expect(deployedResources[0]?.metadata.namespace).toBeUndefined();
     expect(waitedCRDs).toEqual(['widgets.example.com']);
@@ -189,24 +195,16 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     expect(calls).toEqual(['deploy:ConfigMap:true', 'wait:widgets.example.com:1234']);
   });
 
-  it('treats common raw cluster-scoped prerequisite manifests as cluster-scoped', async () => {
-    const namespace: KubernetesResource = {
-      apiVersion: 'v1',
-      kind: 'Namespace',
-      metadata: { name: 'apps', namespace: 'should-be-stripped' },
-    };
-    const clusterRole: KubernetesResource = {
-      apiVersion: 'rbac.authorization.k8s.io/v1',
-      kind: 'ClusterRole',
-      metadata: { name: 'bootstrap-reader', namespace: 'should-be-stripped' },
+  it('uses factory scope metadata for cluster-scoped prerequisite resources', async () => {
+    const appNamespace = namespace({ metadata: { name: 'apps' } });
+    const bootstrapReader = clusterRole({
+      metadata: { name: 'bootstrap-reader' },
       rules: [],
-    };
-    const storageClass: KubernetesResource = {
-      apiVersion: 'storage.k8s.io/v1',
-      kind: 'StorageClass',
-      metadata: { name: 'fast', namespace: 'should-be-stripped' },
+    });
+    const fastStorage = storageClass({
+      metadata: { name: 'fast' },
       provisioner: 'example.com/provisioner',
-    };
+    });
     const serviceAccount: KubernetesResource = {
       apiVersion: 'v1',
       kind: 'ServiceAccount',
@@ -214,7 +212,9 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     };
     const factory = makeFactory('rawClusterPrereqApp', {
       namespace: 'apps',
-      kroPrerequisites: { resources: [namespace, clusterRole, storageClass, serviceAccount] },
+      kroPrerequisites: {
+        resources: [appNamespace, bootstrapReader, fastStorage, serviceAccount],
+      },
     });
     const deployedResources: KubernetesResource[] = [];
     const engine = {
@@ -252,15 +252,22 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     const factory = makeFactory('declarativePrereqApp', {
       kroPrerequisites: {
         resources: [
-          {
-            apiVersion: 'apiextensions.k8s.io/v1',
-            kind: 'CustomResourceDefinition',
+          customResourceDefinition({
             metadata: { name: 'widgets.example.com' },
-          },
+            spec: {
+              group: 'example.com',
+              names: { kind: 'Widget', plural: 'widgets' },
+              scope: 'Namespaced',
+              versions: [
+                { name: 'v1', served: true, storage: true, schema: { openAPIV3Schema: {} } },
+              ],
+            },
+          }),
           {
             apiVersion: 'v1',
             kind: 'ConfigMap',
             metadata: { name: 'bootstrap' },
+            scope: 'namespaced',
             data: { ready: 'true' },
           },
         ],
@@ -280,20 +287,64 @@ describe('KroResourceFactory: prerequisite deployment', () => {
     expect(docs[1]?.metadata?.namespace).toBe('default');
   });
 
+  it('rejects raw prerequisite resources without scope or namespace', () => {
+    const factory = makeFactory('ambiguousRawPrereqApp', {
+      kroPrerequisites: {
+        resources: [
+          {
+            apiVersion: 'v1',
+            kind: 'Namespace',
+            metadata: { name: 'apps' },
+          },
+        ],
+      },
+    });
+
+    expect(() => factory.toYaml()).toThrow(ValidationError);
+    expect(() => factory.toYaml()).toThrow(
+      'KRO prerequisite Namespace/apps must declare its scope or namespace'
+    );
+  });
+
+  it('rejects enhanced prerequisites without explicit scope or namespace', () => {
+    const bareClusterRole = createResource({
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: { name: 'bare-reader' },
+      rules: [],
+    });
+    const factory = makeFactory('ambiguousEnhancedPrereqApp', {
+      namespace: 'apps',
+      kroPrerequisites: { resources: [bareClusterRole] },
+    });
+
+    expect(() => factory.toYaml()).toThrow(ValidationError);
+    expect(() => factory.toYaml()).toThrow(
+      'KRO prerequisite ClusterRole/bare-reader must declare its scope or namespace'
+    );
+  });
+
   it('emits resource prerequisites as ordered Alchemy declarations that the RGD depends on', async () => {
     const factory = makeFactory('alchemyPrereqApp', {
       namespace: 'apps',
       kroPrerequisites: {
         resources: [
-          {
-            apiVersion: 'apiextensions.k8s.io/v1',
-            kind: 'CustomResourceDefinition',
+          customResourceDefinition({
             metadata: { name: 'widgets.example.com' },
-          },
+            spec: {
+              group: 'example.com',
+              names: { kind: 'Widget', plural: 'widgets' },
+              scope: 'Namespaced',
+              versions: [
+                { name: 'v1', served: true, storage: true, schema: { openAPIV3Schema: {} } },
+              ],
+            },
+          }),
           {
             apiVersion: 'v1',
             kind: 'ConfigMap',
             metadata: { name: 'bootstrap' },
+            scope: 'namespaced',
             data: { ready: 'true' },
           },
         ],

--- a/test/factories/kro/resource-graph-definition.test.ts
+++ b/test/factories/kro/resource-graph-definition.test.ts
@@ -13,7 +13,6 @@ describe('ResourceGraphDefinition Factory', () => {
   const createTestRGD = (name: string = 'testRgd') => ({
     metadata: {
       name,
-      namespace: 'default',
     },
     spec: {
       schema: {
@@ -51,7 +50,7 @@ describe('ResourceGraphDefinition Factory', () => {
       expect(enhanced.kind).toBe('ResourceGraphDefinition');
       expect(enhanced.apiVersion).toBe('kro.run/v1alpha1');
       expect(enhanced.metadata.name).toBe('testRgd');
-      expect(enhanced.metadata.namespace).toBe('default');
+      expect(Object.hasOwn(enhanced.metadata, 'namespace')).toBe(false);
       expect(enhanced.spec.schema.kind).toBe('Example');
     });
 
@@ -64,9 +63,26 @@ describe('ResourceGraphDefinition Factory', () => {
       expect(enhanced.spec.resources.service.template.kind).toBe('Service');
     });
 
+    it('should ignore metadata.namespace because ResourceGraphDefinitions are cluster-scoped', () => {
+      const rgdConfig = {
+        ...createTestRGD('namespacedRgd'),
+        metadata: {
+          name: 'namespacedRgd',
+          namespace: 'default',
+          labels: { app: 'typekro' },
+        },
+      };
+
+      const enhanced = resourceGraphDefinition(rgdConfig);
+
+      expect(enhanced.metadata.name).toBe('namespacedRgd');
+      expect(Object.hasOwn(enhanced.metadata, 'namespace')).toBe(false);
+      expect(enhanced.metadata.labels).toEqual({ app: 'typekro' });
+    });
+
     it('should handle RGD with complex resource templates', () => {
       const complexRGD = {
-        metadata: { name: 'complexRgd', namespace: 'kroSystem' },
+        metadata: { name: 'complexRgd' },
         spec: {
           schema: {
             apiVersion: 'webapp.example.com/v1',

--- a/test/unit/alchemy-deployers.test.ts
+++ b/test/unit/alchemy-deployers.test.ts
@@ -290,7 +290,7 @@ describe('DirectTypeKroDeployer', () => {
       expect(getMetadataField(manifest, 'scope')).toBe('cluster');
     });
 
-    it('rehydrates legacy cluster scope before direct redeploy', async () => {
+    it('does not infer cluster scope from legacy JSON-only state before direct redeploy', async () => {
       const ns = namespace({ metadata: { name: 'alchemy-legacy-ns' } });
       const restored = JSON.parse(JSON.stringify(ns));
 
@@ -301,13 +301,15 @@ describe('DirectTypeKroDeployer', () => {
       });
 
       const resourceGraph = mockEngine.deploy.mock.calls[0]?.[0];
+      const options = mockEngine.deploy.mock.calls[0]?.[1];
       const manifest = resourceGraph.resources[0]?.manifest;
       expect(manifest.kind).toBe('Namespace');
       expect(manifest.metadata.namespace).toBeUndefined();
-      expect(getMetadataField(manifest, 'scope')).toBe('cluster');
+      expect(getMetadataField(manifest, 'scope')).toBeUndefined();
+      expect(options.namespace).toBe('default');
     });
 
-    it('scrubs stale namespace from legacy cluster-scoped state before direct redeploy', async () => {
+    it('keeps stale namespace on JSON-only state without explicit cluster scope before direct redeploy', async () => {
       const restored = {
         apiVersion: 'v1',
         kind: 'Namespace',
@@ -323,8 +325,8 @@ describe('DirectTypeKroDeployer', () => {
       const resourceGraph = mockEngine.deploy.mock.calls[0]?.[0];
       const manifest = resourceGraph.resources[0]?.manifest;
       expect(manifest.kind).toBe('Namespace');
-      expect(manifest.metadata.namespace).toBeUndefined();
-      expect(getMetadataField(manifest, 'scope')).toBe('cluster');
+      expect(manifest.metadata.namespace).toBe('default');
+      expect(getMetadataField(manifest, 'scope')).toBeUndefined();
     });
 
     it('scrubs stale namespace when serializing cluster-scoped resources', () => {
@@ -450,7 +452,7 @@ describe('DirectTypeKroDeployer', () => {
       expect(getMetadataField(deployedResource.manifest, 'scope')).toBe('cluster');
     });
 
-    it('preserves cluster scope for legacy Alchemy state without serialized scope', async () => {
+    it('does not infer cluster scope for legacy Alchemy state without serialized scope', async () => {
       const ns = namespace({ metadata: { name: 'alchemy-direct-ns' } });
       const restored = JSON.parse(JSON.stringify(ns));
 
@@ -459,11 +461,11 @@ describe('DirectTypeKroDeployer', () => {
       const callArgs = mockEngine.deleteResource.mock.calls[0];
       const deployedResource = callArgs[0];
       expect(deployedResource.kind).toBe('Namespace');
-      expect(deployedResource.namespace).toBe('');
-      expect(getMetadataField(deployedResource.manifest, 'scope')).toBe('cluster');
+      expect(deployedResource.namespace).toBe('default');
+      expect(getMetadataField(deployedResource.manifest, 'scope')).toBeUndefined();
     });
 
-    it('scrubs stale namespace from legacy cluster-scoped state before delete', async () => {
+    it('keeps stale namespace on JSON-only state without explicit cluster scope before delete', async () => {
       const restored = {
         apiVersion: 'v1',
         kind: 'Namespace',
@@ -475,12 +477,12 @@ describe('DirectTypeKroDeployer', () => {
       const callArgs = mockEngine.deleteResource.mock.calls[0];
       const deployedResource = callArgs[0];
       expect(deployedResource.kind).toBe('Namespace');
-      expect(deployedResource.namespace).toBe('');
-      expect(deployedResource.manifest.metadata.namespace).toBeUndefined();
-      expect(getMetadataField(deployedResource.manifest, 'scope')).toBe('cluster');
+      expect(deployedResource.namespace).toBe('default');
+      expect(deployedResource.manifest.metadata.namespace).toBe('default');
+      expect(getMetadataField(deployedResource.manifest, 'scope')).toBeUndefined();
     });
 
-    it('preserves legacy cluster scope for newer cluster-scoped factory kinds', async () => {
+    it('does not infer cluster scope for JSON-restored factory resources without serialized scope', async () => {
       const ic = ingressClass({
         metadata: { name: 'alchemy-ingress-class' },
         spec: { controller: 'example.com/controller' },
@@ -492,8 +494,8 @@ describe('DirectTypeKroDeployer', () => {
       const callArgs = mockEngine.deleteResource.mock.calls[0];
       const deployedResource = callArgs[0];
       expect(deployedResource.kind).toBe('IngressClass');
-      expect(deployedResource.namespace).toBe('');
-      expect(getMetadataField(deployedResource.manifest, 'scope')).toBe('cluster');
+      expect(deployedResource.namespace).toBe('default');
+      expect(getMetadataField(deployedResource.manifest, 'scope')).toBeUndefined();
     });
   });
 
@@ -621,7 +623,7 @@ describe('KroTypeKroDeployer', () => {
     expect(getMetadataField(manifest, 'scope')).toBe('cluster');
   });
 
-  it('rehydrates legacy ResourceGraphDefinition scope before KRO redeploy', async () => {
+  it('does not infer ResourceGraphDefinition scope from legacy JSON-only state before KRO redeploy', async () => {
     const mockEngine = createMockEngine() as any;
     const deployer = new KroTypeKroDeployer(mockEngine);
     const rgd = resourceGraphDefinition({
@@ -639,10 +641,10 @@ describe('KroTypeKroDeployer', () => {
     const manifest = graph.resources[0]?.manifest;
     expect(manifest.kind).toBe('ResourceGraphDefinition');
     expect(manifest.metadata.namespace).toBeUndefined();
-    expect(getMetadataField(manifest, 'scope')).toBe('cluster');
+    expect(getMetadataField(manifest, 'scope')).toBeUndefined();
   });
 
-  it('scrubs stale namespace from legacy ResourceGraphDefinition state before KRO redeploy', async () => {
+  it('keeps stale namespace on ResourceGraphDefinition state without explicit cluster scope before KRO redeploy', async () => {
     const mockEngine = createMockEngine() as any;
     const deployer = new KroTypeKroDeployer(mockEngine);
     const restored = {
@@ -660,8 +662,8 @@ describe('KroTypeKroDeployer', () => {
     const graph = mockEngine.deploy.mock.calls[0]?.[0];
     const manifest = graph.resources[0]?.manifest;
     expect(manifest.kind).toBe('ResourceGraphDefinition');
-    expect(manifest.metadata.namespace).toBeUndefined();
-    expect(getMetadataField(manifest, 'scope')).toBe('cluster');
+    expect(manifest.metadata.namespace).toBe('default');
+    expect(getMetadataField(manifest, 'scope')).toBeUndefined();
   });
 
   it('uses the factory deleteInstance hook for KRO custom resource deletion', async () => {

--- a/test/unit/alchemy-deployers.test.ts
+++ b/test/unit/alchemy-deployers.test.ts
@@ -15,10 +15,15 @@ import {
   deleteKroInstanceFinalizerSafeForTest,
   listKroInstancesForTest,
 } from '../../src/alchemy/kro-delete.js';
-import { inferKroDeletionOptionsForTest } from '../../src/alchemy/resource-registration.js';
+import {
+  cloneResourceForAlchemyStateForTest,
+  inferKroDeletionOptionsForTest,
+} from '../../src/alchemy/resource-registration.js';
 import { ReadinessEvaluatorRegistry } from '../../src/core/readiness/registry.js';
 import { getMetadataField } from '../../src/core/metadata/index.js';
+import { resourceGraphDefinition } from '../../src/factories/kro/resource-graph-definition.js';
 import { namespace } from '../../src/factories/kubernetes/core/namespace.js';
+import { ingressClass } from '../../src/factories/kubernetes/networking/ingress-class.js';
 import { service } from '../../src/factories/kubernetes/networking/service.js';
 import { deployment } from '../../src/factories/kubernetes/workloads/deployment.js';
 import { getReadinessEvaluator, requireReadinessEvaluator } from '../utils/mock-factories.js';
@@ -267,6 +272,72 @@ describe('DirectTypeKroDeployer', () => {
       // Verify options
       expect(options.namespace).toBe('test-ns');
     });
+
+    it('rehydrates serialized factory scope before direct deploy', async () => {
+      const ns = namespace({ metadata: { name: 'alchemy-direct-ns' } });
+      const restored = cloneResourceForAlchemyStateForTest(ns);
+
+      await deployer.deploy(restored, {
+        mode: 'alchemy',
+        namespace: 'default',
+        waitForReady: false,
+      });
+
+      const resourceGraph = mockEngine.deploy.mock.calls[0]?.[0];
+      const manifest = resourceGraph.resources[0]?.manifest;
+      expect(manifest.kind).toBe('Namespace');
+      expect(manifest.metadata.namespace).toBeUndefined();
+      expect(getMetadataField(manifest, 'scope')).toBe('cluster');
+    });
+
+    it('rehydrates legacy cluster scope before direct redeploy', async () => {
+      const ns = namespace({ metadata: { name: 'alchemy-legacy-ns' } });
+      const restored = JSON.parse(JSON.stringify(ns));
+
+      await deployer.deploy(restored, {
+        mode: 'alchemy',
+        namespace: 'default',
+        waitForReady: false,
+      });
+
+      const resourceGraph = mockEngine.deploy.mock.calls[0]?.[0];
+      const manifest = resourceGraph.resources[0]?.manifest;
+      expect(manifest.kind).toBe('Namespace');
+      expect(manifest.metadata.namespace).toBeUndefined();
+      expect(getMetadataField(manifest, 'scope')).toBe('cluster');
+    });
+
+    it('scrubs stale namespace from legacy cluster-scoped state before direct redeploy', async () => {
+      const restored = {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'alchemy-stale-ns', namespace: 'default' },
+      } as any;
+
+      await deployer.deploy(restored, {
+        mode: 'alchemy',
+        namespace: 'default',
+        waitForReady: false,
+      });
+
+      const resourceGraph = mockEngine.deploy.mock.calls[0]?.[0];
+      const manifest = resourceGraph.resources[0]?.manifest;
+      expect(manifest.kind).toBe('Namespace');
+      expect(manifest.metadata.namespace).toBeUndefined();
+      expect(getMetadataField(manifest, 'scope')).toBe('cluster');
+    });
+
+    it('scrubs stale namespace when serializing cluster-scoped resources', () => {
+      const restored = cloneResourceForAlchemyStateForTest({
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'alchemy-direct-ns', namespace: 'default' },
+        scope: 'cluster',
+      } as any);
+
+      expect(restored.scope).toBe('cluster');
+      expect(restored.metadata?.namespace).toBeUndefined();
+    });
   });
 
   describe('Error Handling', () => {
@@ -366,7 +437,20 @@ describe('DirectTypeKroDeployer', () => {
       expect(deployedResource.namespace).toBe('default');
     });
 
-    it('restores cluster-scope metadata for JSON-restored cluster resources', async () => {
+    it('honors serialized factory scope for JSON-restored cluster resources', async () => {
+      const ns = namespace({ metadata: { name: 'alchemy-direct-ns' } });
+      const restored = cloneResourceForAlchemyStateForTest(ns);
+
+      await deployer.delete(restored, { mode: 'direct', namespace: 'default' });
+
+      const callArgs = mockEngine.deleteResource.mock.calls[0];
+      const deployedResource = callArgs[0];
+      expect(deployedResource.kind).toBe('Namespace');
+      expect(deployedResource.namespace).toBe('');
+      expect(getMetadataField(deployedResource.manifest, 'scope')).toBe('cluster');
+    });
+
+    it('preserves cluster scope for legacy Alchemy state without serialized scope', async () => {
       const ns = namespace({ metadata: { name: 'alchemy-direct-ns' } });
       const restored = JSON.parse(JSON.stringify(ns));
 
@@ -375,6 +459,39 @@ describe('DirectTypeKroDeployer', () => {
       const callArgs = mockEngine.deleteResource.mock.calls[0];
       const deployedResource = callArgs[0];
       expect(deployedResource.kind).toBe('Namespace');
+      expect(deployedResource.namespace).toBe('');
+      expect(getMetadataField(deployedResource.manifest, 'scope')).toBe('cluster');
+    });
+
+    it('scrubs stale namespace from legacy cluster-scoped state before delete', async () => {
+      const restored = {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'alchemy-stale-ns', namespace: 'default' },
+      } as any;
+
+      await deployer.delete(restored, { mode: 'direct', namespace: 'default' });
+
+      const callArgs = mockEngine.deleteResource.mock.calls[0];
+      const deployedResource = callArgs[0];
+      expect(deployedResource.kind).toBe('Namespace');
+      expect(deployedResource.namespace).toBe('');
+      expect(deployedResource.manifest.metadata.namespace).toBeUndefined();
+      expect(getMetadataField(deployedResource.manifest, 'scope')).toBe('cluster');
+    });
+
+    it('preserves legacy cluster scope for newer cluster-scoped factory kinds', async () => {
+      const ic = ingressClass({
+        metadata: { name: 'alchemy-ingress-class' },
+        spec: { controller: 'example.com/controller' },
+      });
+      const restored = JSON.parse(JSON.stringify(ic));
+
+      await deployer.delete(restored, { mode: 'direct', namespace: 'default' });
+
+      const callArgs = mockEngine.deleteResource.mock.calls[0];
+      const deployedResource = callArgs[0];
+      expect(deployedResource.kind).toBe('IngressClass');
       expect(deployedResource.namespace).toBe('');
       expect(getMetadataField(deployedResource.manifest, 'scope')).toBe('cluster');
     });
@@ -481,6 +598,70 @@ describe('KroTypeKroDeployer', () => {
     expect(graph.resources).toHaveLength(1);
     expect(graph.dependencyGraph.getNodes().size).toBe(1);
     expect(graph.dependencyGraph.hasNode(graph.resources[0].id)).toBe(true);
+  });
+
+  it('rehydrates serialized factory scope before KRO deploy', async () => {
+    const mockEngine = createMockEngine() as any;
+    const deployer = new KroTypeKroDeployer(mockEngine);
+    const rgd = resourceGraphDefinition({
+      metadata: { name: 'alchemy-rgd' },
+      spec: {},
+    });
+    const restored = cloneResourceForAlchemyStateForTest(rgd);
+
+    await deployer.deploy(restored, {
+      mode: 'alchemy',
+      namespace: 'default',
+    });
+
+    const graph = mockEngine.deploy.mock.calls[0]?.[0];
+    const manifest = graph.resources[0]?.manifest;
+    expect(manifest.kind).toBe('ResourceGraphDefinition');
+    expect(manifest.metadata.namespace).toBeUndefined();
+    expect(getMetadataField(manifest, 'scope')).toBe('cluster');
+  });
+
+  it('rehydrates legacy ResourceGraphDefinition scope before KRO redeploy', async () => {
+    const mockEngine = createMockEngine() as any;
+    const deployer = new KroTypeKroDeployer(mockEngine);
+    const rgd = resourceGraphDefinition({
+      metadata: { name: 'alchemy-legacy-rgd' },
+      spec: {},
+    });
+    const restored = JSON.parse(JSON.stringify(rgd));
+
+    await deployer.deploy(restored, {
+      mode: 'alchemy',
+      namespace: 'default',
+    });
+
+    const graph = mockEngine.deploy.mock.calls[0]?.[0];
+    const manifest = graph.resources[0]?.manifest;
+    expect(manifest.kind).toBe('ResourceGraphDefinition');
+    expect(manifest.metadata.namespace).toBeUndefined();
+    expect(getMetadataField(manifest, 'scope')).toBe('cluster');
+  });
+
+  it('scrubs stale namespace from legacy ResourceGraphDefinition state before KRO redeploy', async () => {
+    const mockEngine = createMockEngine() as any;
+    const deployer = new KroTypeKroDeployer(mockEngine);
+    const restored = {
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'ResourceGraphDefinition',
+      metadata: { name: 'alchemy-stale-rgd', namespace: 'default' },
+      spec: {},
+    } as any;
+
+    await deployer.deploy(restored, {
+      mode: 'alchemy',
+      namespace: 'default',
+    });
+
+    const graph = mockEngine.deploy.mock.calls[0]?.[0];
+    const manifest = graph.resources[0]?.manifest;
+    expect(manifest.kind).toBe('ResourceGraphDefinition');
+    expect(manifest.metadata.namespace).toBeUndefined();
+    expect(getMetadataField(manifest, 'scope')).toBe('cluster');
   });
 
   it('uses the factory deleteInstance hook for KRO custom resource deletion', async () => {

--- a/test/unit/resource-applier.test.ts
+++ b/test/unit/resource-applier.test.ts
@@ -138,6 +138,20 @@ describe('ResourceApplier', () => {
       expect((serialized.metadata as { name: string }).name).toBe('test-deployment');
     });
 
+    it('should strip persisted scope metadata before sending to Kubernetes', () => {
+      const resource = {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'test-namespace' },
+        scope: 'cluster',
+      };
+
+      const serialized = applier.serializeResourceForK8s(resource);
+
+      expect(serialized.scope).toBeUndefined();
+      expect(serialized.kind).toBe('Namespace');
+    });
+
     it('should call toJSON if available', () => {
       const customJSON: KubernetesResource = {
         apiVersion: 'v1',

--- a/test/unit/resource-scope-metadata.test.ts
+++ b/test/unit/resource-scope-metadata.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'bun:test';
+import { getMetadataField, getResourceScope } from '../../src/core/metadata/index.js';
+import {
+  kroCustomResourceDefinition,
+  resourceGraphDefinition,
+} from '../../src/factories/kro/index.js';
+import {
+  certificateSigningRequest,
+  configMap,
+  customResourceDefinition,
+  ingressClass,
+  namespace,
+  persistentVolume,
+  runtimeClass,
+  storageClass,
+  validatingWebhookConfiguration,
+} from '../../src/factories/kubernetes/index.js';
+
+describe('resource scope metadata', () => {
+  it('honors explicit raw scope and leaves unmarked raw resources unresolved', () => {
+    expect(
+      getResourceScope({
+        apiVersion: 'example.com/v1',
+        kind: 'ClusterThing',
+        metadata: { name: 'demo' },
+        scope: 'cluster',
+      })
+    ).toBe('cluster');
+    expect(
+      getResourceScope({
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'apps' },
+      })
+    ).toBeUndefined();
+  });
+
+  it('factory-created cluster-scoped resources carry scope metadata', () => {
+    const resources = [
+      namespace({ metadata: { name: 'apps' } }),
+      storageClass({ metadata: { name: 'fast' }, provisioner: 'example.com/provisioner' }),
+      persistentVolume({
+        metadata: { name: 'pv' },
+        spec: { capacity: { storage: '1Gi' }, accessModes: ['ReadWriteOnce'] },
+      }),
+      ingressClass({ metadata: { name: 'public' }, spec: { controller: 'example.com/ingress' } }),
+      runtimeClass({ metadata: { name: 'sandboxed' }, handler: 'runsc' }),
+      validatingWebhookConfiguration({ metadata: { name: 'validating' }, webhooks: [] }),
+      certificateSigningRequest({
+        metadata: { name: 'csr' },
+        spec: { request: 'LS0t', signerName: 'example.com/signer', usages: ['client auth'] },
+      }),
+      customResourceDefinition({
+        metadata: { name: 'widgets.example.com' },
+        spec: {
+          group: 'example.com',
+          names: { kind: 'Widget', plural: 'widgets' },
+          scope: 'Namespaced',
+          versions: [{ name: 'v1', served: true, storage: true, schema: { openAPIV3Schema: {} } }],
+        },
+      }),
+      kroCustomResourceDefinition({
+        metadata: { name: 'widgets.kro.run' },
+        spec: {
+          group: 'kro.run',
+          names: { kind: 'Widget', plural: 'widgets' },
+          scope: 'Namespaced',
+          versions: [{ name: 'v1', served: true, storage: true, schema: { openAPIV3Schema: {} } }],
+        },
+      }),
+      resourceGraphDefinition({ metadata: { name: 'widgets' }, spec: {} }),
+    ];
+
+    for (const resource of resources) {
+      expect(getMetadataField(resource, 'scope')).toBe('cluster');
+      expect(getResourceScope(resource)).toBe('cluster');
+    }
+  });
+
+  it('factory-created namespaced resources do not inherit cluster scope', () => {
+    const cm = configMap({ metadata: { name: 'settings', namespace: 'apps' }, data: {} });
+    expect(getMetadataField(cm, 'scope')).toBeUndefined();
+    expect(getResourceScope(cm)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- remove the centralized cluster-scoped Kubernetes kind inventory from resource scope resolution
- make scope resolution depend on factory-attached metadata, or an explicit `scope` field on raw manifests
- annotate cluster-scoped Kubernetes/KRO factories with `scope: "cluster"` as they create resources
- stop the legacy KRO deployment strategy from putting a namespace on ResourceGraphDefinition manifests
- update prerequisite/deployer tests to use factory-created cluster-scoped resources, and add direct metadata coverage

## Validation
- bun run quality
- bun test test/unit/resource-scope-metadata.test.ts test/core/kro-factory-characterization.test.ts test/unit/alchemy-deployers.test.ts
- git diff --check