### PR TITLE
fix: KRO-invalid CEL for optional scalar fields in runtime values-merge + alchemy RGD timeout ignored [0.20.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1] - 2026-06-30
+
+### Fixed
+
+- Fixed KRO-invalid CEL emitted for **optional scalar** spec fields in the runtime values-merge.
+  When a `values` block contained a CEL/ref (forcing the runtime map-merge), each optional overlay
+  field was emitted as `.merge({ "X": has(spec.X) ? spec.X : omit() })`. KRO types `omit()` as
+  `map(string, dyn)`, so for a scalar field the ternary `bool ? <scalar> : map(string, dyn)` failed
+  to compile (`GraphAccepted=False` / `no matching overload for '_?_:_'`). Optional refs now emit a
+  type-safe conditional single-key merge `.merge(has(spec.X) ? {"X": spec.X} : {})` (both branches
+  maps), and the emitted value preserves the field's full expression (e.g. a `string(...)` conversion
+  is not dropped to the bare path). Static maps and the field-level `has(x) ? x : omit()` form are
+  unchanged.
+- Fixed the alchemy KRO RGD deploy ignoring the factory's configured `timeout`: it hardcoded
+  `DEFAULT_RGD_TIMEOUT` (60s) instead of honoring `factoryOptions.timeout` (the non-alchemy paths
+  already did). A converge whose RGD legitimately takes >60s to reach ready (e.g. a Helm workload
+  rollout) false-failed with `AbortError: Delay aborted`.
+
 ## [0.20.0] - 2026-06-30
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -1285,7 +1285,10 @@ export class KroResourceFactoryImpl<
         deploymentStrategy: 'kro',
         kubeConfigOptions,
         kroDeletion,
-        options: { waitForReady: true, timeout: DEFAULT_RGD_TIMEOUT },
+        // Honor the factory's configured timeout (matches the non-alchemy paths, e.g. line ~1700);
+        // hardcoding DEFAULT_RGD_TIMEOUT (60s) ignored a caller's longer timeout and false-failed a
+        // converge whose RGD legitimately takes >60s to reach ready (e.g. a Helm workload rollout).
+        options: { waitForReady: true, timeout: this.factoryOptions.timeout || DEFAULT_RGD_TIMEOUT },
       },
     };
 

--- a/src/core/serialization/cel-references.ts
+++ b/src/core/serialization/cel-references.ts
@@ -1178,25 +1178,125 @@ function celRuntimeMapMergeExpression(
   return expression ?? celLiteralForValueTree(knownBase, context, path);
 }
 
+/**
+ * For an overlay value that is an OPTIONAL schema ref (one that
+ * `maybeWrapWithOmit`/`celMapMergeOperand` would guard with
+ * `has(schema.spec.X) ? ... : omit()`), return the guard and the bare CEL
+ * path. Returns `undefined` for every other value.
+ *
+ * This drives the type-safe runtime-merge overlay form: an optional field
+ * whose fallback is `omit()` must NOT be emitted as a value inside a
+ * `.merge({ "X": has(spec.X) ? spec.X : omit() })` map literal. KRO types
+ * `omit()` as `map(string, dyn)`, so for a SCALAR field the conditional is
+ * `bool ? <scalar> : map(string, dyn)` — both branches must share a type, so
+ * CEL fails to compile with `no matching overload for '_?_:_'`. Instead the
+ * caller emits a conditional single-key merge `.merge(has(spec.X) ? {"X":
+ * spec.X} : {})`, where both branches are maps — type-safe for fields of ANY
+ * type, and a `.merge({})` no-op when the field is absent (true omit
+ * semantics).
+ *
+ * Only single bare schema refs are eligible (`KubernetesRef`, or a
+ * `CelExpression` whose body is a bare `schema.spec.X` / `string(schema.spec.X)`
+ * ref). Anything else — known merge objects, literals, templates, mixed CEL —
+ * is left to the inline map path, which is already type-safe because it never
+ * introduces `omit()` in a value position.
+ */
+function optionalRefMergeGuard(
+  value: unknown,
+  context: SerializationContext | undefined
+): { guard: string; valueExpr: string } | undefined {
+  const omitFields = context?.omitFields;
+  if (!omitFields || omitFields.size === 0) return undefined;
+
+  // `celPath` is the bare `schema.spec.X` path used to build the has() guard; `valueExpr` is the
+  // FULL expression emitted as the field's value. They differ when the value is a CEL conversion of
+  // the ref (e.g. `string(schema.spec.X)`): we guard on `has(schema.spec.X)` but must emit
+  // `string(schema.spec.X)` — emitting the bare path would silently drop the user's conversion.
+  let celPath: string | undefined;
+  let valueExpr: string | undefined;
+  if (isKubernetesRef(value)) {
+    celPath = getInnerCelPath(value);
+    valueExpr = celPath;
+  } else if (isCelExpression(value) && !value.__isTemplate) {
+    const expr = resolveNestedCompositionRefs(
+      value.expression,
+      context?.nestedStatusCel,
+      context?.resourceIds
+    );
+    celPath =
+      /^schema\.spec\.[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/.exec(expr)?.[0] ??
+      /^string\((schema\.spec\.[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\)$/.exec(expr)?.[1];
+    valueExpr = expr;
+  }
+  if (!celPath || valueExpr === undefined) return undefined;
+
+  const guard = optionalSchemaSpecGuard(celPath, omitFields);
+  return guard ? { guard, valueExpr } : undefined;
+}
+
+/**
+ * Append the inline-map merge operand and the conditional single-key merge
+ * operands for a set of overlay entries to `merges`. Optional-ref entries are
+ * pulled out of the inline map (where their `omit()` fallback would be a
+ * KRO type error) and emitted as `.merge(has(spec.X) ? {"X": spec.X} : {})`.
+ */
+function appendOverlayMerges(
+  merges: string[],
+  inlineEntries: string[],
+  optionalEntries: Array<{ key: string; guard: string; valueExpr: string }>
+): void {
+  if (inlineEntries.length > 0) {
+    merges.push(`.merge({${inlineEntries.join(', ')}})`);
+  }
+  for (const { key, guard, valueExpr } of optionalEntries) {
+    merges.push(`.merge(${guard} ? {${JSON.stringify(key)}: ${valueExpr}} : {})`);
+  }
+}
+
 function celDeepMergeRuntimeOverlay(
   base: Record<string, unknown>,
   overlayExpression: string,
   context: SerializationContext | undefined,
   path: string
 ): string {
-  const entries = Object.entries(base).flatMap(([key, baseValue]) => {
-    if (baseValue === undefined) return [];
+  const inlineEntries: string[] = [];
+  const optionalEntries: Array<{ key: string; guard: string; valueExpr: string }> = [];
+
+  for (const [key, baseValue] of Object.entries(base)) {
+    if (baseValue === undefined) continue;
     const overlayValue = mapKeyAccess(overlayExpression, key);
+
+    // The fallback (overlay key absent) is the base value. When the base value
+    // is an optional schema ref, its `omit()` fallback can't sit inside the
+    // inline `.merge({...})` map — emit a conditional single-key merge so the
+    // key is contributed only when the overlay OR the optional spec field is
+    // present (both branches maps → type-safe for scalars and maps alike):
+    //   .merge(overlayHas || has(spec.X) ? {"key": overlayHas ? overlay[key] : spec.X} : {})
+    const optionalGuard = isKnownMergeObject(baseValue)
+      ? undefined
+      : optionalRefMergeGuard(baseValue, context);
+    if (optionalGuard) {
+      const overlayHas = mapHasKey(overlayExpression, key);
+      optionalEntries.push({
+        key,
+        guard: `${overlayHas} || (${optionalGuard.guard})`,
+        valueExpr: `${overlayHas} ? ${overlayValue} : ${optionalGuard.valueExpr}`,
+      });
+      continue;
+    }
+
     const baseExpression = celLiteralForValueTree(baseValue, context, childPath(path, key));
     const mergedValue = isKnownMergeObject(baseValue)
       ? celDeepMergeRuntimeOverlay(baseValue, overlayValue, context, childPath(path, key))
       : overlayValue;
-    return [
-      `${JSON.stringify(key)}: ${mapHasKey(overlayExpression, key)} ? ${mergedValue} : ${baseExpression}`,
-    ];
-  });
+    inlineEntries.push(
+      `${JSON.stringify(key)}: ${mapHasKey(overlayExpression, key)} ? ${mergedValue} : ${baseExpression}`
+    );
+  }
 
-  return `(${overlayExpression}).merge({${entries.join(', ')}})`;
+  const merges: string[] = [];
+  appendOverlayMerges(merges, inlineEntries, optionalEntries);
+  return `(${overlayExpression})${merges.join('')}`;
 }
 
 function celDeepMergeKnownOverlay(
@@ -1205,8 +1305,23 @@ function celDeepMergeKnownOverlay(
   context: SerializationContext | undefined,
   path: string
 ): string {
-  const entries = Object.entries(overlay).flatMap(([key, overlayValue]) => {
-    if (overlayValue === undefined) return [];
+  const inlineEntries: string[] = [];
+  const optionalEntries: Array<{ key: string; guard: string; valueExpr: string }> = [];
+
+  for (const [key, overlayValue] of Object.entries(overlay)) {
+    if (overlayValue === undefined) continue;
+
+    // An optional scalar/leaf schema ref overlay value would otherwise emit
+    // `"X": has(spec.X) ? spec.X : omit()` inside the inline map — a KRO type
+    // error for scalars. Emit it as a conditional single-key merge instead.
+    const optionalGuard = isKnownMergeObject(overlayValue)
+      ? undefined
+      : optionalRefMergeGuard(overlayValue, context);
+    if (optionalGuard) {
+      optionalEntries.push({ key, guard: optionalGuard.guard, valueExpr: optionalGuard.valueExpr });
+      continue;
+    }
+
     const overlayExpression = celLiteralForValueTree(overlayValue, context, childPath(path, key));
     const baseValue = mapKeyAccess(baseExpression, key);
     const mergedValue = isKnownMergeObject(overlayValue)
@@ -1217,10 +1332,12 @@ function celDeepMergeKnownOverlay(
           childPath(path, key)
         )} : ${overlayExpression}`
       : overlayExpression;
-    return [`${JSON.stringify(key)}: ${mergedValue}`];
-  });
+    inlineEntries.push(`${JSON.stringify(key)}: ${mergedValue}`);
+  }
 
-  return `(${baseExpression}).merge({${entries.join(', ')}})`;
+  const merges: string[] = [];
+  appendOverlayMerges(merges, inlineEntries, optionalEntries);
+  return `(${baseExpression})${merges.join('')}`;
 }
 
 function celValuesMergeExpression(

--- a/src/core/serialization/cel-references.ts
+++ b/src/core/serialization/cel-references.ts
@@ -1116,7 +1116,12 @@ function celMapMergeOperand(
     return guard ? `${guard} ? ${operand} : {}` : operand;
   }
 
-  const expression = celLiteralForValueTree(value, context, path);
+  // A known object operand may itself carry optional scalar refs; emit it type-safely so they're
+  // pulled into single-key merges rather than inline `omit()` ternaries (the json round-trip below
+  // normalizes either form). Non-objects serialize directly.
+  const expression = isKnownMergeObject(value)
+    ? celTypeSafeObjectLiteral(value, context, path)
+    : celLiteralForValueTree(value, context, path);
   return `json.unmarshal(json.marshal(${expression}))`;
 }
 
@@ -1285,7 +1290,12 @@ function celDeepMergeRuntimeOverlay(
       continue;
     }
 
-    const baseExpression = celLiteralForValueTree(baseValue, context, childPath(path, key));
+    // Fallback (overlay lacks the key) is the base value. For a nested object base, emit it as a
+    // type-safe literal so its OWN optional scalars are pulled out (celLiteralForValueTree would
+    // re-introduce the invalid inline omit() ternary for them).
+    const baseExpression = isKnownMergeObject(baseValue)
+      ? celTypeSafeObjectLiteral(baseValue, context, childPath(path, key))
+      : celLiteralForValueTree(baseValue, context, childPath(path, key));
     const mergedValue = isKnownMergeObject(baseValue)
       ? celDeepMergeRuntimeOverlay(baseValue, overlayValue, context, childPath(path, key))
       : overlayValue;
@@ -1297,6 +1307,41 @@ function celDeepMergeRuntimeOverlay(
   const merges: string[] = [];
   appendOverlayMerges(merges, inlineEntries, optionalEntries);
   return `(${overlayExpression})${merges.join('')}`;
+}
+
+/**
+ * Emit an object value-tree as a CEL map that is SAFE to sit as a VALUE inside a `.merge({...})` map
+ * literal. Optional scalar/leaf schema refs — at ANY depth — are pulled OUT into conditional
+ * single-key merges `(...).merge(has(spec.X) ? {"X": spec.X} : {})` instead of being emitted inline as
+ * `{"X": has(spec.X) ? spec.X : omit()}`: KRO types `omit()` as `map(string,dyn)`, so for a scalar the
+ * `bool ? scalar : map` ternary fails to compile. Nested objects recurse through this same builder, so
+ * the fix holds at every level. Used for the FALLBACK (base-absent) literal branch of the deep-merge
+ * builders — `celLiteralForValueTree` would re-introduce the invalid inline `omit()` ternary there.
+ * For an object with no optional refs this is byte-equivalent to `celLiteralForValueTree`.
+ */
+function celTypeSafeObjectLiteral(
+  value: Record<string, unknown>,
+  context: SerializationContext | undefined,
+  path: string
+): string {
+  const inlineEntries: string[] = [];
+  const optionalEntries: Array<{ key: string; guard: string; valueExpr: string }> = [];
+  for (const [key, child] of Object.entries(value)) {
+    if (child === undefined) continue;
+    const optionalGuard = isKnownMergeObject(child) ? undefined : optionalRefMergeGuard(child, context);
+    if (optionalGuard) {
+      optionalEntries.push({ key, guard: optionalGuard.guard, valueExpr: optionalGuard.valueExpr });
+      continue;
+    }
+    const childExpr = isKnownMergeObject(child)
+      ? celTypeSafeObjectLiteral(child, context, childPath(path, key))
+      : celLiteralForValueTree(child, context, childPath(path, key));
+    inlineEntries.push(`${JSON.stringify(key)}: ${childExpr}`);
+  }
+  const base = `{${inlineEntries.join(', ')}}`;
+  const merges: string[] = [];
+  appendOverlayMerges(merges, [], optionalEntries);
+  return merges.length > 0 ? `(${base})${merges.join('')}` : base;
 }
 
 function celDeepMergeKnownOverlay(
@@ -1322,16 +1367,19 @@ function celDeepMergeKnownOverlay(
       continue;
     }
 
-    const overlayExpression = celLiteralForValueTree(overlayValue, context, childPath(path, key));
     const baseValue = mapKeyAccess(baseExpression, key);
+    // Nested object: merge onto the present base when the base has the key, else emit the overlay
+    // object as a type-safe literal (its OWN optional scalars pulled out too — celLiteralForValueTree
+    // would re-introduce the invalid inline omit() ternary for them). Non-objects (static / required
+    // refs) serialize directly; optional scalar refs were already handled above.
     const mergedValue = isKnownMergeObject(overlayValue)
       ? `${mapHasKey(baseExpression, key)} ? ${celDeepMergeKnownOverlay(
           baseValue,
           overlayValue,
           context,
           childPath(path, key)
-        )} : ${overlayExpression}`
-      : overlayExpression;
+        )} : ${celTypeSafeObjectLiteral(overlayValue, context, childPath(path, key))}`
+      : celLiteralForValueTree(overlayValue, context, childPath(path, key));
     inlineEntries.push(`${JSON.stringify(key)}: ${mergedValue}`);
   }
 

--- a/test/factories/helm/helm-integration.test.ts
+++ b/test/factories/helm/helm-integration.test.ts
@@ -614,4 +614,44 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     expect(valuesLine).not.toContain('{\\"portString\\": schema.spec.port}');
     expect(valuesLine).not.toContain('omit()');
   });
+
+  // Regression: an optional scalar nested inside an OBJECT overlay must also be type-safe. The
+  // top-level fix only pulled out top-level optional refs; a nested object's fallback (base-absent)
+  // branch was still emitted via celLiteralForValueTree, re-introducing the invalid inline
+  // `{"X": has(spec.X) ? spec.X : omit()}` for its optional scalars at depth.
+  it('emits type-safe CEL for an OPTIONAL SCALAR nested inside an object overlay (no omit() at depth)', () => {
+    const graph = toResourceGraph(
+      {
+        name: 'helm-nested-optional-scalar',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'TestApp',
+        spec: type({ 'secretName?': 'string', 'values?': 'object' }),
+        status: TestStatusSchema,
+      },
+      (schema) => ({
+        app: helmRelease({
+          name: 'dagster',
+          chart: { repository: 'https://charts.example.com', name: 'dagster' },
+          // `global.celeryConfigSecretName` is an optional scalar ref NESTED in the `global` object.
+          values: mergeValuesExpression(schema.spec.values, {
+            global: { celeryConfigSecretName: schema.spec.secretName },
+          }),
+        }),
+      }),
+      () => ({ ready: true })
+    );
+
+    const yaml = graph.toYaml();
+    const valuesLine = yaml.split('\n').find((line) => line.includes('values: "${')) ?? '';
+
+    // No omit() anywhere — at any nesting depth.
+    expect(valuesLine).not.toContain('omit()');
+    expect(valuesLine).not.toMatch(/\? schema\.spec\.\w+ : omit\(\)/);
+    // The nested optional scalar uses the type-safe single-key merge in BOTH the base-present and
+    // base-absent branches (the base-absent fallback is `({}).merge(...)`, not an inline omit ternary).
+    expect(valuesLine).toContain(
+      '.merge(has(schema.spec.secretName) ? {\\"celeryConfigSecretName\\": schema.spec.secretName} : {})'
+    );
+    expect(valuesLine).toContain('({}).merge(has(schema.spec.secretName)');
+  });
 });

--- a/test/factories/helm/helm-integration.test.ts
+++ b/test/factories/helm/helm-integration.test.ts
@@ -277,6 +277,83 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     expect(yaml).not.toContain('__KUBERNETES_REF_');
   });
 
+  // Regression: KRO rejected a runtime values-merge whose overlay carried an
+  // OPTIONAL SCALAR spec field. The old form emitted the field's omit() fallback
+  // as a VALUE inside the `.merge({...})` map literal:
+  //   .merge({ "nameOverride": has(spec.nameOverride) ? spec.nameOverride : omit() })
+  // KRO types omit() as map(string, dyn); for a scalar field the ternary is
+  // `bool ? <string> : map(string, dyn)` — both branches must share a type, so
+  // cel-go fails to compile with:
+  //   GraphAccepted=False reason=InvalidResourceGraph
+  //   ERROR: found no matching overload for '_?_:_' applied to '(bool, string, map(string, dyn))'
+  // The fix emits the field as a conditional single-key merge (both branches
+  // maps): `.merge(has(spec.X) ? {"X": spec.X} : {})` — type-safe for ANY field
+  // type, and a no-op when the field is absent (true omit semantics).
+  //
+  // NOTE: this asserts the STRUCTURE of the emitted CEL — the repo has no cel-go
+  // (KRO's evaluator) available, so the actual KRO type-check is not unit-verifiable
+  // here. The structural assertion below pins the type-safe form precisely.
+  it('emits type-safe runtime values-merge for OPTIONAL SCALAR overlay fields (no scalar-vs-omit() ternary)', () => {
+    const graph = toResourceGraph(
+      {
+        name: 'helm-optional-scalar-merge',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'TestApp',
+        spec: type({
+          'nameOverride?': 'string',
+          'generateCeleryConfigSecret?': 'boolean',
+          replicas: 'number',
+          'values?': 'object',
+        }),
+        status: TestStatusSchema,
+      },
+      (schema) => ({
+        app: helmRelease({
+          name: 'dagster',
+          chart: {
+            repository: 'https://charts.example.com',
+            name: 'dagster',
+          },
+          // Whole-object ref base → forces the RUNTIME map-merge path; overlay
+          // carries optional SCALAR refs (nameOverride, generateCeleryConfigSecret)
+          // plus a required ref (replicaCount).
+          values: mergeValuesExpression(schema.spec.values, {
+            nameOverride: schema.spec.nameOverride,
+            generateCeleryConfigSecret: schema.spec.generateCeleryConfigSecret,
+            replicaCount: schema.spec.replicas,
+          }),
+        }),
+      }),
+      () => ({ ready: true })
+    );
+
+    const yaml = graph.toYaml();
+    const valuesLine = yaml.split('\n').find((line) => line.includes('values: "${')) ?? '';
+
+    // It must take the runtime map-merge path.
+    expect(valuesLine).toContain('json.unmarshal(json.marshal(schema.spec.values))');
+
+    // CORE ASSERTION: no scalar-vs-omit() ternary anywhere — i.e. no
+    // `? <scalar-ref> : omit()` sitting as a value inside a `.merge({...})`.
+    // omit() must not appear at all in this runtime-merge expression.
+    expect(valuesLine).not.toContain('omit()');
+    expect(valuesLine).not.toMatch(/\? schema\.spec\.\w+ : omit\(\)/);
+
+    // The optional scalars must use the type-safe conditional single-key merge:
+    // both branches are maps. (Inner double-quotes are YAML-escaped as \".)
+    expect(valuesLine).toContain(
+      '.merge(has(schema.spec.nameOverride) ? {\\"nameOverride\\": schema.spec.nameOverride} : {})'
+    );
+    expect(valuesLine).toContain(
+      '.merge(has(schema.spec.generateCeleryConfigSecret) ? {\\"generateCeleryConfigSecret\\": schema.spec.generateCeleryConfigSecret} : {})'
+    );
+
+    // The required field stays in the inline merge map (no guard needed).
+    expect(valuesLine).toContain('\\"replicaCount\\": schema.spec.replicas');
+
+    expect(valuesLine).not.toContain('__KUBERNETES_REF_');
+  });
+
   it('allows helper-built plain value trees that contain TypeKro references', () => {
     const graph = toResourceGraph(
       {
@@ -498,5 +575,43 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     expect(graph.resources[0]).toBeDefined();
     const simpleRes0 = graph.resources[0] as unknown as Record<string, Record<string, unknown>>;
     expect(simpleRes0.spec!.values).toBeDefined();
+  });
+
+  // Regression: the conditional single-key merge must emit the overlay's FULL value expression,
+  // not the bare schema path used for the has() guard. For an optional ref wrapped in a CEL
+  // conversion (e.g. `string(schema.spec.port)` — coercing a number to a string-typed chart value),
+  // the guard is `has(schema.spec.port)` but the VALUE must stay `string(schema.spec.port)`. An
+  // earlier iteration stored only the inner path and emitted it as the value, silently dropping string().
+  it('preserves a string() conversion on an optional ref in the runtime values-merge', () => {
+    const graph = toResourceGraph(
+      {
+        name: 'helm-optional-string-cast-merge',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'TestApp',
+        spec: type({ 'port?': 'number', 'values?': 'object' }),
+        status: TestStatusSchema,
+      },
+      (schema) => ({
+        app: helmRelease({
+          name: 'dagster',
+          chart: { repository: 'https://charts.example.com', name: 'dagster' },
+          values: mergeValuesExpression(schema.spec.values, {
+            portString: Cel.expr<string>('string(schema.spec.port)'),
+          }),
+        }),
+      }),
+      () => ({ ready: true })
+    );
+
+    const yaml = graph.toYaml();
+    const valuesLine = yaml.split('\n').find((line) => line.includes('values: "${')) ?? '';
+
+    // Guard on the bare path; the VALUE preserves the string() conversion. (Quotes YAML-escaped as \".)
+    expect(valuesLine).toContain(
+      '.merge(has(schema.spec.port) ? {\\"portString\\": string(schema.spec.port)} : {})'
+    );
+    // Must NOT drop string() and emit the bare ref as the value.
+    expect(valuesLine).not.toContain('{\\"portString\\": schema.spec.port}');
+    expect(valuesLine).not.toContain('omit()');
   });
 });


### PR DESCRIPTION
## 0.20.1 — re-applies #85's two converge-blocking fixes onto the 0.20 line

0.20 shipped the Alchemy scope-metadata refactor but **not** the two fixes from #85 (which was still open against the 0.19 line). Both are required for a dagster platform converge to succeed, so they're re-applied here on top of 0.20.

### 1. KRO-invalid CEL for optional **scalar** fields in the runtime values-merge
When a `values` block contains a CEL/ref (forcing the runtime map-merge), each optional overlay field was emitted as a value inside a `.merge({...})` map literal with an `omit()` fallback:
```
.merge({ "nameOverride": has(spec.nameOverride) ? spec.nameOverride : omit() })
```
KRO types `omit()` as `map(string,dyn)`, so for a scalar field the ternary `bool ? <scalar> : map(string,dyn)` fails to compile:
```
GraphAccepted=False  InvalidResourceGraph
ERROR: found no matching overload for '_?_:_' applied to '(bool, string, map(string, dyn))'
```
Latent since v0.11 (static value maps never take this path; only a CEL/ref in the values triggers it). **Fix:** optional refs emit a type-safe conditional single-key merge `.merge(has(spec.X) ? {"X": spec.X} : {})` (both branches maps), and the emitted **value preserves the field's full expression** — e.g. a `string(schema.spec.x)` conversion is not dropped to the bare `schema.spec.x` (the guard uses the bare path; the value keeps the conversion). Static maps and the field-level `has(x) ? x : omit()` form are untouched.

### 2. Alchemy RGD deploy ignored the configured `timeout` (hardcoded 60s)
The alchemy RGD-declaration path hardcoded `DEFAULT_RGD_TIMEOUT` (60s) for the readiness wait, ignoring `factoryOptions.timeout` (the non-alchemy paths already honor it). With #1 fixed, the RGD is accepted and a Helm workload rollout can legitimately take >60s to reach ready — which then false-failed with `AbortError: Delay aborted`. Now honors `factoryOptions.timeout || DEFAULT_RGD_TIMEOUT`.

## Tests / gates
- Regression tests in `test/factories/helm/helm-integration.test.ts`: the scalar-`omit()` case (asserts the type-safe single-key-merge form, no scalar-vs-`omit()` ternary) and the `string()`-preservation case. Both revert-proven against 0.19.0/0.20.0.
- KRO compile-correctness isn't unit-verifiable in-repo (no cel-go); the fix uses only map/map ternaries (basic, unambiguously valid CEL). Structural assertions guard it.
- `tsc --noEmit` clean; unit suite **4410 pass / 0 fail**. Version bumped to `0.20.1`; CHANGELOG updated.

This supersedes #85 (same fixes, rebased onto 0.20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
