### PR TITLE
fix(serialization): dyn-wrap optional-scalar omit ternaries (single-key merges break KRO merge uniformity)

### DIFF
--- a/src/core/serialization/cel-references.ts
+++ b/src/core/serialization/cel-references.ts
@@ -924,7 +924,9 @@ function celMarkerStringLiteralForValueTree(
   );
 
   if (!resolved.includes('__KUBERNETES_REF_')) {
-    return resolved.includes('${') ? celStringTemplateExpression(resolved) : JSON.stringify(resolved);
+    return resolved.includes('${')
+      ? celStringTemplateExpression(resolved)
+      : JSON.stringify(resolved);
   }
 
   const parts: string[] = [];
@@ -971,7 +973,8 @@ function celLiteralForValueTree(
   }
 
   if (isKubernetesRef(value) || isCelExpression(value)) {
-    const expression = unwrapKroExpression(processResourceReferences(value, context, path)) ?? 'null';
+    const expression =
+      unwrapKroExpression(processResourceReferences(value, context, path)) ?? 'null';
     return celValueTreeBranch(expression);
   }
 
@@ -1189,16 +1192,13 @@ function celRuntimeMapMergeExpression(
  * `has(schema.spec.X) ? ... : omit()`), return the guard and the bare CEL
  * path. Returns `undefined` for every other value.
  *
- * This drives the type-safe runtime-merge overlay form: an optional field
- * whose fallback is `omit()` must NOT be emitted as a value inside a
- * `.merge({ "X": has(spec.X) ? spec.X : omit() })` map literal. KRO types
- * `omit()` as `map(string, dyn)`, so for a SCALAR field the conditional is
- * `bool ? <scalar> : map(string, dyn)` — both branches must share a type, so
- * CEL fails to compile with `no matching overload for '_?_:_'`. Instead the
- * caller emits a conditional single-key merge `.merge(has(spec.X) ? {"X":
- * spec.X} : {})`, where both branches are maps — type-safe for fields of ANY
- * type, and a `.merge({})` no-op when the field is absent (true omit
- * semantics).
+ * This drives the type-safe runtime-merge overlay form. KRO types `omit()` as
+ * `map(string, dyn)`, so a bare `has(spec.X) ? spec.X : omit()` for a SCALAR is
+ * `(bool, scalar, map)` — no matching `_?_:_` overload. The caller (see
+ * {@link inlineOptionalEntry}) instead emits a dyn-wrapped ternary
+ * `"X": has(spec.X) ? dyn(spec.X) : omit()` INLINE in the surrounding merge map,
+ * which unifies to `dyn` and keeps the enclosing map heterogeneous
+ * (`map(string, dyn)`) so it merges uniformly.
  *
  * Only single bare schema refs are eligible (`KubernetesRef`, or a
  * `CelExpression` whose body is a bare `schema.spec.X` / `string(schema.spec.X)`
@@ -1240,21 +1240,37 @@ function optionalRefMergeGuard(
 }
 
 /**
- * Append the inline-map merge operand and the conditional single-key merge
- * operands for a set of overlay entries to `merges`. Optional-ref entries are
- * pulled out of the inline map (where their `omit()` fallback would be a
- * KRO type error) and emitted as `.merge(has(spec.X) ? {"X": spec.X} : {})`.
+ * Render an optional-ref overlay entry as an INLINE map entry whose value is a dyn-wrapped omit ternary:
+ *   "X": guard ? dyn(valueExpr) : omit()
+ *
+ * The `dyn(...)` is load-bearing twice over:
+ *   1. It keeps the ternary itself well-typed. KRO types `omit()` as `map(string,dyn)`, so a bare
+ *      `bool ? scalar : omit()` is `(bool, scalar, map)` — no matching `_?_:_` overload. Wrapping the
+ *      present-branch as `dyn(...)` makes it `(bool, dyn, map)`, which unifies to `dyn`.
+ *   2. It keeps the ENCLOSING map literal heterogeneous → `map(string,dyn)`, so the single
+ *      `.merge({...})` operand has a uniform value type with any other merge operand. The previous
+ *      approach (one conditional single-key `.merge(has(spec.X) ? {"X": spec.X} : {})` per optional
+ *      field) instead produced operands like `map(string,int)` and `map(string,string)`; KRO's `merge`
+ *      requires a SHARED value type across operands and rejected the mix
+ *      (`map(string,int).merge(map(string,string))`). One heterogeneous dyn map sidesteps that.
+ */
+function inlineOptionalEntry(entry: { key: string; guard: string; valueExpr: string }): string {
+  return `${JSON.stringify(entry.key)}: ${entry.guard} ? dyn(${entry.valueExpr}) : omit()`;
+}
+
+/**
+ * Append a SINGLE heterogeneous `.merge({...})` operand carrying both the required inline entries and the
+ * optional-ref entries (the latter as dyn-wrapped omit ternaries — see {@link inlineOptionalEntry}). They
+ * share one map literal so the operand is `map(string,dyn)` and chains cleanly with the base/other merges.
  */
 function appendOverlayMerges(
   merges: string[],
   inlineEntries: string[],
   optionalEntries: Array<{ key: string; guard: string; valueExpr: string }>
 ): void {
-  if (inlineEntries.length > 0) {
-    merges.push(`.merge({${inlineEntries.join(', ')}})`);
-  }
-  for (const { key, guard, valueExpr } of optionalEntries) {
-    merges.push(`.merge(${guard} ? {${JSON.stringify(key)}: ${valueExpr}} : {})`);
+  const allEntries = [...inlineEntries, ...optionalEntries.map(inlineOptionalEntry)];
+  if (allEntries.length > 0) {
+    merges.push(`.merge({${allEntries.join(', ')}})`);
   }
 }
 
@@ -1271,12 +1287,10 @@ function celDeepMergeRuntimeOverlay(
     if (baseValue === undefined) continue;
     const overlayValue = mapKeyAccess(overlayExpression, key);
 
-    // The fallback (overlay key absent) is the base value. When the base value
-    // is an optional schema ref, its `omit()` fallback can't sit inside the
-    // inline `.merge({...})` map — emit a conditional single-key merge so the
-    // key is contributed only when the overlay OR the optional spec field is
-    // present (both branches maps → type-safe for scalars and maps alike):
-    //   .merge(overlayHas || has(spec.X) ? {"key": overlayHas ? overlay[key] : spec.X} : {})
+    // The fallback (overlay key absent) is the base value. When the base value is an optional schema
+    // ref, its `omit()` fallback can't sit bare in a value position — emit a dyn-wrapped omit ternary
+    // (inline, in the one heterogeneous merge map) keyed on overlay-OR-optional-spec presence:
+    //   "key": (overlayHas || has(spec.X)) ? dyn(overlayHas ? overlay[key] : spec.X) : omit()
     const optionalGuard = isKnownMergeObject(baseValue)
       ? undefined
       : optionalRefMergeGuard(baseValue, context);
@@ -1311,13 +1325,14 @@ function celDeepMergeRuntimeOverlay(
 
 /**
  * Emit an object value-tree as a CEL map that is SAFE to sit as a VALUE inside a `.merge({...})` map
- * literal. Optional scalar/leaf schema refs — at ANY depth — are pulled OUT into conditional
- * single-key merges `(...).merge(has(spec.X) ? {"X": spec.X} : {})` instead of being emitted inline as
- * `{"X": has(spec.X) ? spec.X : omit()}`: KRO types `omit()` as `map(string,dyn)`, so for a scalar the
- * `bool ? scalar : map` ternary fails to compile. Nested objects recurse through this same builder, so
- * the fix holds at every level. Used for the FALLBACK (base-absent) literal branch of the deep-merge
- * builders — `celLiteralForValueTree` would re-introduce the invalid inline `omit()` ternary there.
- * For an object with no optional refs this is byte-equivalent to `celLiteralForValueTree`.
+ * literal. Optional scalar/leaf schema refs — at ANY depth — are emitted inline as dyn-wrapped omit
+ * ternaries `"X": has(spec.X) ? dyn(spec.X) : omit()` (see {@link inlineOptionalEntry}) instead of the
+ * bare `"X": has(spec.X) ? spec.X : omit()`: KRO types `omit()` as `map(string,dyn)`, so for a scalar
+ * the bare `bool ? scalar : map` ternary fails to compile. The dyn wrap also keeps this map
+ * heterogeneous (`map(string,dyn)`) so it merges uniformly. Nested objects recurse through this same
+ * builder, so the fix holds at every level. Used for the FALLBACK (base-absent) literal branch of the
+ * deep-merge builders — `celLiteralForValueTree` would re-introduce the invalid inline `omit()` ternary
+ * there. For an object with no optional refs this is byte-equivalent to `celLiteralForValueTree`.
  */
 function celTypeSafeObjectLiteral(
   value: Record<string, unknown>,
@@ -1328,7 +1343,9 @@ function celTypeSafeObjectLiteral(
   const optionalEntries: Array<{ key: string; guard: string; valueExpr: string }> = [];
   for (const [key, child] of Object.entries(value)) {
     if (child === undefined) continue;
-    const optionalGuard = isKnownMergeObject(child) ? undefined : optionalRefMergeGuard(child, context);
+    const optionalGuard = isKnownMergeObject(child)
+      ? undefined
+      : optionalRefMergeGuard(child, context);
     if (optionalGuard) {
       optionalEntries.push({ key, guard: optionalGuard.guard, valueExpr: optionalGuard.valueExpr });
       continue;
@@ -1338,10 +1355,11 @@ function celTypeSafeObjectLiteral(
       : celLiteralForValueTree(child, context, childPath(path, key));
     inlineEntries.push(`${JSON.stringify(key)}: ${childExpr}`);
   }
-  const base = `{${inlineEntries.join(', ')}}`;
-  const merges: string[] = [];
-  appendOverlayMerges(merges, [], optionalEntries);
-  return merges.length > 0 ? `(${base})${merges.join('')}` : base;
+  // Fold the optional refs into the SAME literal as dyn-wrapped omit ternaries. They must live in this
+  // one map (not a trailing `.merge({...})`) — a separate merge operand would be `map(string,dyn)` while
+  // a homogeneous base (e.g. all-int) would be `map(string,int)`, and KRO rejects the mismatched merge.
+  const allEntries = [...inlineEntries, ...optionalEntries.map(inlineOptionalEntry)];
+  return `{${allEntries.join(', ')}}`;
 }
 
 function celDeepMergeKnownOverlay(
@@ -1356,9 +1374,9 @@ function celDeepMergeKnownOverlay(
   for (const [key, overlayValue] of Object.entries(overlay)) {
     if (overlayValue === undefined) continue;
 
-    // An optional scalar/leaf schema ref overlay value would otherwise emit
-    // `"X": has(spec.X) ? spec.X : omit()` inside the inline map — a KRO type
-    // error for scalars. Emit it as a conditional single-key merge instead.
+    // An optional scalar/leaf schema ref overlay value would otherwise emit the bare
+    // `"X": has(spec.X) ? spec.X : omit()` — a KRO type error for scalars. Emit it dyn-wrapped instead
+    // (`has(spec.X) ? dyn(spec.X) : omit()`), inline in the one heterogeneous merge map.
     const optionalGuard = isKnownMergeObject(overlayValue)
       ? undefined
       : optionalRefMergeGuard(overlayValue, context);

--- a/src/factories/dagster/utils/helm-values-mapper.ts
+++ b/src/factories/dagster/utils/helm-values-mapper.ts
@@ -212,8 +212,12 @@ function overlayGlobalValue(
   if (overlayValue === undefined) return;
 
   if (isGraphAwareValue(overlayValue) || isValuesMergeExpression(overlayValue)) {
+    // dyn-wrap the present-value branches: KRO types `omit()` as `map(string,dyn)`, so a bare
+    // `... ? <scalar> : omit()` is `(bool, scalar, map)` — no `_?_:_` overload. `dyn(...)` unifies the
+    // branches to `dyn`, and keeps this value `dyn`-typed so it sits cleanly in the heterogeneous
+    // values-merge map (`map(string,dyn)`).
     target[key] = Cel.expr<string>(
-      `${hasSchemaPath(overlayPath)} ? ${overlayPath} : ${hasSchemaPath(fallbackPath)} ? ${fallbackPath} : omit()`
+      `${hasSchemaPath(overlayPath)} ? dyn(${overlayPath}) : ${hasSchemaPath(fallbackPath)} ? dyn(${fallbackPath}) : omit()`
     ) as TypeKroValueTree;
     return;
   }
@@ -613,7 +617,9 @@ function createDagsterValuesMerge(
 function falseWhenValuePresent(value: unknown, schemaPath: string): boolean | undefined {
   if (value === undefined) return undefined;
   if (isGraphAwareValue(value) || isValuesMergeExpression(value)) {
-    return Cel.expr<boolean>(`${hasSchemaPath(schemaPath)} ? false : omit()`) as boolean;
+    // dyn-wrap the present branch: `... ? false : omit()` is `(bool, bool, map)` (omit() is map-typed)
+    // — no `_?_:_` overload. `dyn(false)` unifies the branches to `dyn`.
+    return Cel.expr<boolean>(`${hasSchemaPath(schemaPath)} ? dyn(false) : omit()`) as boolean;
   }
 
   return false;

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -150,11 +150,13 @@ describe('Dagster bootstrap composition', () => {
     expect(yaml).toContain('schema.spec.global.serviceAccountName');
     expect(yaml).toContain('schema.spec.global.postgresqlSecretName');
     expect(yaml).toContain('schema.spec.global.dagsterInstanceConfigMap');
+    // Present-value branches are dyn-wrapped so the `... : omit()` fallback type-checks (omit() is
+    // map-typed; a bare `scalar : omit()` has no `_?_:_` overload).
     expect(yaml).toContain(
-      'has(schema.spec.serviceAccountName) ? schema.spec.serviceAccountName : has(schema.spec.global) && has(schema.spec.global.serviceAccountName) ? schema.spec.global.serviceAccountName : omit()'
+      'has(schema.spec.serviceAccountName) ? dyn(schema.spec.serviceAccountName) : has(schema.spec.global) && has(schema.spec.global.serviceAccountName) ? dyn(schema.spec.global.serviceAccountName) : omit()'
     );
     expect(yaml).toContain(
-      'has(schema.spec.postgresql) && has(schema.spec.postgresql.passwordSecretName) ? schema.spec.postgresql.passwordSecretName : has(schema.spec.global) && has(schema.spec.global.postgresqlSecretName) ? schema.spec.global.postgresqlSecretName : omit()'
+      'has(schema.spec.postgresql) && has(schema.spec.postgresql.passwordSecretName) ? dyn(schema.spec.postgresql.passwordSecretName) : has(schema.spec.global) && has(schema.spec.global.postgresqlSecretName) ? dyn(schema.spec.global.postgresqlSecretName) : omit()'
     );
     expect(yaml).toContain('schema.spec.postgresql.values');
     expect(yaml).toContain('schema.spec.rabbitmq.values');
@@ -162,8 +164,10 @@ describe('Dagster bootstrap composition', () => {
     expect(yaml).toContain('postgresqlHost');
     expect(yaml).toContain('k8sRunLauncher');
     expect(yaml).toContain(
-      'has(schema.spec.postgresql) && has(schema.spec.postgresql.passwordSecretName) ? false : omit()'
+      'has(schema.spec.postgresql) && has(schema.spec.postgresql.passwordSecretName) ? dyn(false) : omit()'
     );
+    // Invariant: no BARE `<scalar> : omit()` ternary survives anywhere (every omit() fallback is dyn-guarded).
+    expect(yaml).not.toMatch(/\? (?:schema\.spec\.[\w.]+|false|true) : omit\(\)/);
     expect(yaml).not.toContain('\\"deployments\\": [(has(schema.spec.userDeployments');
     expect(yaml).not.toContain('\\"imagePullSecrets\\": [(has(schema.spec.imagePullSecrets');
     expect(yaml).not.toContain('__KUBERNETES_REF_');

--- a/test/factories/helm/helm-integration.test.ts
+++ b/test/factories/helm/helm-integration.test.ts
@@ -333,22 +333,24 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     // It must take the runtime map-merge path.
     expect(valuesLine).toContain('json.unmarshal(json.marshal(schema.spec.values))');
 
-    // CORE ASSERTION: no scalar-vs-omit() ternary anywhere — i.e. no
-    // `? <scalar-ref> : omit()` sitting as a value inside a `.merge({...})`.
-    // omit() must not appear at all in this runtime-merge expression.
-    expect(valuesLine).not.toContain('omit()');
+    // CORE ASSERTION: no BARE scalar-vs-omit() ternary — `? <scalar-ref> : omit()` is the KRO type
+    // error (omit() is map-typed). Every omit() fallback must be dyn-guarded: `? dyn(<scalar>) : omit()`.
     expect(valuesLine).not.toMatch(/\? schema\.spec\.\w+ : omit\(\)/);
+    expect(valuesLine).not.toMatch(/\? string\([^)]*\) : omit\(\)/);
 
-    // The optional scalars must use the type-safe conditional single-key merge:
-    // both branches are maps. (Inner double-quotes are YAML-escaped as \".)
+    // The optional scalars are emitted INLINE as dyn-wrapped omit ternaries, all in ONE heterogeneous
+    // `.merge({...})` (→ map(string,dyn), which merges uniformly). (Inner double-quotes YAML-escaped \".)
     expect(valuesLine).toContain(
-      '.merge(has(schema.spec.nameOverride) ? {\\"nameOverride\\": schema.spec.nameOverride} : {})'
+      '\\"nameOverride\\": has(schema.spec.nameOverride) ? dyn(schema.spec.nameOverride) : omit()'
     );
     expect(valuesLine).toContain(
-      '.merge(has(schema.spec.generateCeleryConfigSecret) ? {\\"generateCeleryConfigSecret\\": schema.spec.generateCeleryConfigSecret} : {})'
+      '\\"generateCeleryConfigSecret\\": has(schema.spec.generateCeleryConfigSecret) ? dyn(schema.spec.generateCeleryConfigSecret) : omit()'
     );
 
-    // The required field stays in the inline merge map (no guard needed).
+    // Exactly one merge operand (no per-field single-key merge split — that broke map-value uniformity).
+    expect(valuesLine.match(/\.merge\(/g)?.length).toBe(1);
+
+    // The required field stays in the same inline merge map (no guard needed).
     expect(valuesLine).toContain('\\"replicaCount\\": schema.spec.replicas');
 
     expect(valuesLine).not.toContain('__KUBERNETES_REF_');
@@ -606,13 +608,14 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     const yaml = graph.toYaml();
     const valuesLine = yaml.split('\n').find((line) => line.includes('values: "${')) ?? '';
 
-    // Guard on the bare path; the VALUE preserves the string() conversion. (Quotes YAML-escaped as \".)
+    // Guard on the bare path; the dyn-wrapped VALUE preserves the string() conversion. (Quotes \".)
     expect(valuesLine).toContain(
-      '.merge(has(schema.spec.port) ? {\\"portString\\": string(schema.spec.port)} : {})'
+      '\\"portString\\": has(schema.spec.port) ? dyn(string(schema.spec.port)) : omit()'
     );
     // Must NOT drop string() and emit the bare ref as the value.
-    expect(valuesLine).not.toContain('{\\"portString\\": schema.spec.port}');
-    expect(valuesLine).not.toContain('omit()');
+    expect(valuesLine).not.toContain('dyn(schema.spec.port)');
+    // No BARE scalar-omit ternary (the string() value is dyn-wrapped, so it's well-typed).
+    expect(valuesLine).not.toMatch(/\? string\([^)]*\) : omit\(\)/);
   });
 
   // Regression: an optional scalar nested inside an OBJECT overlay must also be type-safe. The
@@ -644,14 +647,17 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     const yaml = graph.toYaml();
     const valuesLine = yaml.split('\n').find((line) => line.includes('values: "${')) ?? '';
 
-    // No omit() anywhere — at any nesting depth.
-    expect(valuesLine).not.toContain('omit()');
+    // No BARE scalar-omit ternary at any depth — every omit() fallback is dyn-guarded.
     expect(valuesLine).not.toMatch(/\? schema\.spec\.\w+ : omit\(\)/);
-    // The nested optional scalar uses the type-safe single-key merge in BOTH the base-present and
-    // base-absent branches (the base-absent fallback is `({}).merge(...)`, not an inline omit ternary).
+    // The nested optional scalar is emitted as a dyn-wrapped omit ternary INLINE in BOTH the
+    // base-present (`...["global"]).merge({...})`) and base-absent (literal `{...}`) branches.
     expect(valuesLine).toContain(
-      '.merge(has(schema.spec.secretName) ? {\\"celeryConfigSecretName\\": schema.spec.secretName} : {})'
+      '\\"celeryConfigSecretName\\": has(schema.spec.secretName) ? dyn(schema.spec.secretName) : omit()'
     );
-    expect(valuesLine).toContain('({}).merge(has(schema.spec.secretName)');
+    // Both branches carry the same dyn-wrapped optional entry (present-branch merge + absent literal).
+    expect(
+      valuesLine.match(/\\"celeryConfigSecretName\\": has\(schema\.spec\.secretName\) \? dyn\(schema\.spec\.secretName\) : omit\(\)/g)
+        ?.length
+    ).toBe(2);
   });
 });


### PR DESCRIPTION
Follow-up to #86.

## Problem
#86 fixed the bare `has(spec.X) ? <scalar> : omit()` KRO type error (omit() is typed `map(string,dyn)`, so a scalar present-branch has no matching `_?_:_` overload) by pulling each optional ref out into a conditional **single-key merge**:

```
.merge(has(spec.X) ? {"X": spec.X} : {})
```

That compiles each ternary, but a **live converge** then failed at RGD admission with:

```
merge applied to 'map(string,int).(map(string,image))'
```

KRO's `merge` requires a **shared value type** across operands. Splitting optional fields into separate single-key merges gives each operand its own concrete map value type (`map(string,int)`, `map(string,string)`, …), and mixing them is rejected.

## Fix
Keep **one heterogeneous `.merge({...})`** and emit each optional ref inline as a **dyn-wrapped** omit ternary:

```
"X": has(spec.X) ? dyn(spec.X) : omit()
```

`dyn(...)` does double duty:
1. `(bool, dyn, map)` is a valid `_?_:_` overload → the ternary type-checks.
2. It keeps the enclosing map heterogeneous → `map(string,dyn)`, so the operand merges uniformly with the base and any other merge.

Applied at every emission point:
- `cel-references.ts` — `inlineOptionalEntry` folds optional refs into the single merge map (and into nested literals via `celTypeSafeObjectLiteral`, not a trailing `.merge`, so a homogeneous base can't reintroduce the mismatch).
- `helm-values-mapper.ts` — the dagster multi-source composite chains (`serviceAccountName` / `postgresqlSecretName` / `generateCeleryConfigSecret`) dyn-wrap their present-value branches.

## Tests
Invariant assertions added/updated: no bare `<scalar> : omit()` survives anywhere; exactly one merge operand (no single-key split); `string()` conversions preserved inside the dyn wrap; nested optional scalars dyn-wrapped in both branches. Full unit/factories/core suite green (4486 pass / 0 fail), tsc clean.