### PR TITLE
fix(dagster): dyn-wrap the daemon liveness-probe CEL fallback (KRO rejects (bool,string,map) ternary)

### DIFF
--- a/src/factories/dagster/compositions/dagster-bootstrap.ts
+++ b/src/factories/dagster/compositions/dagster-bootstrap.ts
@@ -199,9 +199,14 @@ function resolveDaemonConfig(
   if (isKubernetesRef(probe) || isKubernetesRef(daemon)) {
     return {
       ...((daemon ?? {}) as object),
+      // dyn-wrap BOTH branches: KRO renders the opaque `objectMapSchema` field as type `string`, while
+      // the default is a map literal — so a bare `has(X) ? <string> : <map>` ternary is
+      // `(bool, string, map)`, which has no `_?_:_` overload (KRO admission fails with exactly that).
+      // dyn() on each branch unifies them to `dyn`; the runtime value (user probe or the default) is
+      // unchanged.
       livenessProbe: Cel.expr<TypeKroValueTreeObject>(
         `has(schema.spec.daemon) && has(schema.spec.daemon.livenessProbe) ? ` +
-          `schema.spec.daemon.livenessProbe : ${DEFAULT_DAEMON_LIVENESS_PROBE_CEL}`
+          `dyn(schema.spec.daemon.livenessProbe) : dyn(${DEFAULT_DAEMON_LIVENESS_PROBE_CEL})`
       ) as unknown as TypeKroValueTreeObject,
     } as DagsterBootstrapConfig['daemon'];
   }

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -362,8 +362,12 @@ describe('Dagster bootstrap default daemon liveness probe', () => {
   it('Emit the default daemon liveness probe as a CEL fallback in the KRO RGD', () => {
     const yaml = dagsterBootstrap.toYaml();
     expect(yaml).toContain('has(schema.spec.daemon.livenessProbe)');
-    expect(yaml).toContain('schema.spec.daemon.livenessProbe :');
     expect(yaml).toContain('dagster-daemon');
     expect(yaml).toContain('liveness-check');
+    // Both branches MUST be dyn-wrapped: the field renders as KRO opaque type `string` but the default
+    // is a map literal, so a bare `has(X) ? <string> : <map>` ternary is `(bool, string, map)` — no
+    // `_?_:_` overload, and KRO rejects the graph. dyn() unifies both branches to `dyn`.
+    expect(yaml).toContain('dyn(schema.spec.daemon.livenessProbe)');
+    expect(yaml).not.toMatch(/\? schema\.spec\.daemon\.livenessProbe : \{/);
   });
 });


### PR DESCRIPTION
Follow-up to #87 (the omit-path dyn-wrap). Live verification of the converge surfaced a **second, independent** KRO admission error in the dagster bootstrap RGD — not an omit() issue.

## Problem
The daemon liveness probe (added in #82) is injected in KRO mode as a CEL fallback so a user-supplied probe wins per instance, else a default applies:

```
has(spec.daemon) && has(spec.daemon.livenessProbe) ? spec.daemon.livenessProbe : {"exec": {...}, ...}
```

`daemon.livenessProbe` is declared via `objectMapSchema`, which KRO renders as the **opaque type `string`**; the default branch is a **map literal**. So the ternary is `(bool, string, map)` — no `_?_:_` overload — and KRO rejects the graph:

```
found no matching overload for '_?_:_' applied to '(bool, string, map(string, dyn))'
```

This was the *only* remaining error after #87 (the omit path was fully clean: 0 bare `? scalar : omit()`, 136 correctly dyn-wrapped). KRO reports all compile errors at once; the two it listed were both branches of this one field.

## Fix
dyn-wrap both branches so they unify to `dyn`:

```
has(spec.daemon) && has(spec.daemon.livenessProbe) ? dyn(spec.daemon.livenessProbe) : dyn({default})
```

Runtime value (user probe or default) is unchanged. Test now asserts both branches are dyn-wrapped and no bare `? spec.daemon.livenessProbe : {` ternary survives. Full suite green (4486/0).