### PR TITLE
feat: add computed status aliases

### DIFF
--- a/src/core/expressions/analysis/alias-inliner.ts
+++ b/src/core/expressions/analysis/alias-inliner.ts
@@ -7,6 +7,8 @@
 
 export type LexicalAliasScope = Record<string, string>;
 
+const UNSUPPORTED_ALIAS_EXPRESSION = '__TYPEKRO_UNSUPPORTED_LEXICAL_ALIAS__';
+
 // biome-ignore lint/suspicious/noExplicitAny: ESTree nodes from acorn/estraverse are intentionally handled dynamically.
 type AnyNode = Record<string, any>;
 
@@ -151,6 +153,8 @@ function collectSingleResourceAliases(
     });
     if (key && expressionSource) {
       aliases[`${aliasName}.${key}`] = expressionSource;
+    } else if (key) {
+      aliases[`${aliasName}.${key}`] = UNSUPPORTED_ALIAS_EXPRESSION;
     }
   }
   return aliases;
@@ -178,6 +182,8 @@ function collectMultiResourceAliases(
     });
     if (key && expressionSource) {
       aliases[`${aliasName}.${key}`] = expressionSource;
+    } else if (key) {
+      aliases[`${aliasName}.${key}`] = UNSUPPORTED_ALIAS_EXPRESSION;
     }
   }
   return aliases;
@@ -302,8 +308,16 @@ function topLevelFunctionStatements(ast: AnyNode): AnyNode[] {
 }
 
 function replaceAliasPath(expression: string, aliasPath: string, aliasExpression: string): string {
+  if (aliasExpression === UNSUPPORTED_ALIAS_EXPRESSION && aliasPathOccurs(expression, aliasPath)) {
+    throw new Error(`Unsupported lexical alias expression: ${aliasPath}`);
+  }
   const pattern = new RegExp(`(?<![\\w$.])${escapeRegExp(aliasPath)}(?![\\w$])`, 'g');
   return expression.replace(pattern, parenthesizeAliasExpression(aliasExpression));
+}
+
+function aliasPathOccurs(expression: string, aliasPath: string): boolean {
+  const pattern = new RegExp(`(?<![\\w$.])${escapeRegExp(aliasPath)}(?![\\w$])`);
+  return pattern.test(expression);
 }
 
 function parenthesizeAliasExpression(expression: string): string {

--- a/src/core/expressions/analysis/alias-inliner.ts
+++ b/src/core/expressions/analysis/alias-inliner.ts
@@ -1,0 +1,372 @@
+/**
+ * Lexical alias collection and inlining for status expressions.
+ *
+ * This pass intentionally works on source/AST before JS values are evaluated,
+ * because JavaScript operators erase the symbolic proxy expression at runtime.
+ */
+
+export type LexicalAliasScope = Record<string, string>;
+
+// biome-ignore lint/suspicious/noExplicitAny: ESTree nodes from acorn/estraverse are intentionally handled dynamically.
+type AnyNode = Record<string, any>;
+
+export function buildLexicalAliasScope(ast: unknown, source: string): LexicalAliasScope {
+  const scope: LexicalAliasScope = {};
+  const statements = topLevelFunctionStatements(ast as AnyNode);
+
+  for (const statement of statements) {
+    if (statement.type === 'ReturnStatement') {
+      break;
+    }
+    if (statement.type !== 'VariableDeclaration' || statement.kind !== 'const') {
+      continue;
+    }
+
+    for (const declaration of statement.declarations ?? []) {
+      collectVariableAlias(declaration, source, scope);
+    }
+  }
+
+  return scope;
+}
+
+export function inlineLexicalAliases(expression: string, scope: LexicalAliasScope): string {
+  let result = expression;
+  const entries = Object.entries(scope).sort((left, right) => right[0].length - left[0].length);
+
+  for (let pass = 0; pass < 20; pass++) {
+    let changed = false;
+    for (const [aliasPath, aliasExpression] of entries) {
+      const next = replaceAliasPath(result, aliasPath, aliasExpression);
+      if (next !== result) {
+        changed = true;
+        result = next;
+      }
+    }
+    if (!changed) {
+      return result;
+    }
+  }
+
+  throw new Error(`Could not fully inline lexical aliases in expression: ${expression}`);
+}
+
+export function topLevelReturnStatement(ast: unknown): AnyNode | undefined {
+  return topLevelFunctionStatements(ast as AnyNode).find(
+    (statement) => statement.type === 'ReturnStatement'
+  );
+}
+
+function collectVariableAlias(
+  declaration: AnyNode,
+  source: string,
+  scope: LexicalAliasScope
+): void {
+  if (
+    declaration.type !== 'VariableDeclarator' ||
+    declaration.id?.type !== 'Identifier' ||
+    !declaration.init
+  ) {
+    return;
+  }
+
+  const aliasName = declaration.id.name;
+  const init = declaration.init;
+  const explicitAliases = collectExplicitAliases(aliasName, init, source);
+  if (explicitAliases) {
+    Object.assign(scope, explicitAliases);
+    return;
+  }
+
+  if (init.type === 'ObjectExpression') {
+    collectObjectAliases(aliasName, init, source, scope);
+    return;
+  }
+
+  if (isInlineableAliasExpression(init)) {
+    scope[aliasName] = getNodeSource(init, source);
+  }
+}
+
+function collectObjectAliases(
+  prefix: string,
+  objectNode: AnyNode,
+  source: string,
+  scope: LexicalAliasScope
+): void {
+  for (const property of objectNode.properties ?? []) {
+    if (property.type !== 'Property') {
+      continue;
+    }
+    const key = propertyName(property.key);
+    if (!key) {
+      continue;
+    }
+    const aliasPath = `${prefix}.${key}`;
+    if (property.value.type === 'ObjectExpression') {
+      collectObjectAliases(aliasPath, property.value, source, scope);
+    } else if (isInlineableAliasExpression(property.value)) {
+      scope[aliasPath] = getNodeSource(property.value, source);
+    }
+  }
+}
+
+function collectExplicitAliases(
+  aliasName: string,
+  init: AnyNode,
+  source: string
+): LexicalAliasScope | undefined {
+  if (init.type !== 'CallExpression' || init.callee?.type !== 'Identifier') {
+    return undefined;
+  }
+
+  if (init.callee.name === 'alias') {
+    return collectSingleResourceAliases(aliasName, init, source);
+  }
+  if (init.callee.name === 'aliases') {
+    return collectMultiResourceAliases(aliasName, init, source);
+  }
+  return undefined;
+}
+
+function collectSingleResourceAliases(
+  aliasName: string,
+  callNode: AnyNode,
+  source: string
+): LexicalAliasScope | undefined {
+  const [resourceNode, definitionsNode] = callNode.arguments ?? [];
+  if (!resourceNode || definitionsNode?.type !== 'ObjectExpression') {
+    return undefined;
+  }
+
+  const resourceSource = getNodeSource(resourceNode, source);
+  const aliases: LexicalAliasScope = {};
+  for (const property of definitionsNode.properties ?? []) {
+    if (property.type !== 'Property') {
+      continue;
+    }
+    const key = propertyName(property.key);
+    const expressionSource = callbackExpressionSource(property.value, source, {
+      identifierPath: resourceSource,
+    });
+    if (key && expressionSource) {
+      aliases[`${aliasName}.${key}`] = expressionSource;
+    }
+  }
+  return aliases;
+}
+
+function collectMultiResourceAliases(
+  aliasName: string,
+  callNode: AnyNode,
+  source: string
+): LexicalAliasScope | undefined {
+  const [resourcesNode, definitionsNode] = callNode.arguments ?? [];
+  if (resourcesNode?.type !== 'ObjectExpression' || definitionsNode?.type !== 'ObjectExpression') {
+    return undefined;
+  }
+
+  const resources = objectResourceBindings(resourcesNode, source);
+  const aliases: LexicalAliasScope = {};
+  for (const property of definitionsNode.properties ?? []) {
+    if (property.type !== 'Property') {
+      continue;
+    }
+    const key = propertyName(property.key);
+    const expressionSource = callbackExpressionSource(property.value, source, {
+      destructuredPaths: resources,
+    });
+    if (key && expressionSource) {
+      aliases[`${aliasName}.${key}`] = expressionSource;
+    }
+  }
+  return aliases;
+}
+
+function callbackExpressionSource(
+  callbackNode: AnyNode,
+  source: string,
+  bindings: { identifierPath?: string; destructuredPaths?: Record<string, string> }
+): string | undefined {
+  if (
+    callbackNode.type !== 'ArrowFunctionExpression' &&
+    callbackNode.type !== 'FunctionExpression'
+  ) {
+    return undefined;
+  }
+
+  const expressionNode = callbackBodyExpression(callbackNode);
+  if (!expressionNode) {
+    return undefined;
+  }
+
+  let expressionSource = getNodeSource(expressionNode, source);
+  const [parameter] = callbackNode.params ?? [];
+  if (parameter?.type === 'Identifier' && bindings.identifierPath) {
+    expressionSource = replaceAliasPath(expressionSource, parameter.name, bindings.identifierPath);
+  } else if (parameter?.type === 'ObjectPattern' && bindings.destructuredPaths) {
+    const parameterBindings = destructuredParameterBindings(parameter, bindings.destructuredPaths);
+    for (const [localName, replacementPath] of Object.entries(parameterBindings)) {
+      expressionSource = replaceAliasPath(expressionSource, localName, replacementPath);
+    }
+  }
+
+  return expressionSource;
+}
+
+function callbackBodyExpression(callbackNode: AnyNode): AnyNode | undefined {
+  if (callbackNode.body?.type && callbackNode.body.type !== 'BlockStatement') {
+    return callbackNode.body;
+  }
+  if (callbackNode.body?.type !== 'BlockStatement') {
+    return undefined;
+  }
+  const statement = (callbackNode.body.body ?? []).find(
+    (node: AnyNode) => node.type === 'ReturnStatement'
+  );
+  return statement?.argument;
+}
+
+function objectResourceBindings(objectNode: AnyNode, source: string): Record<string, string> {
+  const bindings: Record<string, string> = {};
+  for (const property of objectNode.properties ?? []) {
+    if (property.type !== 'Property') {
+      continue;
+    }
+    const key = propertyName(property.key);
+    if (!key) {
+      continue;
+    }
+    bindings[key] = getNodeSource(property.value, source);
+  }
+  return bindings;
+}
+
+function destructuredParameterBindings(
+  parameter: AnyNode,
+  resources: Record<string, string>
+): Record<string, string> {
+  const bindings: Record<string, string> = {};
+  for (const property of parameter.properties ?? []) {
+    if (property.type !== 'Property') {
+      continue;
+    }
+    const key = propertyName(property.key);
+    if (!key || !resources[key]) {
+      continue;
+    }
+    if (property.value.type === 'Identifier') {
+      bindings[property.value.name] = resources[key];
+    } else if (
+      property.value.type === 'AssignmentPattern' &&
+      property.value.left?.type === 'Identifier'
+    ) {
+      bindings[property.value.left.name] = resources[key];
+    }
+  }
+  return bindings;
+}
+
+function isInlineableAliasExpression(node: AnyNode): boolean {
+  return (
+    node.type === 'Identifier' ||
+    node.type === 'Literal' ||
+    node.type === 'TemplateLiteral' ||
+    node.type === 'MemberExpression' ||
+    node.type === 'ChainExpression' ||
+    node.type === 'BinaryExpression' ||
+    node.type === 'LogicalExpression' ||
+    node.type === 'ConditionalExpression' ||
+    node.type === 'UnaryExpression'
+  );
+}
+
+function topLevelFunctionStatements(ast: AnyNode): AnyNode[] {
+  const firstStatement = ast.body?.[0];
+  const expression =
+    firstStatement?.type === 'ExpressionStatement' ? firstStatement.expression : undefined;
+  const functionNode =
+    expression?.type === 'ArrowFunctionExpression' || expression?.type === 'FunctionExpression'
+      ? expression
+      : firstStatement?.type === 'FunctionDeclaration'
+        ? firstStatement
+        : undefined;
+
+  if (!functionNode) {
+    return [];
+  }
+  if (functionNode.body?.type === 'BlockStatement') {
+    return functionNode.body.body ?? [];
+  }
+  return [];
+}
+
+function replaceAliasPath(expression: string, aliasPath: string, aliasExpression: string): string {
+  const pattern = new RegExp(`(?<![\\w$.])${escapeRegExp(aliasPath)}(?![\\w$])`, 'g');
+  return expression.replace(pattern, parenthesizeAliasExpression(aliasExpression));
+}
+
+function parenthesizeAliasExpression(expression: string): string {
+  return needsParentheses(expression) ? `(${expression})` : expression;
+}
+
+function needsParentheses(expression: string): boolean {
+  return /\s(?:\|\||&&|[!=<>]=?|[+\-*/%])\s|\?/.test(expression.trim());
+}
+
+function propertyName(node: AnyNode): string | undefined {
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    return node.value;
+  }
+  return undefined;
+}
+
+export function getNodeSource(node: AnyNode, fullSource: string): string {
+  if (node.range) {
+    return fullSource.substring(node.range[0], node.range[1]);
+  }
+
+  switch (node.type) {
+    case 'Literal':
+      return typeof node.value === 'string' ? JSON.stringify(node.value) : String(node.value);
+    case 'Identifier':
+      return node.name;
+    case 'BinaryExpression':
+    case 'LogicalExpression':
+      return `${getNodeSource(node.left, fullSource)} ${node.operator} ${getNodeSource(node.right, fullSource)}`;
+    case 'ConditionalExpression':
+      return `${getNodeSource(node.test, fullSource)} ? ${getNodeSource(node.consequent, fullSource)} : ${getNodeSource(node.alternate, fullSource)}`;
+    case 'UnaryExpression':
+      return `${node.operator}${getNodeSource(node.argument, fullSource)}`;
+    case 'ChainExpression':
+      return getNodeSource(node.expression, fullSource);
+    case 'MemberExpression': {
+      const object = getNodeSource(node.object, fullSource);
+      const property = node.computed
+        ? `[${getNodeSource(node.property, fullSource)}]`
+        : `.${propertyName(node.property) ?? getNodeSource(node.property, fullSource)}`;
+      return `${object}${property}`;
+    }
+    case 'TemplateLiteral': {
+      let result = '`';
+      const quasis = node.quasis ?? [];
+      const expressions = node.expressions ?? [];
+      for (let index = 0; index < quasis.length; index++) {
+        result += quasis[index]?.value?.raw ?? '';
+        if (expressions[index]) {
+          result += `\${${getNodeSource(expressions[index], fullSource)}}`;
+        }
+      }
+      return `${result}\``;
+    }
+    default:
+      return '<unknown>';
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/core/expressions/analysis/cel-emitter.ts
+++ b/src/core/expressions/analysis/cel-emitter.ts
@@ -384,26 +384,13 @@ export function convertLogicalOrFallback(left: CelExpression, right: CelExpressi
 }
 
 /**
- * Convert logical AND (value && other) to CEL conditional
+ * Convert logical AND to direct CEL boolean conjunction.
  */
 export function convertLogicalAnd(left: CelExpression, right: CelExpression): CelExpression {
   // Add parentheses to operands if they contain lower precedence operators
   const leftExpr = addParenthesesIfNeededFn(left.expression, '&&', true);
   const rightExpr = addParenthesesIfNeededFn(right.expression, '&&', false);
-
-  // For resource references, primarily check for null/undefined
-  if (isResourceReference(left.expression) || left.expression.includes('?')) {
-    const expression = `${leftExpr} != null ? ${rightExpr} : ${leftExpr}`;
-
-    return {
-      [CEL_EXPRESSION_BRAND]: true,
-      expression,
-      _type: undefined,
-    } as CelExpression;
-  }
-
-  // For general expressions, check for all truthy values
-  const expression = `${leftExpr} != null && ${leftExpr} != "" && ${leftExpr} != false && ${leftExpr} != 0 ? ${rightExpr} : ${leftExpr}`;
+  const expression = `${leftExpr} && ${rightExpr}`;
 
   return {
     [CEL_EXPRESSION_BRAND]: true,

--- a/src/core/expressions/analysis/cel-emitter.ts
+++ b/src/core/expressions/analysis/cel-emitter.ts
@@ -383,14 +383,74 @@ export function convertLogicalOrFallback(left: CelExpression, right: CelExpressi
   } as CelExpression;
 }
 
+function isClearlyBooleanExpression(expression: string, type: unknown): boolean {
+  if (type === 'boolean') {
+    return true;
+  }
+
+  const trimmed = expression.trim();
+  if (trimmed === 'true' || trimmed === 'false') {
+    return true;
+  }
+
+  if (trimmed.startsWith('!')) {
+    return true;
+  }
+
+  if (/\s(?:==|!=|>=|<=|>|<)\s/.test(trimmed)) {
+    return !trimmed.includes('?');
+  }
+
+  if (/^(has|startsWith|endsWith|contains)\(/.test(trimmed)) {
+    return true;
+  }
+
+  if (/\.(startsWith|endsWith|contains)\(/.test(trimmed)) {
+    return true;
+  }
+
+  const lastField = trimmed.match(/(?:^|\.)([A-Za-z_$][\w$]*)$/)?.[1]?.toLowerCase();
+  return (
+    !!lastField &&
+    ['ready', 'available', 'enabled', 'healthy', 'succeeded', 'success'].includes(lastField)
+  );
+}
+
 /**
- * Convert logical AND to direct CEL boolean conjunction.
+ * Convert logical AND to direct CEL boolean conjunction when operands are boolean-shaped.
+ * Otherwise preserve JavaScript guard/value semantics for expressions like `value && value.field`.
  */
 export function convertLogicalAnd(left: CelExpression, right: CelExpression): CelExpression {
   // Add parentheses to operands if they contain lower precedence operators
   const leftExpr = addParenthesesIfNeededFn(left.expression, '&&', true);
   const rightExpr = addParenthesesIfNeededFn(right.expression, '&&', false);
-  const expression = `${leftExpr} && ${rightExpr}`;
+
+  if (
+    isClearlyBooleanExpression(left.expression, left._type) &&
+    isClearlyBooleanExpression(right.expression, right._type)
+  ) {
+    const expression = `${leftExpr} && ${rightExpr}`;
+
+    return {
+      [CEL_EXPRESSION_BRAND]: true,
+      expression,
+      _type: undefined,
+    } as CelExpression;
+  }
+
+  // For resource references, primarily check for null/undefined.
+  if (isResourceReference(left.expression) || left.expression.includes('?')) {
+    const expression = `${leftExpr} != null ? ${rightExpr} : ${leftExpr}`;
+
+    return {
+      [CEL_EXPRESSION_BRAND]: true,
+      expression,
+      _type: undefined,
+    } as CelExpression;
+  }
+
+  // For general expressions, check for all truthy values.
+  const expression = `${leftExpr} != null && ${leftExpr} != "" && ${leftExpr} != false && ${leftExpr} != 0 ? ${rightExpr} : ${leftExpr}`;
 
   return {
     [CEL_EXPRESSION_BRAND]: true,

--- a/src/core/expressions/composition/imperative-analyzer.ts
+++ b/src/core/expressions/composition/imperative-analyzer.ts
@@ -6,12 +6,17 @@
  */
 
 import { Parser } from 'acorn';
-import * as estraverse from 'estraverse';
 import { KUBERNETES_REF_MARKER_SOURCE } from '../../../shared/brands.js';
 import { ensureError } from '../../errors.js';
 import { getComponentLogger } from '../../logging/index.js';
 import { Cel } from '../../references/cel.js';
 import type { Enhanced } from '../../types/index.js';
+import {
+  buildLexicalAliasScope,
+  inlineLexicalAliases,
+  topLevelReturnStatement,
+} from '../analysis/alias-inliner.js';
+import { JavaScriptToCelAnalyzer } from '../analysis/analyzer.js';
 import type { ASTNode } from './composition-analyzer-types.js';
 
 const logger = getComponentLogger('imperative-analyzer');
@@ -58,7 +63,7 @@ export function analyzeImperativeComposition(
     });
 
     // Find the return statement in the composition function
-    const returnStatement = findReturnStatement(ast);
+    const returnStatement = topLevelReturnStatement(ast);
 
     if (!returnStatement || !returnStatement.argument) {
       logger.debug('No return statement found in composition function');
@@ -79,10 +84,9 @@ export function analyzeImperativeComposition(
       };
     }
 
-    // Build a variable scope map from all VariableDeclarations in the function body.
-    // This maps local variable names to their initializer source code so that
-    // expressions like `appReplicas` can be expanded to `spec.app.replicas || 1`.
-    const variableScope = buildVariableScope(ast, functionSource);
+    // Build a lexical alias map from top-level const declarations in the composition body.
+    // This lets status fields reference local aliases like `web.ready` and still serialize to CEL.
+    const variableScope = buildLexicalAliasScope(ast, functionSource);
 
     logger.debug('Built variable scope for imperative composition', {
       variableCount: Object.keys(variableScope).length,
@@ -93,6 +97,7 @@ export function analyzeImperativeComposition(
     const statusMappings: Record<string, unknown> = {};
     const errors: string[] = [];
     let hasJavaScriptExpressions = false;
+    const expressionAnalyzer = new JavaScriptToCelAnalyzer();
 
     // Process properties recursively to handle nested objects
     function processProperties(properties: ASTNode[], parentPath = ''): void {
@@ -102,6 +107,11 @@ export function analyzeImperativeComposition(
         if (propertyNode.type === 'Property' && propertyNode.key.type === 'Identifier') {
           const fieldName = propertyNode.key.name;
           const fullFieldName = parentPath ? `${parentPath}.${fieldName}` : fieldName;
+
+          // Convert the property value to source code, then inline supported local aliases.
+          // Alias-inlining errors must fail closed rather than falling back to static values.
+          const rawSource = getNodeSource(propertyNode.value, functionSource);
+          const propertySource = inlineLexicalAliases(rawSource, variableScope);
 
           try {
             // Check if this is a nested object
@@ -127,11 +137,6 @@ export function analyzeImperativeComposition(
               continue;
             }
 
-            // Convert the property value to source code, then inline local
-            // variables so KRO CEL can resolve them (e.g., `appReplicas` → `spec.app.replicas || 1`)
-            const rawSource = getNodeSource(propertyNode.value, functionSource);
-            const propertySource = inlineVariables(rawSource, variableScope);
-
             logger.debug('Analyzing property', {
               fieldName,
               fullFieldName,
@@ -147,18 +152,27 @@ export function analyzeImperativeComposition(
                 propertySource,
               });
 
-              // Convert resource references to proper format for CEL
-              const convertedSource = convertResourceReferencesToCel(propertySource, resources);
+              const analysisResult = expressionAnalyzer.analyzeExpression(propertySource, {
+                type: 'status',
+                availableReferences: resources,
+                factoryType: options.factoryType,
+                dependencies: [],
+              });
+
+              // Convert resource references to proper format for CEL as a fallback for legacy patterns.
+              const celExpression =
+                analysisResult.valid && analysisResult.celExpression
+                  ? Cel.expr(
+                      normalizeKroResourceExpression(analysisResult.celExpression.expression)
+                    )
+                  : Cel.expr(convertResourceReferencesToCel(propertySource, resources));
 
               logger.debug('Converted resource references', {
                 fieldName,
                 fullFieldName,
                 originalSource: propertySource.substring(0, 100),
-                convertedSource: convertedSource.substring(0, 100),
+                convertedSource: celExpression.expression.substring(0, 100),
               });
-
-              // For imperative compositions, create CEL expressions directly from the converted source
-              const celExpression = Cel.expr(convertedSource);
 
               // Set the CEL expression at the correct nested path
               if (parentPath) {
@@ -271,28 +285,6 @@ export function analyzeImperativeComposition(
 }
 
 /**
- * Find the return statement in an AST
- */
-// biome-ignore lint/suspicious/noExplicitAny: AST traversal over parser-produced ESTree nodes is intentionally dynamic.
-function findReturnStatement(ast: any): any {
-  // biome-ignore lint/suspicious/noExplicitAny: parser-produced traversal state is intentionally dynamic.
-  let returnStatement: any = null;
-
-  estraverse.traverse(ast, {
-    enter: (node) => {
-      if (node.type === 'ReturnStatement') {
-        returnStatement = node;
-        return estraverse.VisitorOption.Break;
-      }
-      // Continue normal traversal
-      return undefined;
-    },
-  });
-
-  return returnStatement;
-}
-
-/**
  * Extract source code for a specific AST node
  */
 // biome-ignore lint/suspicious/noExplicitAny: AST node shape varies widely across ESTree variants used in tests/examples.
@@ -389,6 +381,12 @@ function convertResourceReferencesToCel(
   // This is targeted conversion for the specific patterns produced by imperative compositions,
   // not a full JS→CEL transpiler (which is handled by the analysis engine for other code paths).
   return applyJsToCelConversions(source);
+}
+
+function normalizeKroResourceExpression(expression: string): string {
+  return applyJsToCelConversions(
+    expression.replace(/\bresources\./g, '').replace(/(?<![.\w])spec\./g, 'schema.spec.')
+  );
 }
 
 /**
@@ -657,81 +655,5 @@ function applyJsToCelConversions(source: string): string {
     '$1.orValue($2)'
   );
 
-  return result;
-}
-
-// ── Variable scope resolution ────────────────────────────────────────────
-
-/**
- * Build a scope map from VariableDeclaration nodes in the function body.
- *
- * Scans the function's AST for `const` declarations and maps each variable
- * name to its initializer source code. This enables inlining local variables
- * into status expressions so that KRO CEL can resolve them.
- *
- * Only captures simple initializers that reference `spec.*` (schema proxy
- * accesses) or literal values — not complex expressions or factory calls.
- */
-// biome-ignore lint/suspicious/noExplicitAny: Scope builder intentionally uses dynamic AST shapes.
-function buildVariableScope(ast: any, source: string): Record<string, string> {
-  const scope: Record<string, string> = {};
-
-  // biome-ignore lint/suspicious/noExplicitAny: variable-scope traversal operates on arbitrary AST nodes.
-  function visit(node: any): void {
-    if (!node || typeof node !== 'object') return;
-
-    if (node.type === 'VariableDeclaration') {
-      for (const decl of node.declarations || []) {
-        if (
-          decl.type === 'VariableDeclarator' &&
-          decl.id?.type === 'Identifier' &&
-          decl.init
-        ) {
-          const name = decl.id.name;
-          const initSource = getNodeSource(decl.init, source);
-
-          // Only track variables initialized from spec access, literals, or
-          // simple expressions (not factory calls like cluster(...))
-          if (
-            initSource.startsWith('spec.') ||
-            initSource.match(/^['"\d]/)
-          ) {
-            scope[name] = initSource;
-          }
-        }
-      }
-    }
-
-    // Recurse into child nodes
-    for (const key of Object.keys(node)) {
-      if (key === 'type' || key === 'range' || key === 'loc' || key === 'start' || key === 'end') continue;
-      const child = node[key];
-      if (Array.isArray(child)) {
-        for (const item of child) visit(item);
-      } else if (child && typeof child === 'object' && child.type) {
-        visit(child);
-      }
-    }
-  }
-
-  visit(ast);
-  return scope;
-}
-
-/**
- * Replace local variable names in an expression string with their
- * initializer expressions from the variable scope.
- *
- * Only replaces standalone identifiers (word boundaries), not property
- * accesses like `appDeployment.status.*` (which are resource references).
- */
-export function inlineVariables(expression: string, scope: Record<string, string>): string {
-  let result = expression;
-  for (const [name, value] of Object.entries(scope)) {
-    // Replace standalone identifier (not followed by `.` which indicates property access)
-    // and not preceded by `.` (which would be a property of another object)
-    const pattern = new RegExp(`(?<!\\.)\\b${name}\\b(?!\\s*\\.)`, 'g');
-    result = result.replace(pattern, value);
-  }
   return result;
 }

--- a/src/core/expressions/factory/status-builder-analyzer.ts
+++ b/src/core/expressions/factory/status-builder-analyzer.ts
@@ -18,6 +18,7 @@ import { getComponentLogger } from '../../logging/index.js';
 import type { CelExpression, KubernetesRef } from '../../types/common.js';
 import type { Enhanced } from '../../types/kubernetes.js';
 import type { SchemaProxy } from '../../types/serialization.js';
+import { buildLexicalAliasScope } from '../analysis/alias-inliner.js';
 import { JavaScriptToCelAnalyzer } from '../analysis/analyzer.js';
 import type { SourceMapEntry } from '../analysis/source-map.js';
 import {
@@ -118,6 +119,7 @@ export class StatusBuilderAnalyzer {
 
       // Analyze the return statement (delegates to status-ast-utils)
       const returnStatement = analyzeReturnStatementFn(ast, originalSource);
+      const aliasScope = buildLexicalAliasScope(ast, originalSource);
 
       if (!returnStatement || !returnStatement.returnsObject) {
         throw new ConversionError(
@@ -146,7 +148,8 @@ export class StatusBuilderAnalyzer {
             this.expressionAnalyzer,
             this.optionalityHandler,
             this.options,
-            schemaProxy
+            schemaProxy,
+            aliasScope
           );
 
           fieldAnalysis.set(property.name, fieldResult);

--- a/src/core/expressions/factory/status-field-analysis.ts
+++ b/src/core/expressions/factory/status-field-analysis.ts
@@ -13,6 +13,7 @@ import { getComponentLogger } from '../../logging/index.js';
 import type { CelExpression, KubernetesRef } from '../../types/common.js';
 import type { Enhanced } from '../../types/kubernetes.js';
 import type { SchemaProxy } from '../../types/serialization.js';
+import { inlineLexicalAliases, type LexicalAliasScope } from '../analysis/alias-inliner.js';
 import type {
   AnalysisContext,
   CelConversionResult,
@@ -130,10 +131,11 @@ export function analyzeStatusField(
   expressionAnalyzer: JavaScriptToCelAnalyzer,
   optionalityHandler: EnhancedTypeOptionalityHandler,
   options: Required<StatusBuilderAnalysisOptions>,
-  schemaProxy?: SchemaProxy<Record<string, unknown>, Record<string, unknown>>
+  schemaProxy?: SchemaProxy<Record<string, unknown>, Record<string, unknown>>,
+  aliasScope: LexicalAliasScope = {}
 ): StatusFieldAnalysisResult {
   const fieldName = property.name;
-  const originalExpression = property.valueSource;
+  const originalExpression = inlineLexicalAliases(property.valueSource, aliasScope);
 
   try {
     // Detect ||/&& operators that may produce unexpected results with KubernetesRef proxies

--- a/src/core/references/computed.ts
+++ b/src/core/references/computed.ts
@@ -1,0 +1,183 @@
+import * as acorn from 'acorn';
+import * as estraverse from 'estraverse';
+import type {
+  ArrowFunctionExpression,
+  BlockStatement,
+  Node as ESTreeNode,
+  Expression,
+  FunctionExpression,
+  Program,
+  ReturnStatement,
+} from 'estree';
+import { CEL_EXPRESSION_BRAND } from '../constants/brands.js';
+import { ensureError, TypeKroError } from '../errors.js';
+import { JavaScriptToCelAnalyzer } from '../expressions/analysis/analyzer.js';
+import { getNodeSource } from '../expressions/factory/status-ast-utils.js';
+import type { CelExpression } from '../types/common.js';
+import type { Enhanced } from '../types/kubernetes.js';
+
+export type ComputedExpression<T = unknown> = CelExpression<T> & T;
+
+type ComputedResourceMap = Record<string, Enhanced<unknown, unknown>>;
+
+/**
+ * Define a reusable TypeKro status value from a native JavaScript expression.
+ *
+ * `computed(...)` is intended for framework and library authors that want to
+ * expose ergonomic aliases such as `web.ready`, while still letting TypeKro
+ * analyze the underlying JavaScript expression and serialize it to CEL.
+ *
+ * The callback is parsed, not executed. Use the provided resource map inside the
+ * callback, either via destructuring or a named parameter.
+ *
+ * @example
+ * ```ts
+ * const ready = computed({ web }, ({ web }) =>
+ *   web.status.availableReplicas >= web.spec.replicas
+ * );
+ * return { ready };
+ * ```
+ */
+export function computed<T, TResources extends ComputedResourceMap>(
+  resources: TResources,
+  expression: (resources: TResources) => T
+): ComputedExpression<T> {
+  const source = expression.toString();
+  const { expressionSource, resourceParameterName } = extractComputedExpressionSource(source);
+  const normalizedExpression = normalizeComputedResourceParameter(
+    expressionSource,
+    resourceParameterName
+  );
+  const analyzer = new JavaScriptToCelAnalyzer();
+  const result = analyzer.analyzeExpression(normalizedExpression, {
+    type: 'status',
+    availableReferences: resources,
+    factoryType: 'kro',
+    dependencies: [],
+  });
+
+  if (!result.valid || !result.celExpression) {
+    throw new TypeKroError(
+      `computed() could not convert the supplied JavaScript expression to CEL: ${result.errors.map((error) => error.message).join('; ') || 'unknown conversion error'}`,
+      'COMPUTED_EXPRESSION_INVALID',
+      { expression: normalizedExpression }
+    );
+  }
+
+  return {
+    [CEL_EXPRESSION_BRAND]: true,
+    expression: result.celExpression.expression,
+  } as ComputedExpression<T>;
+}
+
+function extractComputedExpressionSource(source: string): {
+  readonly expressionSource: string;
+  readonly resourceParameterName?: string;
+} {
+  const wrappedSource = `(${source})`;
+  let ast: Program;
+  try {
+    ast = acorn.parse(wrappedSource, {
+      ecmaVersion: 2022,
+      sourceType: 'script',
+      ranges: true,
+      locations: true,
+    }) as unknown as Program;
+  } catch (error: unknown) {
+    throw new TypeKroError(
+      `computed() could not parse the supplied function: ${ensureError(error).message}`,
+      'COMPUTED_EXPRESSION_PARSE_FAILED',
+      { source }
+    );
+  }
+
+  const functionNode = firstComputedFunctionNode(ast);
+  if (!functionNode) {
+    throw new TypeKroError(
+      'computed() requires an arrow function or function expression.',
+      'COMPUTED_EXPRESSION_INVALID_FUNCTION',
+      { source }
+    );
+  }
+
+  const bodyExpression = computedFunctionBodyExpression(functionNode);
+  if (!bodyExpression) {
+    throw new TypeKroError(
+      'computed() requires an expression body or a block body with a return expression.',
+      'COMPUTED_EXPRESSION_MISSING_RETURN',
+      { source }
+    );
+  }
+
+  const resourceParameterName = computedResourceParameterName(functionNode);
+  return resourceParameterName
+    ? {
+        expressionSource: getNodeSource(bodyExpression, wrappedSource),
+        resourceParameterName,
+      }
+    : { expressionSource: getNodeSource(bodyExpression, wrappedSource) };
+}
+
+function firstComputedFunctionNode(
+  ast: Program
+): ArrowFunctionExpression | FunctionExpression | undefined {
+  const expression =
+    ast.body[0]?.type === 'ExpressionStatement' ? ast.body[0].expression : undefined;
+  if (expression?.type === 'ArrowFunctionExpression' || expression?.type === 'FunctionExpression') {
+    return expression;
+  }
+  return undefined;
+}
+
+function computedFunctionBodyExpression(
+  functionNode: ArrowFunctionExpression | FunctionExpression
+): Expression | undefined {
+  if (
+    functionNode.type === 'ArrowFunctionExpression' &&
+    functionNode.body.type !== 'BlockStatement'
+  ) {
+    return functionNode.body;
+  }
+  if (functionNode.body.type !== 'BlockStatement') {
+    return undefined;
+  }
+  return firstReturnExpression(functionNode.body);
+}
+
+function firstReturnExpression(body: BlockStatement): Expression | undefined {
+  let found: Expression | undefined;
+  estraverse.traverse(body as unknown as ESTreeNode, {
+    enter: (node) => {
+      if (node.type === 'ReturnStatement') {
+        found = (node as ReturnStatement).argument ?? undefined;
+        return estraverse.VisitorOption.Break;
+      }
+      return undefined;
+    },
+  });
+  return found;
+}
+
+function computedResourceParameterName(
+  functionNode: ArrowFunctionExpression | FunctionExpression
+): string | undefined {
+  const [parameter] = functionNode.params;
+  return parameter?.type === 'Identifier' ? parameter.name : undefined;
+}
+
+function normalizeComputedResourceParameter(
+  expressionSource: string,
+  resourceParameterName?: string
+): string {
+  if (!resourceParameterName || resourceParameterName === 'resources') {
+    return expressionSource;
+  }
+  return expressionSource.replace(
+    new RegExp(`\\b${escapeRegExp(resourceParameterName)}\\.`, 'g'),
+    'resources.'
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/core/references/computed.ts
+++ b/src/core/references/computed.ts
@@ -16,6 +16,59 @@ import type { Enhanced } from '../types/kubernetes.js';
 export type ComputedExpression<T = unknown> = CelExpression<T> & T;
 
 type ComputedResourceMap = Record<string, Enhanced<unknown, unknown>>;
+type AliasDefinitionMap<TInput> = Record<string, (input: TInput) => unknown>;
+type AliasResult<TAliases extends Record<string, (...args: never[]) => unknown>> = {
+  readonly [K in keyof TAliases]: ComputedExpression<ReturnType<TAliases[K]>>;
+};
+
+/**
+ * Define reusable status aliases for a single TypeKro resource.
+ *
+ * @example
+ * ```ts
+ * const web = alias(deployment, {
+ *   ready: (d) => d.status.readyReplicas >= d.spec.replicas,
+ *   available: (d) => d.status.availableReplicas,
+ * });
+ * return { ready: web.ready };
+ * ```
+ */
+export function alias<
+  TResource extends Enhanced<unknown, unknown>,
+  TAliases extends AliasDefinitionMap<TResource>,
+>(resource: TResource, aliasDefinitions: TAliases): AliasResult<TAliases> {
+  return Object.fromEntries(
+    Object.entries(aliasDefinitions).map(([name, expression]) => [
+      name,
+      computedFromSource({ resource }, expression.toString(), 'resources.resource'),
+    ])
+  ) as AliasResult<TAliases>;
+}
+
+/**
+ * Define reusable status aliases over multiple TypeKro resources.
+ *
+ * @example
+ * ```ts
+ * const app = aliases({ deployment, service }, {
+ *   ready: ({ deployment, service }) =>
+ *     deployment.status.readyReplicas >= deployment.spec.replicas &&
+ *     service.status.loadBalancer.ingress.length > 0,
+ * });
+ * return { ready: app.ready };
+ * ```
+ */
+export function aliases<
+  TResources extends ComputedResourceMap,
+  TAliases extends AliasDefinitionMap<TResources>,
+>(resources: TResources, aliasDefinitions: TAliases): AliasResult<TAliases> {
+  return Object.fromEntries(
+    Object.entries(aliasDefinitions).map(([name, expression]) => [
+      name,
+      computed(resources, expression),
+    ])
+  ) as AliasResult<TAliases>;
+}
 
 /**
  * Define a reusable TypeKro status value from a native JavaScript expression.
@@ -39,11 +92,21 @@ export function computed<T, TResources extends ComputedResourceMap>(
   resources: TResources,
   expression: (resources: TResources) => T
 ): ComputedExpression<T> {
-  const source = expression.toString();
-  const { expressionSource, resourceParameterName } = extractComputedExpressionSource(source);
+  return computedFromSource(resources, expression.toString(), 'resources');
+}
+
+function computedFromSource<T, TResources extends ComputedResourceMap>(
+  resources: TResources,
+  source: string,
+  parameterPath: string
+): ComputedExpression<T> {
+  const { expressionSource, resourceParameterBindings } = extractComputedExpressionSource(
+    source,
+    parameterPath
+  );
   const normalizedExpression = normalizeComputedResourceParameter(
     expressionSource,
-    resourceParameterName
+    resourceParameterBindings
   );
   const analyzer = new JavaScriptToCelAnalyzer();
   const result = analyzer.analyzeExpression(normalizedExpression, {
@@ -63,13 +126,16 @@ export function computed<T, TResources extends ComputedResourceMap>(
 
   return {
     [CEL_EXPRESSION_BRAND]: true,
-    expression: result.celExpression.expression,
+    expression: normalizeCelResourceAliases(result.celExpression.expression, resources),
   } as ComputedExpression<T>;
 }
 
-function extractComputedExpressionSource(source: string): {
+function extractComputedExpressionSource(
+  source: string,
+  parameterPath: string
+): {
   readonly expressionSource: string;
-  readonly resourceParameterName?: string;
+  readonly resourceParameterBindings?: Record<string, string>;
 } {
   const wrappedSource = `(${source})`;
   let ast: Program;
@@ -106,11 +172,11 @@ function extractComputedExpressionSource(source: string): {
     );
   }
 
-  const resourceParameterName = computedResourceParameterName(functionNode);
-  return resourceParameterName
+  const resourceParameterBindings = computedResourceParameterBindings(functionNode, parameterPath);
+  return resourceParameterBindings
     ? {
         expressionSource: getNodeSource(bodyExpression, wrappedSource),
-        resourceParameterName,
+        resourceParameterBindings,
       }
     : { expressionSource: getNodeSource(bodyExpression, wrappedSource) };
 }
@@ -146,26 +212,80 @@ function topLevelReturnExpression(body: BlockStatement): Expression | undefined 
   return statement?.type === 'ReturnStatement' ? (statement.argument ?? undefined) : undefined;
 }
 
-function computedResourceParameterName(
-  functionNode: ArrowFunctionExpression | FunctionExpression
-): string | undefined {
+function computedResourceParameterBindings(
+  functionNode: ArrowFunctionExpression | FunctionExpression,
+  parameterPath: string
+): Record<string, string> | undefined {
   const [parameter] = functionNode.params;
-  return parameter?.type === 'Identifier' ? parameter.name : undefined;
+  if (!parameter) {
+    return undefined;
+  }
+  if (parameter.type === 'Identifier') {
+    return { [parameter.name]: parameterPath };
+  }
+  if (parameter.type !== 'ObjectPattern') {
+    return undefined;
+  }
+
+  const bindings: Record<string, string> = {};
+  for (const property of parameter.properties) {
+    if (property.type !== 'Property' || property.key.type !== 'Identifier') {
+      continue;
+    }
+    const resourceName = property.key.name;
+    if (property.value.type === 'Identifier') {
+      bindings[property.value.name] = `${parameterPath}.${resourceName}`;
+    } else if (
+      property.value.type === 'AssignmentPattern' &&
+      property.value.left.type === 'Identifier'
+    ) {
+      bindings[property.value.left.name] = `${parameterPath}.${resourceName}`;
+    }
+  }
+
+  return Object.keys(bindings).length > 0 ? bindings : undefined;
 }
 
 function normalizeComputedResourceParameter(
   expressionSource: string,
-  resourceParameterName?: string
+  resourceParameterBindings?: Record<string, string>
 ): string {
-  if (!resourceParameterName || resourceParameterName === 'resources') {
+  if (!resourceParameterBindings) {
     return expressionSource;
   }
-  return expressionSource.replace(
-    new RegExp(`\\b${escapeRegExp(resourceParameterName)}\\.`, 'g'),
-    'resources.'
-  );
+  let normalizedExpression = expressionSource;
+  for (const [localName, replacementPath] of Object.entries(resourceParameterBindings)) {
+    if (localName === replacementPath) {
+      continue;
+    }
+    normalizedExpression = normalizedExpression.replace(
+      new RegExp(`\\b${escapeRegExp(localName)}\\.`, 'g'),
+      `${replacementPath}.`
+    );
+  }
+  return normalizedExpression;
 }
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function normalizeCelResourceAliases(expression: string, resources: ComputedResourceMap): string {
+  let normalizedExpression = expression.replace(/\bresources\./g, '');
+  for (const [localName, resource] of Object.entries(resources)) {
+    const resourceId = resourceIdOf(resource);
+    if (!resourceId || resourceId === localName) {
+      continue;
+    }
+    normalizedExpression = normalizedExpression.replace(
+      new RegExp(`\\b${escapeRegExp(localName)}\\.`, 'g'),
+      `${resourceId}.`
+    );
+  }
+  return normalizedExpression;
+}
+
+function resourceIdOf(resource: Enhanced<unknown, unknown>): string | undefined {
+  const candidate = (resource as { readonly id?: unknown }).id;
+  return typeof candidate === 'string' ? candidate : undefined;
 }

--- a/src/core/references/computed.ts
+++ b/src/core/references/computed.ts
@@ -1,13 +1,10 @@
 import * as acorn from 'acorn';
-import * as estraverse from 'estraverse';
 import type {
   ArrowFunctionExpression,
   BlockStatement,
-  Node as ESTreeNode,
   Expression,
   FunctionExpression,
   Program,
-  ReturnStatement,
 } from 'estree';
 import { CEL_EXPRESSION_BRAND } from '../constants/brands.js';
 import { ensureError, TypeKroError } from '../errors.js';
@@ -103,7 +100,7 @@ function extractComputedExpressionSource(source: string): {
   const bodyExpression = computedFunctionBodyExpression(functionNode);
   if (!bodyExpression) {
     throw new TypeKroError(
-      'computed() requires an expression body or a block body with a return expression.',
+      'computed() requires an expression body or a block body with a direct top-level return expression.',
       'COMPUTED_EXPRESSION_MISSING_RETURN',
       { source }
     );
@@ -141,21 +138,12 @@ function computedFunctionBodyExpression(
   if (functionNode.body.type !== 'BlockStatement') {
     return undefined;
   }
-  return firstReturnExpression(functionNode.body);
+  return topLevelReturnExpression(functionNode.body);
 }
 
-function firstReturnExpression(body: BlockStatement): Expression | undefined {
-  let found: Expression | undefined;
-  estraverse.traverse(body as unknown as ESTreeNode, {
-    enter: (node) => {
-      if (node.type === 'ReturnStatement') {
-        found = (node as ReturnStatement).argument ?? undefined;
-        return estraverse.VisitorOption.Break;
-      }
-      return undefined;
-    },
-  });
-  return found;
+function topLevelReturnExpression(body: BlockStatement): Expression | undefined {
+  const statement = body.body.find((node) => node.type === 'ReturnStatement');
+  return statement?.type === 'ReturnStatement' ? (statement.argument ?? undefined) : undefined;
 }
 
 function computedResourceParameterName(

--- a/src/core/references/index.ts
+++ b/src/core/references/index.ts
@@ -14,8 +14,13 @@ export { CelEvaluationError } from '../types/references.js';
 export * from './cel.js';
 // CEL evaluation
 export { CelEvaluator } from './cel-evaluator.js';
+export * from './computed.js';
 // External references
-export { createExternalRefWithoutRegistration, externalRef, observedResource } from './external-refs.js';
+export {
+  createExternalRefWithoutRegistration,
+  externalRef,
+  observedResource,
+} from './external-refs.js';
 // Reference resolution (DeploymentMode is both a const object and a type via TS namespacing)
 export { DeploymentMode, ReferenceResolver } from './resolver.js';
 // Schema proxy

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,15 @@
 // 1. ESSENTIAL — Core APIs every user needs
 // =============================================================================
 
+export type {
+  AnnotationMap,
+  EnvVarMap,
+  HotReloadAspectOptions,
+  HotReloadContainer,
+  HotReloadVolume,
+  LabelMap,
+  LocalWorkspaceAspectOptions,
+} from './core/aspects/index.js';
 // Aspect helpers for typed resource customization
 export {
   AspectApplicationError,
@@ -118,15 +127,6 @@ export {
   withResourceDefaults,
   withServiceAccount,
   workloads,
-} from './core/aspects/index.js';
-export type {
-  AnnotationMap,
-  EnvVarMap,
-  HotReloadAspectOptions,
-  HotReloadContainer,
-  HotReloadVolume,
-  LabelMap,
-  LocalWorkspaceAspectOptions,
 } from './core/aspects/index.js';
 export type {
   AppendOperation,
@@ -164,8 +164,8 @@ export type {
   CompatibleAspectTargets,
   FactoryAspectTargetDescriptor,
   ImagePullPolicy,
-  MergeOperation,
   MergeByNameOperation,
+  MergeOperation,
   MetadataAspectSurface,
   OverrideAspectSurface,
   PatchEachOperation,
@@ -174,15 +174,15 @@ export type {
   ResourceAspectMetadata,
   ResourceSpecOverrideSchema,
   ToYamlOptions,
-  WorkloadPodTemplateAspectSchema,
   WorkloadAspectFactoryTarget,
+  WorkloadPodTemplateAspectSchema,
 } from './core/aspects/types.js';
 // Imperative composition (define compositions with native TypeScript)
 export { kubernetesComposition } from './core/composition/imperative.js';
 // Resource factory (used inside resource builders)
 export { createResource } from './core/proxy/create-resource.js';
 // CEL expression helpers (used in status builders)
-export { Cel, cel, externalRef, observedResource } from './core/references/index.js';
+export { Cel, cel, computed, externalRef, observedResource } from './core/references/index.js';
 export type {
   ResourceBuilder,
   ResourceDependency,

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,15 @@ export { kubernetesComposition } from './core/composition/imperative.js';
 // Resource factory (used inside resource builders)
 export { createResource } from './core/proxy/create-resource.js';
 // CEL expression helpers (used in status builders)
-export { Cel, cel, computed, externalRef, observedResource } from './core/references/index.js';
+export {
+  alias,
+  aliases,
+  Cel,
+  cel,
+  computed,
+  externalRef,
+  observedResource,
+} from './core/references/index.js';
 export type {
   ResourceBuilder,
   ResourceDependency,

--- a/test/core/expressions/analyzer-converter-methods.test.ts
+++ b/test/core/expressions/analyzer-converter-methods.test.ts
@@ -447,13 +447,9 @@ describe('Analyzer Converter Methods — Safety Net', () => {
       expect(result).toContain('db.status.replicas');
     });
 
-    it('should handle && converted to null-check pattern', () => {
-      // The analyzer converts && to a null-check ternary pattern:
-      // a && b → a != null ? b : a
+    it('should handle && as direct CEL conjunction', () => {
       const result = cel('deployment.status.replicas > 0 && service.status.ready');
-      expect(result).toContain('deployment.status.replicas > 0');
-      expect(result).toContain('!= null');
-      expect(result).toContain('service.status.ready');
+      expect(result).toBe('deployment.status.replicas > 0 && service.status.ready');
     });
 
     it('should handle nested ternary with correct grouping', () => {

--- a/test/core/expressions/analyzer-converter-methods.test.ts
+++ b/test/core/expressions/analyzer-converter-methods.test.ts
@@ -452,6 +452,13 @@ describe('Analyzer Converter Methods — Safety Net', () => {
       expect(result).toBe('deployment.status.replicas > 0 && service.status.ready');
     });
 
+    it('should preserve && guard/value semantics for non-boolean resource fields', () => {
+      const result = cel('svc.status.loadBalancer && svc.status.loadBalancer.ingress[0].ip');
+      expect(result).toBe(
+        'resources.svc.status.loadBalancer != null ? resources.svc.status.loadBalancer.ingress[0].ip : resources.svc.status.loadBalancer'
+      );
+    });
+
     it('should handle nested ternary with correct grouping', () => {
       const result = cel('deployment.status.replicas > 0 ? "ready" : "pending"');
       expect(result).toContain('deployment.status.replicas > 0');
@@ -459,9 +466,8 @@ describe('Analyzer Converter Methods — Safety Net', () => {
       expect(result).toContain('"pending"');
     });
 
-    it('should handle || and && converted to nested null-check patterns', () => {
+    it('should handle || fallback around boolean && expressions', () => {
       // || is converted to: a != null ? a : b
-      // && is converted to: a != null ? b : a
       const result = cel('deployment.status.ready || service.status.ready && db.status.ready');
       expect(result).toContain('!= null');
       expect(result).toContain('deployment.status.ready');
@@ -476,8 +482,7 @@ describe('Analyzer Converter Methods — Safety Net', () => {
       expect(result).toContain('"pending"');
     });
 
-    it('should handle chained || and && as nested null-checks', () => {
-      // Both || and && become null-check ternary patterns
+    it('should handle chained || and boolean && expressions', () => {
       const result = cel('deployment.status.ready || service.status.ready && db.status.ready');
       expect(result).toContain('!= null');
       expect(result).toContain('deployment.status.ready');

--- a/test/core/expressions/cel-output-equivalence.test.ts
+++ b/test/core/expressions/cel-output-equivalence.test.ts
@@ -13,14 +13,13 @@
  * output before migration.
  */
 
-import { describe, expect, it, beforeEach } from 'bun:test';
+import { beforeEach, describe, expect, it } from 'bun:test';
 import fc from 'fast-check';
-
-import {
-  JavaScriptToCelAnalyzer,
-  type AnalysisContext,
-} from '../../../src/core/expressions/analysis/analyzer.js';
 import { KUBERNETES_REF_BRAND } from '../../../src/core/constants/brands.js';
+import {
+  type AnalysisContext,
+  JavaScriptToCelAnalyzer,
+} from '../../../src/core/expressions/analysis/analyzer.js';
 import type { KubernetesRef } from '../../../src/core/types/common.js';
 
 describe('Property-Based Tests: CEL Output Equivalence', () => {
@@ -51,12 +50,51 @@ describe('Property-Based Tests: CEL Output Equivalence', () => {
    */
   const identifierArb = fc.stringMatching(/^[a-zA-Z_][a-zA-Z0-9_]*$/).filter((s) => {
     const reserved = [
-      'break', 'case', 'catch', 'continue', 'debugger', 'default', 'delete',
-      'do', 'else', 'finally', 'for', 'function', 'if', 'in', 'instanceof',
-      'new', 'return', 'switch', 'this', 'throw', 'try', 'typeof', 'var',
-      'void', 'while', 'with', 'class', 'const', 'enum', 'export', 'extends',
-      'import', 'super', 'implements', 'interface', 'let', 'package', 'private',
-      'protected', 'public', 'static', 'yield', 'null', 'true', 'false',
+      'break',
+      'case',
+      'catch',
+      'continue',
+      'debugger',
+      'default',
+      'delete',
+      'do',
+      'else',
+      'finally',
+      'for',
+      'function',
+      'if',
+      'in',
+      'instanceof',
+      'new',
+      'return',
+      'switch',
+      'this',
+      'throw',
+      'try',
+      'typeof',
+      'var',
+      'void',
+      'while',
+      'with',
+      'class',
+      'const',
+      'enum',
+      'export',
+      'extends',
+      'import',
+      'super',
+      'implements',
+      'interface',
+      'let',
+      'package',
+      'private',
+      'protected',
+      'public',
+      'static',
+      'yield',
+      'null',
+      'true',
+      'false',
     ];
     return s.length > 0 && s.length <= 15 && !reserved.includes(s);
   });
@@ -339,9 +377,7 @@ describe('Deterministic Tests: CEL Output Equivalence', () => {
   it('should convert logical AND to CEL', () => {
     const result = analyzer.analyzeStringExpression('ready && available', mockContext);
     expect(result.valid).toBe(true);
-    // Logical AND is converted to a truthy check in CEL for Kro compatibility
-    expect(result.celExpression?.expression).toContain('?');
-    expect(result.celExpression?.expression).toContain('available');
+    expect(result.celExpression?.expression).toBe('ready && available');
   });
 
   it('should convert logical OR to CEL', () => {

--- a/test/core/expressions/error-scenarios.test.ts
+++ b/test/core/expressions/error-scenarios.test.ts
@@ -433,8 +433,8 @@ describe('Error Scenarios and Source Mapping', () => {
       expect(result.celExpression).toBeDefined();
       expect(sourceEntry?.celExpression).toBeDefined();
 
-      // Should be able to compare both
-      expect(sourceEntry?.originalExpression).not.toBe(sourceEntry?.celExpression);
+      // Direct CEL-compatible expressions may serialize identically.
+      expect(sourceEntry?.celExpression).toBe(expression);
     });
 
     it('should provide performance debugging information', () => {

--- a/test/core/imperative-analyzer-characterization.test.ts
+++ b/test/core/imperative-analyzer-characterization.test.ts
@@ -131,7 +131,7 @@ describe('analyzeImperativeComposition', () => {
       expect(result.hasJavaScriptExpressions).toBe(true);
       expect(isCelExpr(result.statusMappings.phase)).toBe(true);
       expect((result.statusMappings.phase as CelExpression).expression).toContain(
-        'resources.helm.status.phase'
+        'helm.status.phase'
       );
     });
 
@@ -148,7 +148,7 @@ describe('analyzeImperativeComposition', () => {
 
       expect(isCelExpr(result.statusMappings.name)).toBe(true);
       expect((result.statusMappings.name as CelExpression).expression).toContain(
-        'resources.deployment.metadata.name'
+        'deployment.metadata.name'
       );
     });
 
@@ -165,7 +165,7 @@ describe('analyzeImperativeComposition', () => {
 
       expect(isCelExpr(result.statusMappings.replicas)).toBe(true);
       expect((result.statusMappings.replicas as CelExpression).expression).toContain(
-        'resources.deployment.spec.replicas'
+        'deployment.spec.replicas'
       );
     });
   });
@@ -230,6 +230,19 @@ describe('analyzeImperativeComposition', () => {
       const result = analyzeImperativeComposition(fn, {}, { factoryType: 'kro' });
 
       expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.statusMappings).toEqual({});
+      expect(result.hasJavaScriptExpressions).toBe(false);
+    });
+
+    it('fails closed for cyclic lexical aliases', () => {
+      const fn = new Function(
+        'const ready = available; const available = ready; return { ready };'
+      ) as (...args: unknown[]) => unknown;
+
+      const result = analyzeImperativeComposition(fn, {}, { factoryType: 'kro' });
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain('Could not fully inline lexical aliases');
       expect(result.statusMappings).toEqual({});
       expect(result.hasJavaScriptExpressions).toBe(false);
     });

--- a/test/unit/computed-status-alias.test.ts
+++ b/test/unit/computed-status-alias.test.ts
@@ -1,8 +1,312 @@
 import { describe, expect, it } from 'bun:test';
+import { Parser } from 'acorn';
 import { type } from 'arktype';
-import { computed, kubernetesComposition, simple } from '../../src/index.js';
+import {
+  buildLexicalAliasScope,
+  inlineLexicalAliases,
+} from '../../src/core/expressions/analysis/alias-inliner.js';
+import { alias, aliases, computed, kubernetesComposition, simple } from '../../src/index.js';
 
 describe('computed status aliases', () => {
+  it('inlines const identifier aliases returned from composition status', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'const-identifier-alias-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'ConstIdentifierAliasApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean', available: 'number' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const ready = deployment.status.readyReplicas >= deployment.spec.replicas;
+        const available = deployment.status.availableReplicas;
+
+        return { ready, available };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.readyReplicas >= web.spec.replicas}');
+    expect(yaml).toContain('available: ${web.status.availableReplicas}');
+  });
+
+  it('inlines object property aliases returned from composition status', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'object-property-alias-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'ObjectPropertyAliasApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean', available: 'number' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const web = {
+          ready: deployment.status.readyReplicas >= deployment.spec.replicas,
+          stats: {
+            available: deployment.status.availableReplicas,
+          },
+        };
+
+        return { ready: web.ready, available: web.stats.available };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.readyReplicas >= web.spec.replicas}');
+    expect(yaml).toContain('available: ${web.status.availableReplicas}');
+  });
+
+  it('inlines aliases that reference earlier aliases', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'chained-alias-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'ChainedAliasApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const available = deployment.status.availableReplicas;
+        const desired = deployment.spec.replicas;
+        const ready = available >= desired;
+
+        return { ready };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.availableReplicas >= web.spec.replicas}');
+  });
+
+  it('inlines aliases inside returned expressions', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'nested-return-alias-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'NestedReturnAliasApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const available = deployment.status.availableReplicas;
+
+        return { ready: available >= deployment.spec.replicas };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.availableReplicas >= web.spec.replicas}');
+  });
+
+  it('inlines explicit alias objects through the same status path', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'explicit-alias-inline-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'ExplicitAliasInlineApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean', available: 'number' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const web = alias(deployment, {
+          ready: (d) => d.status.readyReplicas >= d.spec.replicas,
+          available: (d) => d.status.availableReplicas,
+        });
+
+        return { ready: web.ready, available: web.available };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.readyReplicas >= web.spec.replicas}');
+    expect(yaml).toContain('available: ${web.status.availableReplicas}');
+  });
+
+  it('inlines explicit multi-resource aliases through the same status path', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'explicit-multi-alias-inline-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'ExplicitMultiAliasInlineApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const service = simple.Service({
+          id: 'webService',
+          name: 'web',
+          selector: { app: 'web' },
+          ports: [{ port: 80 }],
+        });
+        const app = aliases(
+          { deployment, service },
+          {
+            ready: ({ deployment, service }) =>
+              deployment.status.readyReplicas >= deployment.spec.replicas &&
+              service.status.loadBalancer.ingress!.length > 0,
+          }
+        );
+
+        return { ready: app.ready };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain(
+      'ready: ${web.status.readyReplicas >= web.spec.replicas && webService.status.loadBalancer.ingress.length > 0}'
+    );
+  });
+
+  it('does not inline aliases from nested function scopes', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'nested-scope-alias-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'NestedScopeAliasApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const ready = false;
+        function nested() {
+          const ready = deployment.status.readyReplicas >= deployment.spec.replicas;
+          return ready;
+        }
+        void nested;
+
+        return { ready };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).not.toContain('ready: ${web.status.readyReplicas >= web.spec.replicas}');
+  });
+
+  it('fails closed for cyclic lexical aliases', () => {
+    const source = `() => {
+      const ready = available;
+      const available = ready;
+      return { ready };
+    }`;
+    const ast = Parser.parse(source, { ecmaVersion: 2022, ranges: true });
+    const aliases = buildLexicalAliasScope(ast, source);
+
+    expect(() => inlineLexicalAliases('ready', aliases)).toThrow(/Could not fully inline/);
+  });
+
+  it('serializes single-resource aliases returned from composition status', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'single-resource-alias-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'SingleResourceAliasApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean', available: 'number' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const web = alias(deployment, {
+          ready: (d) => d.status.readyReplicas >= d.spec.replicas,
+          available: (d) => d.status.availableReplicas,
+        });
+
+        return { ready: web.ready, available: web.available };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.readyReplicas >= web.spec.replicas}');
+    expect(yaml).toContain('available: ${web.status.availableReplicas}');
+  });
+
+  it('serializes multi-resource aliases returned from composition status', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'multi-resource-alias-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'MultiResourceAliasApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const service = simple.Service({
+          id: 'webService',
+          name: 'web',
+          selector: { app: 'web' },
+          ports: [{ port: 80 }],
+        });
+        const app = aliases(
+          { deployment, service },
+          {
+            ready: ({ deployment, service }) =>
+              deployment.status.readyReplicas >= deployment.spec.replicas &&
+              service.status.loadBalancer.ingress!.length > 0,
+          }
+        );
+
+        return { ready: app.ready };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain(
+      'ready: ${web.status.readyReplicas >= web.spec.replicas && webService.status.loadBalancer.ingress.length > 0}'
+    );
+  });
+
   it('serializes a computed alias returned from composition status', () => {
     const composition = kubernetesComposition(
       {

--- a/test/unit/computed-status-alias.test.ts
+++ b/test/unit/computed-status-alias.test.ts
@@ -92,4 +92,55 @@ describe('computed status aliases', () => {
     const yaml = composition.toYaml();
     expect(yaml).toContain('ready: ${web.status.availableReplicas >= web.spec.replicas}');
   });
+
+  it('uses only the direct top-level return in block-body computed expressions', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'computed-top-level-return-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'ComputedTopLevelReturnApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const ready = computed({ deployment }, ({ deployment }) => {
+          function helper() {
+            return deployment.status.availableReplicas >= deployment.spec.replicas;
+          }
+          void helper;
+          return deployment.status.readyReplicas > 0;
+        });
+
+        return { ready };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.readyReplicas > 0}');
+    expect(yaml).not.toContain('ready: ${web.status.availableReplicas >= web.spec.replicas}');
+  });
+
+  it('rejects block-body computed expressions without a direct top-level return', () => {
+    const deployment = simple.Deployment({
+      id: 'web',
+      name: 'web',
+      image: 'nginx:latest',
+      replicas: 2,
+    });
+
+    const branchOnlyReturn = new Function(
+      'resources',
+      'const { deployment } = resources; if (deployment.status.readyReplicas > 0) { return true; }'
+    ) as (resources: { readonly deployment: typeof deployment }) => boolean;
+
+    expect(() => computed({ deployment }, branchOnlyReturn)).toThrow(
+      /direct top-level return expression/
+    );
+  });
 });

--- a/test/unit/computed-status-alias.test.ts
+++ b/test/unit/computed-status-alias.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test';
+import { type } from 'arktype';
+import { computed, kubernetesComposition, simple } from '../../src/index.js';
+
+describe('computed status aliases', () => {
+  it('serializes a computed alias returned from composition status', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'computed-alias-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'ComputedAliasApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const web = {
+          ready: computed(
+            { deployment },
+            ({ deployment }) => deployment.status.availableReplicas >= deployment.spec.replicas
+          ),
+        };
+
+        return { ready: web.ready };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.availableReplicas >= web.spec.replicas}');
+  });
+
+  it('supports a named resources parameter for computed expressions', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'computed-resources-param-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'ComputedResourcesParamApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const ready = computed(
+          { deployment },
+          (resources) =>
+            resources.deployment.status.availableReplicas >= resources.deployment.spec.replicas
+        );
+
+        return { ready };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.availableReplicas >= web.spec.replicas}');
+  });
+
+  it('supports arbitrary named resource map parameters for computed expressions', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'computed-param-alias-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'ComputedParamAliasApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const ready = computed(
+          { deployment },
+          (refs) => refs.deployment.status.availableReplicas >= refs.deployment.spec.replicas
+        );
+
+        return { ready };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.availableReplicas >= web.spec.replicas}');
+  });
+});

--- a/test/unit/computed-status-alias.test.ts
+++ b/test/unit/computed-status-alias.test.ts
@@ -236,6 +236,19 @@ describe('computed status aliases', () => {
     expect(() => inlineLexicalAliases('ready', aliases)).toThrow(/Could not fully inline/);
   });
 
+  it('fails closed for unsupported explicit alias expressions when referenced', () => {
+    const source = `() => {
+      const web = alias(deployment, { ready: true });
+      return { ready: web.ready };
+    }`;
+    const ast = Parser.parse(source, { ecmaVersion: 2022, ranges: true });
+    const aliases = buildLexicalAliasScope(ast, source);
+
+    expect(() => inlineLexicalAliases('web.ready', aliases)).toThrow(
+      /Unsupported lexical alias expression: web.ready/
+    );
+  });
+
   it('serializes single-resource aliases returned from composition status', () => {
     const composition = kubernetesComposition(
       {


### PR DESCRIPTION
## Summary
- Add source-level lexical status alias inlining for status builder functions.
- Add explicit `alias(...)` and `aliases(...)` helpers as convenience and escape hatches.
- Keep `computed(...)` as the lower-level primitive for computed status expressions.
- Preserve direct CEL conjunction output for JavaScript `&&` expressions.

## Behavior
- Supports top-level `const` aliases, nested object aliases, chained aliases, and aliases referenced inside returned expressions.
- Ignores aliases declared inside nested function scopes so helper closures do not leak into status analysis.
- Fails closed for cyclic aliases and malformed explicit alias shapes instead of emitting unsafe or partial CEL.
- Normalizes analyzer output for resource references, bare `spec.*` references, optional chaining, and nullish coalescing before CEL emission.

## User-facing result
This enables natural app/resource status code such as:

```ts
const web = app.server("web", { /* ... */ });

return {
  ready: web.ready,
};
```

without requiring user-facing type casts or explicit CEL strings.

## Validation
- `bun test test/unit/computed-status-alias.test.ts test/core/imperative-analyzer-characterization.test.ts --timeout 10000`
- `bunx biome check src/core/expressions/analysis/alias-inliner.ts test/unit/computed-status-alias.test.ts`
- `bun run typecheck`
- `git diff --check`
- `bun run test` (`4427 pass`, `0 fail`)