### PR TITLE
fix: serialize aliased conditional status fields

### DIFF
--- a/src/core/serialization/status-analysis-pipeline.ts
+++ b/src/core/serialization/status-analysis-pipeline.ts
@@ -21,6 +21,7 @@
  * @see ROADMAP.md Phase 2.9
  */
 
+import { KUBERNETES_REF_MARKER_SOURCE } from '../../shared/brands.js';
 import {
   containsCelExpressions,
   containsKubernetesRefs,
@@ -724,7 +725,8 @@ export function runStatusAnalysisPipeline<
       logger
     );
 
-    let { analyzedStatusMappings, imperativeAnalysisSucceeded, phaseBStatusMappings } = analysisResult.value;
+    let { analyzedStatusMappings, imperativeAnalysisSucceeded, phaseBStatusMappings } =
+      analysisResult.value;
 
     if (analysisResult.outcome === 'degraded') {
       logger.warn('Status analysis degraded', { reason: analysisResult.reason });
@@ -795,6 +797,26 @@ function isComparisonArtifact(value: unknown): boolean {
   return false;
 }
 
+function isCleanPhaseBCel(value: unknown): value is { expression: string } {
+  if (!value || !isCelExpression(value)) return false;
+
+  const expr = (value as { expression: string }).expression;
+  return !expr.includes('({') && !expr.includes('=>') && !expr.includes('new ');
+}
+
+function hasKubernetesRefMarker(value: string): boolean {
+  return new RegExp(KUBERNETES_REF_MARKER_SOURCE).test(value);
+}
+
+function isPrimitiveExecutionArtifact(value: unknown): boolean {
+  if (isComparisonArtifact(value)) return true;
+  if (value === null) return true;
+  if (typeof value === 'boolean') return true;
+  if (typeof value === 'number') return true;
+  if (typeof value === 'string') return !hasKubernetesRefMarker(value);
+  return false;
+}
+
 /**
  * Merge Phase A raw status mappings with Phase B fn.toString analysis results.
  *
@@ -847,22 +869,18 @@ function mergePhaseAAndPhaseB(
       continue;
     }
 
-    // Phase A has a comparison artifact → use Phase B's CEL expression,
+    // Phase A has a primitive execution artifact → use Phase B's CEL expression,
     // but only if Phase B produced clean CEL (not garbled fn.toString with
     // factory calls like `simple.Deployment({...}).status.readyReplicas`).
-    if (isComparisonArtifact(phaseAValue) && phaseBValue && isCelExpression(phaseBValue)) {
-      const expr = (phaseBValue as { expression: string }).expression;
-      const isGarbled = expr.includes('({') || expr.includes('=>') || expr.includes('new ');
-      if (!isGarbled) {
-        logger.debug('Replacing Phase A artifact with Phase B CEL', {
-          field: key,
-          phaseAValue,
-          phaseBExpression: expr.substring(0, 80),
-        });
-        merged[key] = phaseBValue;
-        continue;
-      }
-      // Garbled Phase B → keep Phase A's artifact (will be classified as static)
+    if (isPrimitiveExecutionArtifact(phaseAValue) && isCleanPhaseBCel(phaseBValue)) {
+      const expr = phaseBValue.expression;
+      logger.debug('Replacing Phase A artifact with Phase B CEL', {
+        field: key,
+        phaseAValue,
+        phaseBExpression: expr.substring(0, 80),
+      });
+      merged[key] = phaseBValue;
+      continue;
     }
 
     // Phase A value is already correct

--- a/src/core/serialization/status-analysis-pipeline.ts
+++ b/src/core/serialization/status-analysis-pipeline.ts
@@ -801,7 +801,36 @@ function isCleanPhaseBCel(value: unknown): value is { expression: string } {
   if (!value || !isCelExpression(value)) return false;
 
   const expr = (value as { expression: string }).expression;
-  return !expr.includes('({') && !expr.includes('=>') && !expr.includes('new ');
+  return (
+    !expr.includes('({') &&
+    !expr.includes('=>') &&
+    !expr.includes('new ') &&
+    !containsUnsupportedBareCall(expr)
+  );
+}
+
+const KNOWN_CEL_FUNCTIONS = new Set([
+  'bool',
+  'double',
+  'duration',
+  'dyn',
+  'has',
+  'int',
+  'omit',
+  'size',
+  'string',
+  'timestamp',
+]);
+
+function containsUnsupportedBareCall(expression: string): boolean {
+  const callPattern = /(?<![.\w])([A-Za-z_$][\w$]*)\s*\(/g;
+  for (const match of expression.matchAll(callPattern)) {
+    const [, functionName] = match;
+    if (!functionName || !KNOWN_CEL_FUNCTIONS.has(functionName)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function hasKubernetesRefMarker(value: string): boolean {

--- a/test/unit/computed-status-alias.test.ts
+++ b/test/unit/computed-status-alias.test.ts
@@ -122,6 +122,66 @@ describe('computed status aliases', () => {
     expect(yaml).toContain('ready: ${web.status.availableReplicas >= web.spec.replicas}');
   });
 
+  it('serializes direct conditional status fields as CEL', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'direct-conditional-status-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'DirectConditionalStatusApp',
+        spec: type({ image: 'string' }),
+        status: type({ phase: 'string' }),
+      },
+      (spec) => {
+        const web = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+
+        return {
+          phase: web.status.availableReplicas >= web.spec.replicas ? 'Ready' : 'Installing',
+        };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain(
+      "phase: \"${web.status.availableReplicas >= web.spec.replicas ? 'Ready' : 'Installing'}\""
+    );
+    expect(yaml).not.toContain('phase: Installing');
+  });
+
+  it('inlines aliases inside conditional status fields', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'aliased-conditional-status-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'AliasedConditionalStatusApp',
+        spec: type({ image: 'string' }),
+        status: type({ ready: 'boolean', phase: 'string' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+        const ready = deployment.status.availableReplicas >= deployment.spec.replicas;
+
+        return { ready, phase: ready ? 'Ready' : 'Installing' };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).toContain('ready: ${web.status.availableReplicas >= web.spec.replicas}');
+    expect(yaml).toContain(
+      'phase: "${web.status.availableReplicas >= web.spec.replicas ? \\"Ready\\" : \\"Installing\\"}"'
+    );
+    expect(yaml).not.toContain('phase: Installing');
+  });
+
   it('inlines explicit alias objects through the same status path', () => {
     const composition = kubernetesComposition(
       {

--- a/test/unit/computed-status-alias.test.ts
+++ b/test/unit/computed-status-alias.test.ts
@@ -182,6 +182,37 @@ describe('computed status aliases', () => {
     expect(yaml).not.toContain('phase: Installing');
   });
 
+  it('does not emit unsupported helper calls as status CEL', () => {
+    function phaseFor(available: number) {
+      return available >= 1 ? 'Ready' : 'Installing';
+    }
+
+    const composition = kubernetesComposition(
+      {
+        name: 'unsupported-helper-status-app',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'UnsupportedHelperStatusApp',
+        spec: type({ image: 'string' }),
+        status: type({ phase: 'string' }),
+      },
+      (spec) => {
+        const web = simple.Deployment({
+          id: 'web',
+          name: 'web',
+          image: spec.image,
+          replicas: 2,
+        });
+
+        return { phase: phaseFor(web.status.availableReplicas) };
+      }
+    );
+
+    const yaml = composition.toYaml();
+    expect(yaml).not.toContain('phaseFor(');
+    expect(yaml).not.toContain('phase: ${');
+    expect(yaml).not.toContain('phase: "${');
+  });
+
   it('inlines explicit alias objects through the same status path', () => {
     const composition = kubernetesComposition(
       {


### PR DESCRIPTION
Summary:
- Replace primitive Phase A execution artifacts with clean Phase B CEL in imperative status merging.
- Preserve TypeKro marker strings so schema-backed placeholder strings remain authoritative.
- Add regressions for direct and aliased conditional status fields.

Validation:
- bun test test/unit/computed-status-alias.test.ts --timeout 10000
- bun run typecheck
- bunx biome check src/core/serialization/status-analysis-pipeline.ts test/unit/computed-status-alias.test.ts
- git diff --check
- bun run test