### PR TITLE
fix(expressions): strict-CEL review findings — single-resource remap hole + analyzer cache vs lambda scopes

### DIFF
--- a/src/core/composition/nested-status-cel.ts
+++ b/src/core/composition/nested-status-cel.ts
@@ -251,11 +251,32 @@ function phaseBHasExpression(phaseBFallback: unknown): phaseBFallback is { expre
  * Uses scored matching: exact-lowercase → single-resource → unambiguous-prefix.
  * Logs a warning when no match or ambiguous match is found.
  */
+/**
+ * Is `id` a minified/local SHORTHAND identifier (`d`, `d1`, `_a`) rather than a meaningful name?
+ * Shorthands come from fn.toString() locals and are safe to bind to the sole resource of a
+ * single-resource graph; a NAMED variable that matched nothing is meaningful information — binding it
+ * by "there's only one thing here" guesswork silently rewrites what the author wrote (the strict-CEL
+ * review finding: `nosuchresource.status.ready` must not validate as `deployment.status.ready`).
+ */
+const isShorthandIdentifier = (id: string): boolean => /^_*[a-zA-Z][0-9]{0,2}$/.test(id);
+
+export interface RemapVariableNamesOptions {
+  /**
+   * Allow the single-resource fallback (rule 2) for NAMED variables, not just shorthands. Default
+   * true — the serializer keeps its historical behavior. The status-CEL VALIDATOR passes false so an
+   * unknown named reference stays visible to the unknown-resource scan instead of being silently
+   * bound to the only resource (see `validateStatusCelExpressions`).
+   */
+  namedVariableSingleResourceFallback?: boolean;
+}
+
 export function remapVariableNames(
   exprStr: string,
   innerResourceIds: string[],
-  preserveVariables?: ReadonlySet<string>
+  preserveVariables?: ReadonlySet<string>,
+  options?: RemapVariableNamesOptions
 ): string {
+  const namedFallback = options?.namedVariableSingleResourceFallback !== false;
   const lambdaVariables = extractCelLambdaVariables(exprStr);
   const shouldPreserveVariable = (id: string): boolean =>
     preserveVariables?.has(id) === true || lambdaVariables.has(id);
@@ -278,7 +299,9 @@ export function remapVariableNames(
     // 2. Single resource — only treat minified/local shorthand names as
     // unambiguous. Named variables like `inner` or `inngest` may refer to
     // nested composition handles rather than the sole concrete resource.
-    if (innerResourceIds.length === 1) {
+    // Callers that need unknown NAMED references to stay visible (the
+    // status-CEL validator) disable the named-variable fallback.
+    if (innerResourceIds.length === 1 && (namedFallback || isShorthandIdentifier(id))) {
       return innerResourceIds[0];
     }
 

--- a/src/core/expressions/analysis/cache.ts
+++ b/src/core/expressions/analysis/cache.ts
@@ -316,6 +316,10 @@ export class ExpressionCache {
       availableReferences: Object.keys(context.availableReferences || {}).sort(),
       factoryType: context.factoryType || 'direct',
       strictCelDiagnostics: isStrictCelDiagnosticsEnabled(context),
+      // Lambda-local scopes change what an identifier MEANS (a registered local converts cleanly; the
+      // same name without it is an unknown resource — a strict-mode throw). Omitting them let a result
+      // cached under one scope answer for the other (the strict-CEL review finding #2).
+      localScopeIdentifiers: [...(context.localScopeIdentifiers ?? [])].sort(),
     };
 
     return this.simpleHash(JSON.stringify(contextData));

--- a/src/core/validation/cel-validator.ts
+++ b/src/core/validation/cel-validator.ts
@@ -362,70 +362,109 @@ export function validateStatusCelExpressions(
   // Separate static and dynamic fields
   const { staticFields, dynamicFields } = separateStatusFields(statusMappings);
 
+  /**
+   * Scan a (remapped) expression for direct resource references (`id.status.` / `id.spec.` /
+   * `id.metadata.`) whose root is not a known resource, schema, CEL lambda variable, or preserved
+   * nested-composition handle. Shared by the two validation passes below.
+   */
+  function scanUnknownReferences(
+    expression: string
+  ): Array<{ referencedId: string; matchedRef: string }> {
+    // Extract CEL lambda variable names to exclude them from resource ID checks.
+    // CEL macros like .all(v, body), .exists(v, body), .map(v, body), .filter(v, body)
+    // introduce lambda variables that should not be treated as resource IDs.
+    const lambdaVarPattern = /\.(?:all|exists|map|filter)\(\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*,/g;
+    const lambdaVars = new Set<string>();
+    let lambdaMatch: RegExpExecArray | null = lambdaVarPattern.exec(expression);
+    while (lambdaMatch !== null) {
+      if (lambdaMatch[1]) lambdaVars.add(lambdaMatch[1]);
+      lambdaMatch = lambdaVarPattern.exec(expression);
+    }
+    // Also add 'each' as it's a Kro readyWhen keyword for forEach collections
+    lambdaVars.add('each');
+
+    const findings: Array<{ referencedId: string; matchedRef: string }> = [];
+    const directResourceRefPattern = /\b([a-zA-Z][a-zA-Z0-9]*)\.(status|spec|metadata)\./g;
+    let directMatch: RegExpExecArray | null = directResourceRefPattern.exec(expression);
+    while (directMatch !== null) {
+      const referencedId = directMatch[1] ?? '';
+      if (
+        referencedId !== 'schema' &&
+        !resourceIds.has(referencedId) &&
+        !lambdaVars.has(referencedId) &&
+        !preserveVariables.has(referencedId)
+      ) {
+        findings.push({ referencedId, matchedRef: directMatch[0] ?? '' });
+      }
+      directMatch = directResourceRefPattern.exec(expression);
+    }
+    return findings;
+  }
+
   // Only validate dynamic fields that will be sent to Kro
   function validateExpression(fieldName: string, value: unknown): void {
     if (isCelExpression(value)) {
-      const expression = remapVariableNames(
-        value.expression,
-        Array.from(resourceIds).filter((id): id is string => typeof id === 'string'),
-        preserveVariables
-      );
+      const idList = Array.from(resourceIds).filter((id): id is string => typeof id === 'string');
 
-      // Check for direct resource references (resourceId.status.field, resourceId.spec.field, resourceId.metadata.field)
-      // This is the most important validation - ensuring referenced resources actually exist
-      //
-      // Extract CEL lambda variable names to exclude them from resource ID checks.
-      // CEL macros like .all(v, body), .exists(v, body), .map(v, body), .filter(v, body)
-      // introduce lambda variables that should not be treated as resource IDs.
-      const lambdaVarPattern = /\.(?:all|exists|map|filter)\(\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*,/g;
-      const lambdaVars = new Set<string>();
-      let lambdaMatch: RegExpExecArray | null = lambdaVarPattern.exec(expression);
-      while (lambdaMatch !== null) {
-        if (lambdaMatch[1]) lambdaVars.add(lambdaMatch[1]);
-        lambdaMatch = lambdaVarPattern.exec(expression);
-      }
-      // Also add 'each' as it's a Kro readyWhen keyword for forEach collections
-      lambdaVars.add('each');
-
-      const directResourceRefPattern = /\b([a-zA-Z][a-zA-Z0-9]*)\.(status|spec|metadata)\./g;
-      let directMatch: RegExpExecArray | null = directResourceRefPattern.exec(expression);
-      while (directMatch !== null) {
-        const referencedId = directMatch[1] ?? '';
-        if (
-          referencedId !== 'schema' &&
-          !resourceIds.has(referencedId) &&
-          !lambdaVars.has(referencedId) &&
-          !preserveVariables.has(referencedId)
-        ) {
-          // Check if this specific reference is a cross-composition status access.
-          // Cross-composition references (e.g., `otherComposition.status.ready`) are valid
-          // even if the referenced composition is not a registered resource in THIS graph.
-          // We only suppress the error when the SPECIFIC unresolved reference accesses .status.,
-          // not when .status. appears anywhere in the expression.
-          const matchedRef = directMatch[0] ?? '';
-          const isCrossCompositionRef =
-            matchedRef.includes('.status.') && !matchedRef.includes('.spec.');
-          if (isCrossCompositionRef) {
-            warnings.push({
-              field: fieldName,
-              expression,
-              error: `Reference '${referencedId}' is not a registered resource — treating as cross-composition reference`,
-              suggestion: `If this is not a cross-composition reference, check that resource '${referencedId}' is created in the composition`,
-              code: 'unknown-resource',
-              referencedResource: referencedId,
-            });
-          } else {
-            errors.push({
-              field: fieldName,
-              expression,
-              error: `Referenced resource '${referencedId}' does not exist`,
-              suggestion: `Available resources: ${Array.from(resourceIds).join(', ')}`,
-              code: 'unknown-resource',
-              referencedResource: referencedId,
-            });
-          }
+      // PASS 1 — mirror the serializer's variable remapping EXACTLY (single-resource fallback
+      // included) so anything the serializer will successfully resolve doesn't false-positive.
+      // These findings gate LENIENT composition validation, so this pass must stay byte-identical
+      // to the historical behavior.
+      const expression = remapVariableNames(value.expression, idList, preserveVariables);
+      const lenientFindings = scanUnknownReferences(expression);
+      for (const { referencedId, matchedRef } of lenientFindings) {
+        // Check if this specific reference is a cross-composition status access.
+        // Cross-composition references (e.g., `otherComposition.status.ready`) are valid
+        // even if the referenced composition is not a registered resource in THIS graph.
+        // We only suppress the error when the SPECIFIC unresolved reference accesses .status.,
+        // not when .status. appears anywhere in the expression.
+        const isCrossCompositionRef =
+          matchedRef.includes('.status.') && !matchedRef.includes('.spec.');
+        if (isCrossCompositionRef) {
+          warnings.push({
+            field: fieldName,
+            expression,
+            error: `Reference '${referencedId}' is not a registered resource — treating as cross-composition reference`,
+            suggestion: `If this is not a cross-composition reference, check that resource '${referencedId}' is created in the composition`,
+            code: 'unknown-resource',
+            referencedResource: referencedId,
+          });
+        } else {
+          errors.push({
+            field: fieldName,
+            expression,
+            error: `Referenced resource '${referencedId}' does not exist`,
+            suggestion: `Available resources: ${Array.from(resourceIds).join(', ')}`,
+            code: 'unknown-resource',
+            referencedResource: referencedId,
+          });
         }
-        directMatch = directResourceRefPattern.exec(expression);
+      }
+
+      // PASS 2 — the same scan WITHOUT the named-variable single-resource fallback. A name that is
+      // unknown here but resolved in pass 1 was bound purely by "there's only one resource here"
+      // guesswork — in a one-resource graph that guesswork would otherwise blind validation to a
+      // genuinely nonexistent reference (`nosuchresource.status.ready` silently validating as
+      // `deployment.status.ready`). Reported as WARNINGS (never errors — lenient serialization still
+      // resolves them via the fallback) carrying code 'unknown-resource', which the strict factory
+      // gate (`strictCelDiagnostics` / TYPEKRO_STRICT_CEL) escalates to a serialization failure.
+      const strictExpression = remapVariableNames(value.expression, idList, preserveVariables, {
+        namedVariableSingleResourceFallback: false,
+      });
+      if (strictExpression !== expression) {
+        const alreadyReported = new Set(lenientFindings.map((f) => f.referencedId));
+        for (const { referencedId } of scanUnknownReferences(strictExpression)) {
+          if (alreadyReported.has(referencedId)) continue;
+          alreadyReported.add(referencedId);
+          warnings.push({
+            field: fieldName,
+            expression: strictExpression,
+            error: `Reference '${referencedId}' resolves only via the single-resource fallback (bound to '${idList[0]}') — not a provable resource reference`,
+            suggestion: `Reference the resource by its id ('${idList[0]}'), or check that '${referencedId}' names a resource created in this composition`,
+            code: 'unknown-resource',
+            referencedResource: referencedId,
+          });
+        }
       }
     } else if (typeof value === 'object' && value !== null) {
       // Recursively validate nested objects

--- a/test/core/expressions/strict-cel-diagnostics.test.ts
+++ b/test/core/expressions/strict-cel-diagnostics.test.ts
@@ -172,6 +172,41 @@ describe('Strict CEL diagnostics', () => {
     });
   });
 
+  describe('analyzer cache vs lambda-local scopes (review finding 2)', () => {
+    it('does not reuse a result cached under a different localScopeIdentifiers set', () => {
+      // Same expression, same strictness, same known resources — differing ONLY in whether `item`
+      // is a registered lambda-local. With the local registered, strict mode converts cleanly; without
+      // it, strict mode must throw. A cache key that omits localScopeIdentifiers would return the
+      // first (clean) result for the second call and swallow the throw.
+      const withLocal = makeContext({
+        strictCelDiagnostics: true,
+        localScopeIdentifiers: ['item'],
+      });
+      const first = analyzer.analyzeExpression('item.status.ready', withLocal);
+      expect(first.valid).toBe(true);
+
+      const withoutLocal = makeContext({ strictCelDiagnostics: true });
+      expect(() => analyzer.analyzeExpression('item.status.ready', withoutLocal)).toThrow(
+        UnknownResourceError
+      );
+    });
+
+    it('does not reuse a no-local result for a later local-scoped conversion', () => {
+      // The reverse order: the throwing (no-local) attempt must not poison the local-scoped one.
+      const withoutLocal = makeContext({ strictCelDiagnostics: true });
+      expect(() => analyzer.analyzeExpression('elem.status.ready', withoutLocal)).toThrow(
+        UnknownResourceError
+      );
+
+      const withLocal = makeContext({
+        strictCelDiagnostics: true,
+        localScopeIdentifiers: ['elem'],
+      });
+      const result = analyzer.analyzeExpression('elem.status.ready', withLocal);
+      expect(result.valid).toBe(true);
+    });
+  });
+
   describe('factory-level strictCelDiagnostics option', () => {
     const AppSpec = type({ name: 'string' });
     const AppStatus = type({ ready: 'boolean' });
@@ -234,6 +269,55 @@ describe('Strict CEL diagnostics', () => {
 
       const yamlOutput = factory.toYaml();
       expect(yamlOutput).toContain('nosuchresource.status.ready');
+    });
+
+    // ── review finding 1: SINGLE-resource graphs ──
+    // The serializer's variable remapping has a single-resource fallback that binds ANY unknown
+    // name to the sole resource. The validator must NOT inherit that guesswork — in a one-resource
+    // graph, `nosuchresource.status.ready` under strict mode has to throw, not silently validate
+    // as `deployment.status.ready`.
+    function buildSingleResourceGraphWithUnknownStatusRef() {
+      return toResourceGraph(
+        {
+          name: 'strict-cel-single-resource-test',
+          apiVersion: 'example.com/v1',
+          kind: 'StrictCelSingleResourceTest',
+          spec: AppSpec,
+          status: AppStatus,
+        },
+        (schema) => ({
+          deployment: simple.Deployment({
+            name: schema.spec.name,
+            image: 'nginx:latest',
+            id: 'deployment',
+          }),
+        }),
+        () => ({
+          ready: Cel.expr<boolean>('nosuchresource.status.ready'),
+        })
+      );
+    }
+
+    it('toYaml() throws for an unknown named reference even in a SINGLE-resource graph (strict)', () => {
+      const graph = buildSingleResourceGraphWithUnknownStatusRef();
+      const factory = graph.factory('kro', { strictCelDiagnostics: true });
+
+      try {
+        factory.toYaml();
+        throw new Error('expected toYaml to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ConversionError);
+        const conversionError = error as ConversionError;
+        expect(conversionError.message).toContain('nosuchresource');
+      }
+    });
+
+    it('toYaml() still serializes a single-resource graph leniently (fallback remap preserved)', () => {
+      const graph = buildSingleResourceGraphWithUnknownStatusRef();
+      const factory = graph.factory('kro');
+      // The SERIALIZER keeps its historical single-resource remap (lenient mode is unchanged);
+      // only the VALIDATOR refuses to let that guesswork mask the unknown reference.
+      expect(() => factory.toYaml()).not.toThrow();
     });
 
     it('toYaml() throws under TYPEKRO_STRICT_CEL=1 without the factory option', () => {


### PR DESCRIPTION
Closes the two findings from the maintainer review of #91.

## Finding 1 — strict mode missed unknown refs in single-resource graphs

`validateStatusCelExpressions` (cel-validator.ts:368) remapped status CEL **before** the
unknown-reference scan, and `remapVariableNames`' single-resource fallback binds ANY unknown
identifier to the sole resource. In a one-resource graph,
`Cel.expr('nosuchresource.status.ready')` under `strictCelDiagnostics: true` remapped to
`deployment.status.ready` and serialized successfully — defeating the strict gate.

**Fix — two-pass validation.** The naive fix (disable the fallback for validation) regressed the
computed-status-alias suite: the fallback is *load-bearing* for lenient fn.toString locals, and the
validator's errors gate lenient composition creation. So:

- **Pass 1** mirrors the serializer exactly (fallback included) — lenient findings byte-identical
  to before.
- **Pass 2** re-remaps with the new `RemapVariableNamesOptions.namedVariableSingleResourceFallback:
  false` (shorthand locals like `d`/`_a` keep the fallback, implementing the rule's own comment);
  names resolved *only* by single-resource guesswork are reported as `unknown-resource`
  **warnings** — lenient serialization is unchanged, and the strict factory gate escalates them to
  a serialization failure naming the expression.

Semantics note: in strict mode, a *legitimate* named variable resolved purely by "there's only one
resource here" is now also rejected — intentionally: the mechanism is indistinguishable from
`nosuchresource`, and strict mode's contract is "no guesswork survives serialization." Reference
the resource by id (or an exact/prefix-matching name) under strict.

## Finding 2 — analyzer cache ignored lambda-local scopes

`hashContext` (cache.ts:314) keyed on strictness + known resources but not
`localScopeIdentifiers`, so a result cached with `item` registered as a lambda-local answered for a
context where `item` is an unknown resource — swallowing the strict throw (and vice versa). The
sorted `localScopeIdentifiers` now join the cache key.

## Verification

- Regression tests for both findings (the exact repros); confirmed failing on the unfixed source
  (2/19) and passing with the fixes (19/19 + 2 cache tests).
- The naive-fix regression is itself pinned: computed-status-alias 19/19.
- Full unit suite 4464 pass / 0 fail; `bun run typecheck` + `bun run lint` green.

No release — for maintainer review.