### PR TITLE
fix(kro): date-shaped env values corrupt the RGD; fail fast on graph rejection instead of a 60s hang

### DIFF
--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -1723,8 +1723,14 @@ export class KroResourceFactoryImpl<
     // identical post-processed output and share the single-apply guard.
     const rgdYaml = this.buildRgdYaml();
 
-    // Parse the YAML to get the RGD object
-    const rgdManifests = k8s.loadAllYaml(rgdYaml);
+    // Parse the YAML to get the RGD object. Use js-yaml with JSON_SCHEMA to MATCH the dump schema in
+    // `serializeResourceGraphToYaml` (same fix as the alchemy path above — this is the imperative/direct
+    // KRO deploy path). `k8s.loadAllYaml` uses js-yaml's DEFAULT (timestamp-aware) schema, which coerces an
+    // unquoted date-shaped scalar — e.g. an env value `"2026-06-01"` — to a `Date` OBJECT, so the applied
+    // RGD would carry an object where KRO requires a string and rejects the graph (`GraphAccepted=False`).
+    const rgdManifests = yaml.loadAll(rgdYaml, undefined, {
+      schema: yaml.JSON_SCHEMA,
+    }) as k8s.KubernetesObject[];
     const rgdManifest = rgdManifests[0] as k8s.KubernetesObject;
 
     // Ensure the RGD has the required properties for deployment

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -5,7 +5,7 @@
  * using the Kro controller for dependency resolution and resource management.
  */
 
-import * as k8s from '@kubernetes/client-node';
+import type * as k8s from '@kubernetes/client-node';
 import { compile as compileExpression } from 'angular-expressions';
 import * as yaml from 'js-yaml';
 // Alchemy v2 (declarative): `toAlchemyResources(spec)` emits these as the RGD + instance

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -1273,7 +1273,18 @@ export class KroResourceFactoryImpl<
     // 1. RGD declaration (deployed once per factory; shared by all instances). Reuse the normal
     // serializer so externalRef/forEach/includeWhen/readyWhen + singleton boundaries match
     // non-alchemy KRO deploys.
-    const rgdManifest = yaml.load(this.buildRgdYaml()) as Record<string, unknown>;
+    //
+    // Load with JSON_SCHEMA to MATCH `serializeResourceGraphToYaml`'s dump schema. The dump uses
+    // JSON_SCHEMA (no YAML timestamp/`!!timestamp` type), so a string value that merely LOOKS like a
+    // date — e.g. an env var `"2026-06-01"` — is emitted UNQUOTED. Loading it back with js-yaml's
+    // DEFAULT schema (timestamp-aware) would coerce that scalar to a `Date` OBJECT, and the applied
+    // RGD would then carry an object where a string belongs — KRO rejects the whole graph
+    // (`GraphAccepted=False: expected string type ..., got object`) and it never reconciles. Matching
+    // the load schema to the dump makes the round-trip lossless (the scalar stays the string it was).
+    const rgdManifest = yaml.load(this.buildRgdYaml(), { schema: yaml.JSON_SCHEMA }) as Record<
+      string,
+      unknown
+    >;
     const rgdFactory =
       this.rgdProvider ??
       (await import('../../factories/kro/resource-graph-definition.js')).resourceGraphDefinition;

--- a/src/core/deployment/readiness-waiter.ts
+++ b/src/core/deployment/readiness-waiter.ts
@@ -199,6 +199,16 @@ export class ReadinessWaiter {
           }
         } else if (result && typeof result === 'object' && 'ready' in result) {
           lastStatus = result;
+          // Terminal (non-recoverable) not-ready — e.g. Kro rejected the RGD graph. Fail FAST with the
+          // real reason rather than polling to the deadline (whose abort surfaces as an opaque
+          // "Delay aborted"). Re-thrown by the catch below, which allowlists ResourceGraphFactoryError.
+          if (!result.ready && (result as ResourceStatus).terminal) {
+            throw new ResourceGraphFactoryError(
+              `${deployedResource.kind}/${deployedResource.name} will not become ready: ${result.message ?? result.reason ?? 'terminal failure'}`,
+              deployedResource.id,
+              'deployment'
+            );
+          }
           if (result.ready) {
             this.readyResources.add(resourceKey);
 
@@ -251,6 +261,11 @@ export class ReadinessWaiter {
           error instanceof DOMException &&
           (error.name === 'AbortError' || error.name === 'TimeoutError')
         ) {
+          throw error;
+        }
+        // Re-throw a terminal readiness failure (the fail-fast above) — it is NOT a transient
+        // read error to be swallowed and retried; the spec will not become ready without a change.
+        if (error instanceof ResourceGraphFactoryError) {
           throw error;
         }
 

--- a/src/core/serialization/yaml.ts
+++ b/src/core/serialization/yaml.ts
@@ -37,6 +37,21 @@ import { finalizeCelForKro, getInnerCelPath, normalizeRefMarkersToCelPaths, proc
 import { generateKroSchema } from './schema.js';
 
 /**
+ * The RGD dump schema: JSON_SCHEMA (null/bool/int/float/string only — no !!binary/!!omap/etc. coercions)
+ * PLUS the implicit `timestamp` type. The timestamp type is added NOT to emit dates, but so js-yaml treats
+ * a date-SHAPED string scalar (e.g. an env value `"2026-06-01"`) as ambiguous and QUOTES it. Under bare
+ * JSON_SCHEMA it has no timestamp type, so such a scalar is emitted UNQUOTED — and any downstream
+ * timestamp-aware parser (KRO, kubectl/GitOps, or js-yaml's own default-schema load) coerces it to a `Date`
+ * OBJECT where the manifest requires a string, and KRO rejects the graph (`GraphAccepted=False`). Quoting
+ * on dump keeps it a string for EVERY consumer. Only date-shaped strings change; all other output is
+ * byte-identical to plain JSON_SCHEMA. (Loaders should still pass JSON_SCHEMA — see kro-factory — but with
+ * this the emitted YAML is safe even for external consumers that don't.)
+ */
+// `yaml.types` exists at runtime but is absent from @types/js-yaml — reference it through a typed cast.
+const yamlTimestampType = (yaml as unknown as { types: { timestamp: yaml.Type } }).types.timestamp;
+const RGD_DUMP_SCHEMA = yaml.JSON_SCHEMA.extend({ implicit: [yamlTimestampType] });
+
+/**
  * Read a non-enumerable property from an Enhanced resource.
  *
  * Used only for `__externalRef` which is NOT part of the WeakMap migration
@@ -1019,6 +1034,6 @@ export function serializeResourceGraphToYaml(
     sortKeys: false,
     quotingType: '"',
     forceQuotes: false,
-    schema: yaml.JSON_SCHEMA,
+    schema: RGD_DUMP_SCHEMA,
   });
 }

--- a/src/core/types/kubernetes.ts
+++ b/src/core/types/kubernetes.ts
@@ -298,6 +298,15 @@ export interface ResourceStatus {
   reason?: string; // Machine-readable reason code
   message?: string; // Human-readable status message
   details?: Record<string, unknown>; // Additional debugging information
+  /**
+   * When true, this not-ready state is TERMINAL for the current spec — it will not self-resolve by
+   * waiting (e.g. Kro rejected an RGD's graph: `GraphAccepted=False`). The readiness waiter fails FAST
+   * with `message`/`reason` instead of polling to the deadline (which would surface an opaque abort).
+   * A subsequent converge that applies a corrected spec still reconciles normally — so this drives
+   * clear, immediate diagnostics WITHOUT requiring manual resource deletion. Only meaningful with
+   * `ready: false`.
+   */
+  terminal?: boolean;
 }
 
 /**

--- a/src/factories/kro/resource-graph-definition.ts
+++ b/src/factories/kro/resource-graph-definition.ts
@@ -124,10 +124,28 @@ export function resourceGraphDefinition(
         (c: KubernetesCondition) => c && c.status === 'False'
       );
       if (status.state === 'failed' || failedCondition) {
+        // A graph-ACCEPTANCE failure (Kro rejected the RGD spec for THIS generation — e.g. an invalid
+        // resource template like a non-string env value) is TERMINAL: it never flips to accepted without
+        // a spec change. Signal `terminal` so the waiter fails fast with the reason instead of polling to
+        // the deadline (which surfaced an opaque "Delay aborted" that read like a cluster-access outage).
+        // Other transient `status: False` conditions stay retryable (ready:false, no terminal).
+        const rejected = currentConditions.find(
+          (c: KubernetesCondition) => c?.status === 'False' && /accepted/i.test(c?.type ?? '')
+        );
+        const cause = rejected ?? failedCondition;
+        if (rejected) {
+          rgdLogger.warn('ResourceGraphDefinition was rejected by Kro (terminal)', {
+            name: liveRGD?.metadata?.name,
+            type: rejected.type,
+            reason: rejected.reason,
+            message: rejected.message,
+          });
+        }
         return {
           ready: false,
           reason: 'RGDProcessingFailed',
-          message: `RGD processing failed: ${failedCondition?.message || 'Unknown error'}`,
+          message: `RGD processing failed: ${cause?.message || 'Unknown error'}`,
+          ...(rejected ? { terminal: true } : {}),
           details: { state: status.state, generation, conditions },
         };
       }

--- a/test/core/rgd-date-string-env.test.ts
+++ b/test/core/rgd-date-string-env.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression: a string env value that LOOKS like a YAML timestamp (e.g. "2026-06-01") must survive the
+ * RGD serialize→apply round-trip as a STRING, not be coerced to a Date object.
+ *
+ * `serializeResourceGraphToYaml` dumps with js-yaml JSON_SCHEMA (no timestamp type → the scalar is
+ * emitted UNQUOTED). The alchemy deploy path then `yaml.load`s that RGD back into the object it applies;
+ * with js-yaml's DEFAULT (timestamp-aware) schema the unquoted scalar coerced to a `Date`, so the applied
+ * RGD carried an object where KRO's schema requires a string → `GraphAccepted=False` → the graph never
+ * reconciled. The load must use JSON_SCHEMA to match the dump. Revert-proven: without the fix the value
+ * comes back as a Date.
+ */
+import { describe, expect, it } from 'bun:test';
+import { type } from 'arktype';
+import { kubernetesComposition, simple, withEnvVars } from '../../src/index.js';
+
+const findEnvValue = (decls: any[], name: string): unknown => {
+  for (const d of decls) {
+    const res = d?.props?.resource ?? d?.resource;
+    const resources = res?.spec?.resources;
+    if (!Array.isArray(resources)) continue;
+    for (const r of resources) {
+      const containers = r?.template?.spec?.template?.spec?.containers ?? [];
+      for (const c of containers) {
+        const hit = (c?.env ?? []).find((e: any) => e?.name === name);
+        if (hit) return hit.value;
+      }
+    }
+  }
+  return undefined;
+};
+
+describe('RGD date-shaped env value round-trips as a string (alchemy deploy path)', () => {
+  it('keeps GCP_PARTITIONS_START_DATE a string, not a Date object', async () => {
+    const comp = kubernetesComposition(
+      { name: 'cs', kind: 'CS', spec: type({ name: 'string' }), status: type({ ready: 'boolean' }) },
+      (spec) => {
+        const d = simple.Deployment({ name: spec.name, image: 'nginx', id: 'dep' });
+        return { ready: d.status.readyReplicas >= 1 };
+      }
+    );
+    const f = await comp.factory('kro', {
+      namespace: 'ns',
+      waitForReady: false,
+      aspects: [withEnvVars({ GCP_PARTITIONS_START_DATE: '2026-06-01', GCP_OTHER: 'prod' })],
+    });
+    const decls = (await f.toAlchemyResources({ name: 'demo', namespace: 'ns' } as any)) as any[];
+
+    const value = findEnvValue(decls, 'GCP_PARTITIONS_START_DATE');
+    expect(value).toBe('2026-06-01');
+    expect(typeof value).toBe('string');
+    expect(value instanceof Date).toBe(false);
+    expect(findEnvValue(decls, 'GCP_OTHER')).toBe('prod');
+  });
+});

--- a/test/core/rgd-date-string-env.test.ts
+++ b/test/core/rgd-date-string-env.test.ts
@@ -51,4 +51,25 @@ describe('RGD date-shaped env value round-trips as a string (alchemy deploy path
     expect(value instanceof Date).toBe(false);
     expect(findEnvValue(decls, 'GCP_OTHER')).toBe('prod');
   });
+
+  it('emits the date-shaped env value QUOTED in toYaml (safe for external/timestamp-aware parsers)', async () => {
+    const comp = kubernetesComposition(
+      { name: 'cs', kind: 'CS', spec: type({ name: 'string' }), status: type({ ready: 'boolean' }) },
+      (spec) => {
+        const d = simple.Deployment({ name: spec.name, image: 'nginx', id: 'dep' });
+        return { ready: d.status.readyReplicas >= 1 };
+      }
+    );
+    const f = await comp.factory('kro', {
+      namespace: 'ns',
+      waitForReady: false,
+      aspects: [withEnvVars({ GCP_PARTITIONS_START_DATE: '2026-06-01', GCP_OTHER: 'prod' })],
+    });
+    const yamlOut = await f.toYaml();
+    // Quoted → a downstream timestamp-aware YAML parser (KRO/kubectl/GitOps) keeps it a string.
+    expect(yamlOut).toContain('value: "2026-06-01"');
+    expect(yamlOut).not.toContain('value: 2026-06-01\n');
+    // A plain (non-ambiguous) value is left unquoted — only date-shaped scalars change.
+    expect(yamlOut).toContain('value: prod');
+  });
 });

--- a/test/core/rgd-terminal-rejection.test.ts
+++ b/test/core/rgd-terminal-rejection.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The RGD readiness evaluator must flag a Kro graph-acceptance rejection (`GraphAccepted=False` for the
+ * current generation) as TERMINAL, so the readiness waiter fails fast with the reason instead of polling
+ * to the deadline (which surfaced an opaque "Delay aborted" that read like a cluster-access outage).
+ * Transient non-acceptance `False` conditions stay retryable.
+ */
+import { describe, expect, it } from 'bun:test';
+import { resourceGraphDefinition } from '../../src/factories/kro/resource-graph-definition.js';
+import { getReadinessEvaluator } from '../utils/mock-factories.js';
+
+const evaluator = () => {
+  const rgd = resourceGraphDefinition({ metadata: { name: 'cs' } });
+  const ev = getReadinessEvaluator(rgd);
+  if (!ev) throw new Error('no readiness evaluator');
+  return ev as (live: unknown) => { ready: boolean; terminal?: boolean; message?: string };
+};
+
+const liveRGD = (conditions: unknown[]) => ({
+  apiVersion: 'kro.run/v1alpha1',
+  kind: 'ResourceGraphDefinition',
+  metadata: { name: 'cs', generation: 2, uid: 'u' },
+  status: { state: 'Inactive', conditions },
+});
+
+describe('RGD readiness terminal detection', () => {
+  it('marks GraphAccepted=False as terminal with the Kro reason', () => {
+    const r = evaluator()(
+      liveRGD([
+        { type: 'KindReady', status: 'True', observedGeneration: 2 },
+        {
+          type: 'GraphAccepted',
+          status: 'False',
+          reason: 'InvalidResourceGraph',
+          message: 'expected string type for path spec...env[10].value, got object',
+          observedGeneration: 2,
+        },
+      ])
+    );
+    expect(r.ready).toBe(false);
+    expect(r.terminal).toBe(true);
+    expect(r.message).toContain('got object');
+  });
+
+  it('does NOT mark a transient non-acceptance False condition terminal', () => {
+    const r = evaluator()(
+      liveRGD([{ type: 'SomethingSyncing', status: 'False', message: 'still syncing', observedGeneration: 2 }])
+    );
+    expect(r.ready).toBe(false);
+    expect(r.terminal).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

A real converge (a Dagster code-server whose env carried `GCP_PARTITIONS_START_DATE: "2026-06-01"`) failed with an opaque `Delay aborted` after 60s that looked like a cluster-access outage. It was neither — KRO had **rejected the RGD**:

```
GraphAccepted=False :: expected string type for path spec...env[10].value, got object
→ ResourceGraphDefinition = Inactive / Ready=False  (never reconciles)
```

Two independent bugs combined here.

## 1. Root cause — date-shaped string env values get corrupted (a `Date` object, not a string)

`serializeResourceGraphToYaml` dumps the RGD with js-yaml **`JSON_SCHEMA`** (no YAML timestamp type), so a string that merely *looks* like a date — `2026-06-01` — is emitted **unquoted**. The alchemy deploy path then loaded that YAML back with js-yaml's **default** (timestamp-aware) schema:

```ts
// kro-factory.ts
const rgdManifest = yaml.load(this.buildRgdYaml()) as Record<string, unknown>; // default schema → Date!
```

so the scalar was coerced to a `Date` **object**. The applied RGD carried an object where KRO's schema requires a string → `GraphAccepted=False` → the graph never reconciled.

**Fix:** load with `JSON_SCHEMA` to match the dump, making the round-trip lossless. (Verified round-trip: `yaml.load('value: 2026-06-01', { schema: JSON_SCHEMA })` → `"2026-06-01"` string; default schema → `Date`.)

## 2. Self-heal / diagnostics — fail fast on a rejected graph instead of hanging

A `GraphAccepted=False` is **terminal** for that spec, but the RGD readiness evaluator could only return `ready:false` (retryable), so the deploy polled to the deadline and the external abort surfaced as `Delay aborted` — the real reason was lost.

- Added an optional `terminal` flag to the readiness contract (`ResourceStatus`).
- The RGD evaluator flags a graph-acceptance rejection (`*Accepted` = `False` for the current generation) as `terminal`, carrying the KRO reason, plus a WARN log.
- The readiness waiter fails **fast** with that reason instead of polling to the deadline. Transient non-acceptance `False` conditions stay retryable.

A subsequent converge that applies a corrected spec reconciles normally — **no manual RGD deletion is needed**; you just get the real reason in seconds.

## Result

Valid RGDs are produced in the first place, and if one is ever rejected you get, e.g., `... will not become ready: RGD processing failed: expected string type ..., got object` immediately — and it self-heals on the next good converge.

## Tests
- `test/core/rgd-date-string-env.test.ts` — the date-shaped env value round-trips as a string through the alchemy deploy path (revert-proven: fails as a `Date` without the fix).
- `test/core/rgd-terminal-rejection.test.ts` — `GraphAccepted=False` → `terminal` with the reason; a transient non-acceptance `False` condition is **not** terminal.
- Changed-path suites green (131 pass across readiness-waiter / alchemy-deployers / kro-readiness / yaml / serialization / engine); typecheck clean.

No version bump / changelog — releases are cut separately. Not merging — leaving that to you.
