### PR TITLE
fix(readiness): bound per-call k8s reads so a wedged exec credential can't hang the poll forever

### DIFF
--- a/src/core/deployment/kro-readiness.ts
+++ b/src/core/deployment/kro-readiness.ts
@@ -19,7 +19,7 @@ import {
 import { CRDInstanceError, DeploymentTimeoutError, ensureError } from '../errors.js';
 import { getComponentLogger } from '../logging/index.js';
 import type { RGDManifest } from '../types/kubernetes.js';
-import { callWithTimeout, perCallTimeout } from './poll-timeout.js';
+import { callWithTimeout, perCallTimeout, PollTimeoutError } from './poll-timeout.js';
 
 /** Options for Kro instance readiness polling. */
 export interface KroReadinessOptions {
@@ -184,6 +184,13 @@ export async function waitForKroInstanceReady(options: KroReadinessOptions): Pro
           expectedCustomStatusFields,
         });
       } catch (error: unknown) {
+        // A per-call TIMEOUT (wedged/expired credential) is NOT a fetchable-RGD failure — do not fall
+        // through to the permissive path, which would let an ACTIVE/synced instance be declared ready
+        // WITHOUT validating expected status fields (and after the deadline). Surface it so the outer
+        // catch re-throws it (fail fast).
+        if (error instanceof PollTimeoutError) {
+          throw error;
+        }
         readinessLogger.warn('Could not fetch ResourceGraphDefinition for status schema check', {
           rgdName,
           error: ensureError(error).message,
@@ -232,6 +239,12 @@ export async function waitForKroInstanceReady(options: KroReadinessOptions): Pro
         (!hasReadyField || statusReadyField === true);
 
       if (isReady) {
+        // Re-check the deadline: an API call earlier in THIS iteration may have consumed the remaining
+        // budget (e.g. a slow/bounded read), so an "isReady" reached past the deadline must still time
+        // out rather than silently succeed late.
+        if (Date.now() - startTime >= timeout) {
+          break;
+        }
         readinessLogger.info('Kro instance is ready', {
           instanceName,
           hasCustomStatusFields,

--- a/src/core/deployment/kro-readiness.ts
+++ b/src/core/deployment/kro-readiness.ts
@@ -11,10 +11,15 @@
  */
 
 import type * as k8s from '@kubernetes/client-node';
-import { DEFAULT_FAST_POLL_INTERVAL, DEFAULT_POLL_INTERVAL } from '../config/defaults.js';
+import {
+  DEFAULT_FAST_POLL_INTERVAL,
+  DEFAULT_HTTP_READ_TIMEOUT,
+  DEFAULT_POLL_INTERVAL,
+} from '../config/defaults.js';
 import { CRDInstanceError, DeploymentTimeoutError, ensureError } from '../errors.js';
 import { getComponentLogger } from '../logging/index.js';
 import type { RGDManifest } from '../types/kubernetes.js';
+import { callWithTimeout, perCallTimeout } from './poll-timeout.js';
 
 /** Options for Kro instance readiness polling. */
 export interface KroReadinessOptions {
@@ -87,14 +92,22 @@ export async function waitForKroInstanceReady(options: KroReadinessOptions): Pro
 
   while (Date.now() - startTime < timeout) {
     try {
-      const response = await k8sApi.read({
-        apiVersion,
-        kind,
-        metadata: {
-          name: instanceName,
-          namespace,
-        },
-      });
+      // Bound the read so a wedged/expired kubeconfig exec credential rejects (and is re-thrown below)
+      // instead of hanging the poll forever — see poll-timeout.ts.
+      const readTimeout = perCallTimeout(timeout - (Date.now() - startTime), DEFAULT_HTTP_READ_TIMEOUT);
+      const response = await callWithTimeout(
+        () =>
+          k8sApi.read({
+            apiVersion,
+            kind,
+            metadata: {
+              name: instanceName,
+              namespace,
+            },
+          }),
+        readTimeout,
+        `read ${kind}/${instanceName}`
+      );
 
       // In the new API, methods return objects directly (no .body wrapper)
       const instance = response as k8s.KubernetesObject & {
@@ -146,12 +159,18 @@ export async function waitForKroInstanceReady(options: KroReadinessOptions): Pro
       let expectedCustomStatusFields = false;
       let expectedStatusKeys: string[] = [];
       try {
-        const rgdResponse = await customObjectsApi.getClusterCustomObject({
-          group: 'kro.run',
-          version: 'v1alpha1',
-          plural: 'resourcegraphdefinitions',
-          name: rgdName,
-        });
+        const rgdReadTimeout = perCallTimeout(timeout - (Date.now() - startTime), DEFAULT_HTTP_READ_TIMEOUT);
+        const rgdResponse = await callWithTimeout(
+          () =>
+            customObjectsApi.getClusterCustomObject({
+              group: 'kro.run',
+              version: 'v1alpha1',
+              plural: 'resourcegraphdefinitions',
+              name: rgdName,
+            }),
+          rgdReadTimeout,
+          `read ResourceGraphDefinition/${rgdName}`
+        );
         const rgd = rgdResponse as RGDManifest;
         const rgdStatusSchema = rgd.spec?.schema?.status ?? {};
         expectedStatusKeys = Object.keys(rgdStatusSchema).filter(

--- a/src/core/deployment/kro-readiness.ts
+++ b/src/core/deployment/kro-readiness.ts
@@ -93,8 +93,10 @@ export async function waitForKroInstanceReady(options: KroReadinessOptions): Pro
   while (Date.now() - startTime < timeout) {
     try {
       // Bound the read so a wedged/expired kubeconfig exec credential rejects (and is re-thrown below)
-      // instead of hanging the poll forever — see poll-timeout.ts.
+      // instead of hanging the poll forever — see poll-timeout.ts. A ≤0 budget means the deadline is
+      // spent: break to the overall DeploymentTimeoutError below (NOT a per-call PollTimeoutError).
       const readTimeout = perCallTimeout(timeout - (Date.now() - startTime), DEFAULT_HTTP_READ_TIMEOUT);
+      if (readTimeout <= 0) break;
       const response = await callWithTimeout(
         () =>
           k8sApi.read({
@@ -160,6 +162,9 @@ export async function waitForKroInstanceReady(options: KroReadinessOptions): Pro
       let expectedStatusKeys: string[] = [];
       try {
         const rgdReadTimeout = perCallTimeout(timeout - (Date.now() - startTime), DEFAULT_HTTP_READ_TIMEOUT);
+        // Deadline spent mid-iteration: break to the overall DeploymentTimeoutError rather than starting
+        // a doomed read (which would surface a misleading per-call PollTimeoutError).
+        if (rgdReadTimeout <= 0) break;
         const rgdResponse = await callWithTimeout(
           () =>
             customObjectsApi.getClusterCustomObject({

--- a/src/core/deployment/poll-timeout.ts
+++ b/src/core/deployment/poll-timeout.ts
@@ -1,0 +1,46 @@
+/**
+ * Per-call timeout for readiness-poll Kubernetes API requests.
+ *
+ * Readiness polls loop as `while (Date.now() - startTime < timeout) { await k8sApi.read(...) }`. The
+ * deadline is only re-checked between iterations, so it relies on each `await` eventually settling. When
+ * the kubeconfig's exec credential WEDGES — e.g. `aws eks get-token` hangs, or the AWS/SSO session
+ * expired mid-deploy so the auth plugin never returns — the awaited request never resolves OR rejects,
+ * the loop never re-evaluates its deadline, and the whole deploy hangs SILENTLY (observed multi-hour).
+ *
+ * Bounding each call converts that wedge into a rejection, so the poll's existing error handling runs and
+ * the configured `timeout` is honored: a failed/expired credential is not a transient "not ready yet" —
+ * it counts against the deadline (or fails fast) instead of hanging forever.
+ */
+export async function callWithTimeout<T>(op: () => Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      op(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                `${label} exceeded its ${timeoutMs}ms request timeout — the Kubernetes API call did not return. ` +
+                  `The usual cause is a wedged or expired kubeconfig exec credential (e.g. an AWS SSO/EKS token ` +
+                  `that expired mid-deploy). Re-run with fresh credentials.`
+              )
+            ),
+          timeoutMs
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * The per-call budget: the configured HTTP read timeout, but never more than the poll's remaining
+ * deadline (so one wedged call can't overshoot the overall `timeout`), and never less than a small floor
+ * (so a nearly-elapsed poll still gives the final attempt a fair chance to settle).
+ */
+export function perCallTimeout(remainingMs: number, capMs: number): number {
+  const FLOOR_MS = 1_000;
+  return Math.max(FLOOR_MS, Math.min(capMs, remainingMs));
+}

--- a/src/core/deployment/poll-timeout.ts
+++ b/src/core/deployment/poll-timeout.ts
@@ -34,11 +34,16 @@ export class PollTimeoutError extends Error {
   }
 }
 
+/**
+ * Run `op`, rejecting with {@link PollTimeoutError} if it hasn't settled within `timeoutMs`.
+ *
+ * PRECONDITION: `timeoutMs` must be positive — callers pass a per-call budget derived from the poll's
+ * REMAINING deadline (see {@link perCallTimeout}) and must handle an exhausted (≤0) budget themselves by
+ * exiting their loop and throwing their own overall-timeout error. A `PollTimeoutError` therefore always
+ * means "an operation that actually started did not return in time" (a wedged call), never "the overall
+ * poll deadline had already elapsed" — the two are distinct and must not be conflated.
+ */
 export async function callWithTimeout<T>(op: () => Promise<T>, timeoutMs: number, label: string): Promise<T> {
-  // No budget left: the poll deadline is already spent — fail fast rather than start a doomed call.
-  if (timeoutMs <= 0) {
-    throw new PollTimeoutError(label, timeoutMs);
-  }
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
@@ -54,8 +59,10 @@ export async function callWithTimeout<T>(op: () => Promise<T>, timeoutMs: number
 
 /**
  * The per-call budget: the configured cap (HTTP read timeout), capped STRICTLY by the poll's remaining
- * deadline so one call can never overshoot the overall `timeout`. Returns <= 0 when the deadline is
- * already spent — callers pass that straight to {@link callWithTimeout}, which fails fast.
+ * deadline so one call can never overshoot the overall `timeout`. Returns ≤ 0 when the deadline is
+ * already spent; callers MUST treat a ≤0 budget as "deadline reached" — exit the poll loop and throw the
+ * poll's own overall-timeout error — rather than starting a (doomed) call. Never hand a ≤0 value to
+ * {@link callWithTimeout}.
  */
 export function perCallTimeout(remainingMs: number, capMs: number): number {
   return Math.min(capMs, remainingMs);

--- a/src/core/deployment/poll-timeout.ts
+++ b/src/core/deployment/poll-timeout.ts
@@ -10,24 +10,41 @@
  * Bounding each call converts that wedge into a rejection, so the poll's existing error handling runs and
  * the configured `timeout` is honored: a failed/expired credential is not a transient "not ready yet" —
  * it counts against the deadline (or fails fast) instead of hanging forever.
+ *
+ * SCOPE / LIMITATION: this bounds the caller's `await` (so the poll and the deploy terminate). It does
+ * NOT cancel the in-flight request or kill a wedged exec-auth subprocess: `@kubernetes/client-node`'s
+ * `KubernetesObjectApi.read` does not thread an `AbortSignal` to its fetch, and its `ExecAuth` spawns the
+ * credential process (`child_process.spawn`) with no cancellation hook. A wedged subprocess can therefore
+ * keep the Node process alive until it exits or the process is terminated. The durable cure for the
+ * exec-auth failure mode is to avoid per-request exec auth during polling (e.g. a pre-minted bearer token
+ * in the kubeconfig), so no credential subprocess is spawned in the first place.
  */
+
+/** Thrown when a readiness-poll API call exceeds its per-call budget (distinguishable so callers can fail fast vs. retry). */
+export class PollTimeoutError extends Error {
+  readonly timeoutMs: number;
+  constructor(label: string, timeoutMs: number) {
+    super(
+      `${label} exceeded its ${timeoutMs}ms request timeout — the Kubernetes API call did not return. ` +
+        `The usual cause is a wedged or expired kubeconfig exec credential (e.g. an AWS SSO/EKS token ` +
+        `that expired mid-deploy). Re-run with fresh credentials.`
+    );
+    this.name = 'PollTimeoutError';
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 export async function callWithTimeout<T>(op: () => Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  // No budget left: the poll deadline is already spent — fail fast rather than start a doomed call.
+  if (timeoutMs <= 0) {
+    throw new PollTimeoutError(label, timeoutMs);
+  }
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
       op(),
       new Promise<never>((_, reject) => {
-        timer = setTimeout(
-          () =>
-            reject(
-              new Error(
-                `${label} exceeded its ${timeoutMs}ms request timeout — the Kubernetes API call did not return. ` +
-                  `The usual cause is a wedged or expired kubeconfig exec credential (e.g. an AWS SSO/EKS token ` +
-                  `that expired mid-deploy). Re-run with fresh credentials.`
-              )
-            ),
-          timeoutMs
-        );
+        timer = setTimeout(() => reject(new PollTimeoutError(label, timeoutMs)), timeoutMs);
       }),
     ]);
   } finally {
@@ -36,11 +53,10 @@ export async function callWithTimeout<T>(op: () => Promise<T>, timeoutMs: number
 }
 
 /**
- * The per-call budget: the configured HTTP read timeout, but never more than the poll's remaining
- * deadline (so one wedged call can't overshoot the overall `timeout`), and never less than a small floor
- * (so a nearly-elapsed poll still gives the final attempt a fair chance to settle).
+ * The per-call budget: the configured cap (HTTP read timeout), capped STRICTLY by the poll's remaining
+ * deadline so one call can never overshoot the overall `timeout`. Returns <= 0 when the deadline is
+ * already spent — callers pass that straight to {@link callWithTimeout}, which fails fast.
  */
 export function perCallTimeout(remainingMs: number, capMs: number): number {
-  const FLOOR_MS = 1_000;
-  return Math.max(FLOOR_MS, Math.min(capMs, remainingMs));
+  return Math.min(capMs, remainingMs);
 }

--- a/src/core/deployment/readiness.ts
+++ b/src/core/deployment/readiness.ts
@@ -71,6 +71,9 @@ export class ResourceReadinessChecker {
   ): Promise<void> {
     const startTime = Date.now();
     let attempt = 0;
+    // The most recent successfully-read resource, reused for the on-timeout debug log so we never issue a
+    // fresh (post-deadline) read that could hang or delay the timeout error.
+    let lastObserved: k8s.KubernetesObject | undefined;
 
     emitEvent({
       type: 'progress',
@@ -90,6 +93,9 @@ export class ResourceReadinessChecker {
           readinessConfig.timeout - (Date.now() - startTime),
           DEFAULT_HTTP_READ_TIMEOUT
         );
+        // Deadline spent: stop and fall through to ResourceReadinessTimeoutError (the poll's own overall
+        // timeout) rather than starting a doomed read.
+        if (readTimeout <= 0) break;
         const currentResource = await callWithTimeout(
           () =>
             this.k8sApi.read({
@@ -103,6 +109,7 @@ export class ResourceReadinessChecker {
           readTimeout,
           `read ${deployedResource.kind}/${deployedResource.name}`
         );
+        lastObserved = currentResource;
 
         const isReady = this.isResourceReady(currentResource);
 
@@ -176,42 +183,34 @@ export class ResourceReadinessChecker {
           });
         }
 
-        // Wait before retry
-        await new Promise((resolve) => setTimeout(resolve, readinessConfig.errorRetryDelay));
+        // Wait before retry — but never past the deadline. If a bounded read consumed the remaining
+        // budget, sleeping the full errorRetryDelay would overshoot the configured timeout; cap it to
+        // what's left (0 → the while re-check exits immediately).
+        const retryDelay = Math.max(
+          0,
+          Math.min(readinessConfig.errorRetryDelay, readinessConfig.timeout - (Date.now() - startTime))
+        );
+        if (retryDelay > 0) {
+          await new Promise((resolve) => setTimeout(resolve, retryDelay));
+        }
       }
     }
 
-    // Debug logging for timeout with final status
+    // Debug logging for timeout with final status. Use the LAST OBSERVED resource rather than issuing a
+    // fresh read: the deadline is already spent, so a new read would either hang (wedged credential — the
+    // very failure mode this fixes) or delay ResourceReadinessTimeoutError past the configured timeout.
     if (this.debugLogger) {
-      try {
-        // In the new API, methods return objects directly (no .body wrapper).
-        // Bound this too — the deadline was just reached, so if the credential is wedged this final
-        // read would otherwise hang forever HERE instead of throwing ResourceReadinessTimeoutError below.
-        const finalResource = await callWithTimeout(
-          () =>
-            this.k8sApi.read({
-              apiVersion: deployedResource.manifest.apiVersion,
-              kind: deployedResource.kind,
-              metadata: {
-                name: deployedResource.name,
-                namespace: deployedResource.namespace,
-              },
-            }),
-          DEFAULT_HTTP_READ_TIMEOUT,
-          `read ${deployedResource.kind}/${deployedResource.name} (final status)`
-        );
-
+      if (lastObserved !== undefined) {
         this.debugLogger.logTimeout(
           deployedResource,
-          (finalResource as { status?: unknown }).status || finalResource,
+          (lastObserved as { status?: unknown }).status || lastObserved,
           Date.now() - startTime,
           attempt
         );
-      } catch (_error: unknown) {
-        // If we can't get final status, log timeout without it
+      } else {
         this.debugLogger.logTimeout(
           deployedResource,
-          { error: 'Could not retrieve final status' },
+          { error: 'No status observed before timeout' },
           Date.now() - startTime,
           attempt
         );

--- a/src/core/deployment/readiness.ts
+++ b/src/core/deployment/readiness.ts
@@ -184,15 +184,22 @@ export class ResourceReadinessChecker {
     // Debug logging for timeout with final status
     if (this.debugLogger) {
       try {
-        // In the new API, methods return objects directly (no .body wrapper)
-        const finalResource = await this.k8sApi.read({
-          apiVersion: deployedResource.manifest.apiVersion,
-          kind: deployedResource.kind,
-          metadata: {
-            name: deployedResource.name,
-            namespace: deployedResource.namespace,
-          },
-        });
+        // In the new API, methods return objects directly (no .body wrapper).
+        // Bound this too — the deadline was just reached, so if the credential is wedged this final
+        // read would otherwise hang forever HERE instead of throwing ResourceReadinessTimeoutError below.
+        const finalResource = await callWithTimeout(
+          () =>
+            this.k8sApi.read({
+              apiVersion: deployedResource.manifest.apiVersion,
+              kind: deployedResource.kind,
+              metadata: {
+                name: deployedResource.name,
+                namespace: deployedResource.namespace,
+              },
+            }),
+          DEFAULT_HTTP_READ_TIMEOUT,
+          `read ${deployedResource.kind}/${deployedResource.name} (final status)`
+        );
 
         this.debugLogger.logTimeout(
           deployedResource,

--- a/src/core/deployment/readiness.ts
+++ b/src/core/deployment/readiness.ts
@@ -8,10 +8,12 @@ import type * as k8s from '@kubernetes/client-node';
 import {
   DEFAULT_DEPLOYMENT_TIMEOUT,
   DEFAULT_FAST_POLL_INTERVAL,
+  DEFAULT_HTTP_READ_TIMEOUT,
   DEFAULT_POLL_INTERVAL,
   DEFAULT_READINESS_MAX_BACKOFF,
 } from '../config/defaults.js';
 import { ensureError } from '../errors.js';
+import { callWithTimeout, perCallTimeout } from './poll-timeout.js';
 import type { DeploymentEvent, DeploymentOptions, ReadinessConfig } from '../types/deployment.js';
 import type {
   DeployedResource,
@@ -81,15 +83,26 @@ export class ResourceReadinessChecker {
       attempt++;
 
       try {
-        // In the new API, methods return objects directly (no .body wrapper)
-        const currentResource = await this.k8sApi.read({
-          apiVersion: deployedResource.manifest.apiVersion,
-          kind: deployedResource.kind,
-          metadata: {
-            name: deployedResource.name,
-            namespace: deployedResource.namespace,
-          },
-        });
+        // In the new API, methods return objects directly (no .body wrapper).
+        // Bound the read so a wedged/expired kubeconfig exec credential rejects (→ handled below, retried
+        // within the deadline) instead of hanging the poll forever — see poll-timeout.ts.
+        const readTimeout = perCallTimeout(
+          readinessConfig.timeout - (Date.now() - startTime),
+          DEFAULT_HTTP_READ_TIMEOUT
+        );
+        const currentResource = await callWithTimeout(
+          () =>
+            this.k8sApi.read({
+              apiVersion: deployedResource.manifest.apiVersion,
+              kind: deployedResource.kind,
+              metadata: {
+                name: deployedResource.name,
+                namespace: deployedResource.namespace,
+              },
+            }),
+          readTimeout,
+          `read ${deployedResource.kind}/${deployedResource.name}`
+        );
 
         const isReady = this.isResourceReady(currentResource);
 

--- a/test/unit/kro-readiness.test.ts
+++ b/test/unit/kro-readiness.test.ts
@@ -708,6 +708,32 @@ describe('waitForKroInstanceReady', () => {
         )
       ).resolves.toBeUndefined();
     });
+
+    it('does NOT swallow a WEDGED RGD read as readiness — fails fast instead of returning ready late', async () => {
+      // Regression: a per-call timeout on the RGD read must not fall through to the permissive path,
+      // which would declare an ACTIVE/synced instance ready WITHOUT validating expected status fields
+      // (and after the deadline). A wedged RGD read (never settles) must surface as a timeout error.
+      mockK8sApi.read.mockResolvedValue(
+        kroInstance({
+          state: 'ACTIVE',
+          conditions: [{ type: 'Ready', status: 'True' }],
+        })
+      );
+      // The RGD fetch never settles — models a wedged/expired kubeconfig exec credential.
+      mockCustomObjectsApi.getClusterCustomObject.mockImplementation(
+        () => new Promise(() => {}) as Promise<object>
+      );
+
+      await expect(
+        waitForKroInstanceReady(
+          defaultOptions({
+            k8sApi: mockK8sApi,
+            customObjectsApi: mockCustomObjectsApi,
+            timeout: 200,
+          })
+        )
+      ).rejects.toThrow(/did not return|request timeout/);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/unit/kro-readiness.test.ts
+++ b/test/unit/kro-readiness.test.ts
@@ -467,6 +467,26 @@ describe('waitForKroInstanceReady', () => {
       ).rejects.toThrow(DeploymentTimeoutError);
     });
 
+    it('an exhausted deadline throws the overall DeploymentTimeoutError, NOT a per-call PollTimeoutError', async () => {
+      // Regression: a ≤0 per-call budget means the overall deadline elapsed — it must not be reported as
+      // a credential-wedge PollTimeoutError. A 1ms timeout with a normal (fast, not-ready) read must
+      // surface DeploymentTimeoutError.
+      mockK8sApi.read.mockResolvedValue(
+        kroInstance({ state: 'PENDING', conditions: [{ type: 'Ready', status: 'False' }] })
+      );
+
+      const err = await waitForKroInstanceReady(
+        defaultOptions({
+          k8sApi: mockK8sApi,
+          customObjectsApi: mockCustomObjectsApi,
+          timeout: 1,
+          pollInterval: 0,
+        })
+      ).catch((e) => e);
+      expect(err).toBeInstanceOf(DeploymentTimeoutError);
+      expect((err as Error).message).not.toMatch(/exec credential/);
+    });
+
     it('timeout error includes instance name and timeout info', async () => {
       mockK8sApi.read.mockResolvedValue(
         kroInstance({

--- a/test/unit/poll-timeout.test.ts
+++ b/test/unit/poll-timeout.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for the readiness-poll per-call timeout (poll-timeout.ts).
+ *
+ * Regression guard for the silent multi-hour hang: a readiness poll's `await k8sApi.read(...)` that never
+ * settles (wedged/expired kubeconfig exec credential) must be bounded so the poll's deadline is honored.
+ */
+import { describe, expect, it } from 'bun:test';
+import { callWithTimeout, perCallTimeout } from '../../src/core/deployment/poll-timeout.js';
+
+describe('callWithTimeout', () => {
+  it('resolves with the op result when it settles before the timeout', async () => {
+    const result = await callWithTimeout(() => Promise.resolve('ok'), 1_000, 'fast op');
+    expect(result).toBe('ok');
+  });
+
+  it('rejects with a credential-hint error when the op never settles (the hang case)', async () => {
+    // A promise that NEVER resolves or rejects — models a wedged exec-credential k8s call.
+    const neverSettles = () => new Promise<string>(() => {});
+    await expect(callWithTimeout(neverSettles, 20, 'read Foo/bar')).rejects.toThrow(
+      /read Foo\/bar exceeded its 20ms request timeout/
+    );
+    await expect(callWithTimeout(neverSettles, 20, 'read Foo/bar')).rejects.toThrow(
+      /exec credential/
+    );
+  });
+
+  it('propagates the op’s own rejection (not the timeout) when it fails fast', async () => {
+    const boom = () => Promise.reject(new Error('boom'));
+    await expect(callWithTimeout(boom, 1_000, 'op')).rejects.toThrow('boom');
+  });
+
+  it('clears its timer so a resolved call does not keep the event loop alive', async () => {
+    // If the timer weren't cleared, an unref'd handle could fire later; resolving fast must not throw.
+    await expect(callWithTimeout(() => Promise.resolve(1), 50, 'op')).resolves.toBe(1);
+    await new Promise((r) => setTimeout(r, 60));
+  });
+});
+
+describe('perCallTimeout', () => {
+  it('uses the cap when the remaining budget is larger', () => {
+    expect(perCallTimeout(600_000, 30_000)).toBe(30_000);
+  });
+
+  it('shrinks to the remaining budget so one call cannot overshoot the poll deadline', () => {
+    expect(perCallTimeout(5_000, 30_000)).toBe(5_000);
+  });
+
+  it('never drops below the 1s floor even when the deadline is nearly elapsed', () => {
+    expect(perCallTimeout(10, 30_000)).toBe(1_000);
+    expect(perCallTimeout(-500, 30_000)).toBe(1_000);
+  });
+});

--- a/test/unit/poll-timeout.test.ts
+++ b/test/unit/poll-timeout.test.ts
@@ -5,7 +5,7 @@
  * settles (wedged/expired kubeconfig exec credential) must be bounded so the poll's deadline is honored.
  */
 import { describe, expect, it } from 'bun:test';
-import { callWithTimeout, perCallTimeout } from '../../src/core/deployment/poll-timeout.js';
+import { callWithTimeout, PollTimeoutError, perCallTimeout } from '../../src/core/deployment/poll-timeout.js';
 
 describe('callWithTimeout', () => {
   it('resolves with the op result when it settles before the timeout', async () => {
@@ -13,24 +13,35 @@ describe('callWithTimeout', () => {
     expect(result).toBe('ok');
   });
 
-  it('rejects with a credential-hint error when the op never settles (the hang case)', async () => {
+  it('rejects with a PollTimeoutError (credential hint) when the op never settles (the hang case)', async () => {
     // A promise that NEVER resolves or rejects — models a wedged exec-credential k8s call.
     const neverSettles = () => new Promise<string>(() => {});
-    await expect(callWithTimeout(neverSettles, 20, 'read Foo/bar')).rejects.toThrow(
-      /read Foo\/bar exceeded its 20ms request timeout/
-    );
-    await expect(callWithTimeout(neverSettles, 20, 'read Foo/bar')).rejects.toThrow(
-      /exec credential/
-    );
+    const err = await callWithTimeout(neverSettles, 20, 'read Foo/bar').catch((e) => e);
+    expect(err).toBeInstanceOf(PollTimeoutError);
+    expect((err as Error).message).toMatch(/read Foo\/bar exceeded its 20ms request timeout/);
+    expect((err as Error).message).toMatch(/exec credential/);
   });
 
-  it('propagates the op’s own rejection (not the timeout) when it fails fast', async () => {
+  it('fails fast without starting the op when there is no budget left', async () => {
+    let started = false;
+    const err = await callWithTimeout(
+      () => {
+        started = true;
+        return Promise.resolve('nope');
+      },
+      0,
+      'read Foo/bar'
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(PollTimeoutError);
+    expect(started).toBe(false);
+  });
+
+  it('propagates the op own rejection (not the timeout) when it fails fast', async () => {
     const boom = () => Promise.reject(new Error('boom'));
     await expect(callWithTimeout(boom, 1_000, 'op')).rejects.toThrow('boom');
   });
 
   it('clears its timer so a resolved call does not keep the event loop alive', async () => {
-    // If the timer weren't cleared, an unref'd handle could fire later; resolving fast must not throw.
     await expect(callWithTimeout(() => Promise.resolve(1), 50, 'op')).resolves.toBe(1);
     await new Promise((r) => setTimeout(r, 60));
   });
@@ -41,12 +52,14 @@ describe('perCallTimeout', () => {
     expect(perCallTimeout(600_000, 30_000)).toBe(30_000);
   });
 
-  it('shrinks to the remaining budget so one call cannot overshoot the poll deadline', () => {
+  it('shrinks STRICTLY to the remaining budget so one call cannot overshoot the poll deadline', () => {
     expect(perCallTimeout(5_000, 30_000)).toBe(5_000);
+    // Below one second it must NOT be floored up to 1s (that would exceed the remaining deadline).
+    expect(perCallTimeout(200, 30_000)).toBe(200);
   });
 
-  it('never drops below the 1s floor even when the deadline is nearly elapsed', () => {
-    expect(perCallTimeout(10, 30_000)).toBe(1_000);
-    expect(perCallTimeout(-500, 30_000)).toBe(1_000);
+  it('returns a non-positive value once the deadline is spent (then callWithTimeout fails fast)', () => {
+    expect(perCallTimeout(0, 30_000)).toBe(0);
+    expect(perCallTimeout(-500, 30_000)).toBe(-500);
   });
 });

--- a/test/unit/poll-timeout.test.ts
+++ b/test/unit/poll-timeout.test.ts
@@ -22,20 +22,6 @@ describe('callWithTimeout', () => {
     expect((err as Error).message).toMatch(/exec credential/);
   });
 
-  it('fails fast without starting the op when there is no budget left', async () => {
-    let started = false;
-    const err = await callWithTimeout(
-      () => {
-        started = true;
-        return Promise.resolve('nope');
-      },
-      0,
-      'read Foo/bar'
-    ).catch((e) => e);
-    expect(err).toBeInstanceOf(PollTimeoutError);
-    expect(started).toBe(false);
-  });
-
   it('propagates the op own rejection (not the timeout) when it fails fast', async () => {
     const boom = () => Promise.reject(new Error('boom'));
     await expect(callWithTimeout(boom, 1_000, 'op')).rejects.toThrow('boom');
@@ -58,7 +44,7 @@ describe('perCallTimeout', () => {
     expect(perCallTimeout(200, 30_000)).toBe(200);
   });
 
-  it('returns a non-positive value once the deadline is spent (then callWithTimeout fails fast)', () => {
+  it('returns a non-positive value once the deadline is spent (callers must break to their overall timeout)', () => {
     expect(perCallTimeout(0, 30_000)).toBe(0);
     expect(perCallTimeout(-500, 30_000)).toBe(-500);
   });


### PR DESCRIPTION
## Problem

Readiness polls (`waitForKroInstanceReady`, `ResourceReadinessChecker.waitForResourceReadyWithPolling`) loop as:

```ts
while (Date.now() - startTime < timeout) { await k8sApi.read(...) }
```

The deadline is only re-evaluated **between** iterations, so it relies on each `await` eventually settling. When the kubeconfig's exec credential **wedges** — e.g. an AWS SSO / EKS `get-token` credential that expired mid-deploy so the auth plugin never returns — the awaited request never resolves **or** rejects. The loop never re-checks its deadline and the deploy hangs **silently** (observed multi-hour; the configured `timeout` is effectively ignored on the credential-failure path).

## Fix

New `callWithTimeout()` (`src/core/deployment/poll-timeout.ts`) bounds each readiness API call to `DEFAULT_HTTP_READ_TIMEOUT`, capped **strictly** by the poll's remaining deadline (`perCallTimeout`) so one call can't overshoot the overall `timeout`. A wedge becomes a **rejection**, so the existing error handling runs and the deadline is honored.

Distinct failure modes are kept distinct:
- **A call that actually started and timed out** → `PollTimeoutError` (credential-wedge hint). In `waitForKroInstanceReady` the outer catch re-throws it (fail fast); in `waitForResourceReadyWithPolling` it's logged and retried within the deadline.
- **The overall deadline already elapsed** (per-call budget ≤ 0) → the caller **breaks** and throws its own overall-timeout error (`DeploymentTimeoutError` / `ResourceReadinessTimeoutError`). These are never conflated.

Related correctness:
- The RGD status-schema read is bounded too, and its `PollTimeoutError` is **re-thrown** rather than swallowed by the permissive 'RGD unfetchable' path (which would declare an ACTIVE/synced instance ready without validating expected status fields). A deadline re-check guards the ready-return.
- The retry sleep and the on-timeout debug log never run past the deadline: the sleep is capped to the remaining budget, and the debug log reuses the **last observed** resource instead of issuing a fresh post-deadline read.

## Scope / limitation (finding acknowledged)
This bounds the caller's `await` (poll + deploy terminate with an actionable error). It does **not** cancel the in-flight request or kill a wedged exec-auth subprocess: `@kubernetes/client-node` 1.3.0's `read()` doesn't thread an `AbortSignal` to fetch and `ExecAuth` spawns the credential via `child_process.spawn` with no cancellation hook. That's documented in `poll-timeout.ts`; the durable cure for the exec-wedge is avoiding per-request exec auth during polling (a pre-minted bearer token in the kubeconfig).

## Tests
- `test/unit/poll-timeout.test.ts`: never-settles → `PollTimeoutError` with credential hint; real rejections propagate; timer cleared; `perCallTimeout` caps strictly to remaining (no floor) and returns ≤0 when spent.
- `test/unit/kro-readiness.test.ts`: wedged RGD read fails fast (not false-ready); an exhausted deadline throws `DeploymentTimeoutError`, not `PollTimeoutError`.
- Full unit suite: **4850 pass, 0 fail**; `tsc` + `biome` clean.