### PR TITLE
Expose single-node Ceph daemon resource sizing

### DIFF
--- a/docs/advanced/arktype-schemas.md
+++ b/docs/advanced/arktype-schemas.md
@@ -104,6 +104,16 @@ const ConfigSpec = type({
 | `'string[]'` | `[]string` |
 | `'"a" \| "b"'` | `string \| enum="a,b"` |
 
+### Nullable fields in KRO mode
+
+KRO SimpleSchema has no syntax for an explicitly nullable field. TypeKro therefore rejects ArkType
+spec fields such as `type({ value: SomeSchema.or('null') })` when generating a KRO graph instead of
+silently changing `T | null` into `T` or `T | undefined`.
+
+Use an optional field when omission expresses the intended state, and use `Cel.default(value,
+fallback)` for graph-aware defaults. Use direct mode when explicit `null` is part of the required
+input contract.
+
 ## Real-World Example
 
 ```typescript

--- a/docs/advanced/arktype-schemas.md
+++ b/docs/advanced/arktype-schemas.md
@@ -108,7 +108,8 @@ const ConfigSpec = type({
 
 KRO SimpleSchema has no syntax for an explicitly nullable field. TypeKro therefore rejects ArkType
 spec fields such as `type({ value: SomeSchema.or('null') })` when generating a KRO graph instead of
-silently changing `T | null` into `T` or `T | undefined`.
+silently changing `T | null` into `T` or `T | undefined`. This also applies recursively to nullable
+array members, nested collection members, and record values.
 
 Use an optional field when omission expresses the intended state, and use `Cel.default(value,
 fallback)` for graph-aware defaults. Use direct mode when explicit `null` is part of the required

--- a/docs/api/rook/index.md
+++ b/docs/api/rook/index.md
@@ -122,8 +122,26 @@ await local.deploy({
   storageSize: '16Gi',
   objectStoreName: 'application-objects',
   bucketStorageClassName: 'application-buckets-retain',
+  resources: {
+    // Each supplied daemon entry replaces that daemon's development default.
+    // This cluster has enough memory for a less constrained OSD.
+    osd: {
+      requests: { cpu: '500m', memory: '2Gi' },
+      limits: { memory: '4Gi' },
+    },
+  },
 });
 ```
+
+The development profile has deliberately small defaults for `mon`, `mgr`,
+`osd`, `prepareosd`, and `rgw`. Use the optional `resources` map when the
+defaults do not fit the target node. Each daemon entry is independent, so an
+OSD override does not require restating the monitor, manager, prepare job, or
+gateway defaults. A supplied entry replaces that daemon's complete resource
+requirements; specify every request and limit that the daemon should retain.
+The same values are admitted and rendered in direct and KRO modes, including
+the OSD resource requirements on its storage device set and the RGW gateway
+requirements on the separately materialized `CephObjectStore`.
 
 The production profile requires the availability and operational decisions
 that the local profile deliberately supplies as unsafe single-node defaults:

--- a/src/core/composition/context.ts
+++ b/src/core/composition/context.ts
@@ -114,6 +114,8 @@ export interface CompositionContext {
   singletonDefinitions?: Map<string, SingletonDefinitionRecord>;
   /** True when this context is a direct-mode re-execution. */
   isReExecution?: boolean | undefined;
+  /** Suppress resource-construction warnings during internal analysis executions. */
+  suppressResourceDiagnostics?: boolean | undefined;
   /** Deployment modes supported by the composition owning this context. */
   supportedModes?: readonly ('direct' | 'kro')[];
   /**
@@ -145,6 +147,8 @@ export interface CompositionContextOptions {
    * pass (which generates CEL) and only run the spec-driven execution.
    */
   isReExecution?: boolean;
+  /** Suppress resource-construction warnings during internal analysis executions. */
+  suppressResourceDiagnostics?: boolean;
   /** Deployment modes supported by the composition owning this context. */
   supportedModes?: readonly ('direct' | 'kro')[];
   /**
@@ -262,6 +266,7 @@ export function createCompositionContext(
     nestedStatusSnapshots: new Map(),
     singletonDefinitions: new Map(),
     isReExecution: contextOptions?.isReExecution,
+    suppressResourceDiagnostics: contextOptions?.suppressResourceDiagnostics,
     ...(contextOptions?.supportedModes ? { supportedModes: contextOptions.supportedModes } : {}),
     isNestedCall: contextOptions?.isNestedCall,
     addResource(id: string, resource: Enhanced<unknown, unknown>) {

--- a/src/core/composition/imperative.ts
+++ b/src/core/composition/imperative.ts
@@ -445,6 +445,7 @@ function executeNestedCompositionWithSpec<
   const uniqueExecutionName = `${compositionName}-execution-${++globalCompositionCounter}`;
   const executionContext = createCompositionContext(uniqueExecutionName, {
     ...(parentContext.isReExecution ? { isReExecution: true } : {}),
+    ...(parentContext.suppressResourceDiagnostics ? { suppressResourceDiagnostics: true } : {}),
     isNestedCall: true,
     ...(options?.supportedModes ? { supportedModes: options.supportedModes } : {}),
   });

--- a/src/core/deployment/crd-manager.ts
+++ b/src/core/deployment/crd-manager.ts
@@ -48,6 +48,13 @@ const BUILT_IN_API_GROUPS = [
   'scheduling.k8s.io/v1',
 ];
 
+type FluxCRDPatcher = (kubeClient: k8s.KubeConfig) => Promise<unknown>;
+
+async function patchFluxCRDs(kubeClient: k8s.KubeConfig): Promise<void> {
+  const { patchFluxCRDSchemas } = await import('../runtime-patches/crd-patcher.js');
+  await patchFluxCRDSchemas(kubeClient);
+}
+
 export class CRDManager {
   private fluxCRDsPatchPromise: Promise<void> | null = null;
   private logger = getComponentLogger('crd-manager');
@@ -56,7 +63,8 @@ export class CRDManager {
     private k8sApi: k8s.KubernetesObjectApi,
     private kubeClient: k8s.KubeConfig,
     private abortableDelay: (ms: number, signal?: AbortSignal) => Promise<void>,
-    private withAbortSignal: <T>(operation: Promise<T>, signal?: AbortSignal) => Promise<T>
+    private withAbortSignal: <T>(operation: Promise<T>, signal?: AbortSignal) => Promise<T>,
+    private fluxCRDPatcher: FluxCRDPatcher = patchFluxCRDs
   ) {}
 
   /**
@@ -141,8 +149,7 @@ export class CRDManager {
       logger[logLevel]('Checking Flux CRDs for Kubernetes 1.33+ compatibility...');
 
       try {
-        const { patchFluxCRDSchemas } = await import('../runtime-patches/crd-patcher.js');
-        await patchFluxCRDSchemas(this.kubeClient);
+        await this.fluxCRDPatcher(this.kubeClient);
         logger[logLevel]('Flux CRDs patched successfully');
       } catch (error: unknown) {
         this.fluxCRDsPatchPromise = null;
@@ -364,7 +371,9 @@ export class CRDManager {
         const crdList = crds as unknown as CustomResourceDefinitionList;
         const match = crdList?.items?.find((crd: CustomResourceDefinitionItem) => {
           const spec = crd.spec;
-          return spec?.group === group && spec?.names?.kind === kind && !crd.metadata?.deletionTimestamp;
+          return (
+            spec?.group === group && spec?.names?.kind === kind && !crd.metadata?.deletionTimestamp
+          );
         });
         if (match?.metadata?.name && match.spec?.names?.plural) {
           crdName = match.metadata.name;

--- a/src/core/proxy/create-resource.ts
+++ b/src/core/proxy/create-resource.ts
@@ -550,7 +550,11 @@ export function createResource<TSpec extends object, TStatus extends object>(
       );
     }
 
-    if (options?.scope === 'namespaced' && !hasNamespace) {
+    if (
+      options?.scope === 'namespaced' &&
+      !hasNamespace &&
+      !getCurrentCompositionContext()?.suppressResourceDiagnostics
+    ) {
       debugLogger.warn(
         `${resource.kind} is namespaced but no namespace specified. Kubernetes will use 'default'.`,
         {

--- a/src/core/references/cel.ts
+++ b/src/core/references/cel.ts
@@ -3,7 +3,7 @@ import { isCelExpression, isKubernetesRef } from '../../utils/type-guards.js';
 import { CEL_EXPRESSION_BRAND, KUBERNETES_REF_MARKER_SOURCE } from '../constants/brands.js';
 import { TypeKroError } from '../errors.js';
 import { getComponentLogger } from '../logging/index.js';
-import { getInnerCelPath } from '../serialization/cel-references.js';
+import { celLiteralForValueTree, getInnerCelPath } from '../serialization/cel-references.js';
 import type { CelExpression, RefOrValue } from '../types.js';
 
 const logger = getComponentLogger('cel');
@@ -295,7 +295,7 @@ function math<T = unknown>(
  * properly quotes string literals and converts marker strings
  * (containing `__KUBERNETES_REF__` tokens) to CEL concatenation.
  */
-function celValueForTernary(value: RefOrValue<CelValue>): string {
+function celValueForTernary(value: RefOrValue<unknown>): string {
   if (isKubernetesRef(value)) {
     return getInnerCelPath(value);
   }
@@ -307,6 +307,9 @@ function celValueForTernary(value: RefOrValue<CelValue>): string {
   }
   if (value === null || value === undefined) {
     return '""';
+  }
+  if (typeof value === 'object') {
+    return celLiteralForValueTree(value, undefined, 'cel.ternary');
   }
   const str = String(value);
   // Check for __KUBERNETES_REF__ markers from template literal coercion.
@@ -403,12 +406,30 @@ function cond<T = unknown>(
  * Use a value when its optional CEL path is present, otherwise use a fallback.
  *
  * This is shorthand for `has(value) ? value : fallback` with the same literal
- * quoting and template-marker handling as {@link cond}.
+ * quoting and template-marker handling as {@link cond}. Object and array
+ * fallbacks are serialized as structured CEL literals, so integrations can
+ * preserve `value ?? fallback` semantics without inspecting schema proxies.
+ *
+ * With concrete direct-mode values, this evaluates as native JavaScript `??`.
  */
 function defaultValue<T extends CelValue>(
   value: RefOrValue<T>,
   fallback: RefOrValue<NonNullable<T>>
-): CelExpression<NonNullable<T>> & NonNullable<T> {
+): CelExpression<NonNullable<T>> & NonNullable<T>;
+function defaultValue<T extends object | null | undefined>(
+  value: RefOrValue<T>,
+  fallback: RefOrValue<NonNullable<T>>
+): CelExpression<NonNullable<T>> & NonNullable<T>;
+function defaultValue(
+  value: RefOrValue<unknown>,
+  fallback: RefOrValue<unknown>
+): CelExpression<unknown> | unknown {
+  // Preserve ordinary JavaScript `??` semantics in direct mode. Schema/resource
+  // refs and nested CEL expressions take the graph path below.
+  if (!isKubernetesRef(value) && !isCelExpression(value)) {
+    return value ?? fallback;
+  }
+
   const guard = isKubernetesRef(value)
     ? (schemaSpecHasGuard(getInnerCelPath(value)) ?? has(value).expression)
     : has(value).expression;
@@ -417,16 +438,11 @@ function defaultValue<T extends CelValue>(
   return {
     [CEL_EXPRESSION_BRAND]: true,
     expression,
-  } as CelExpression<NonNullable<T>> & NonNullable<T>;
+  } as CelExpression<unknown>;
 }
 
 /** Alias for {@link defaultValue}. */
-function coalesce<T extends CelValue>(
-  value: RefOrValue<T>,
-  fallback: RefOrValue<NonNullable<T>>
-): CelExpression<NonNullable<T>> & NonNullable<T> {
-  return defaultValue(value, fallback);
-}
+const coalesce: typeof defaultValue = defaultValue;
 
 /**
  * Creates a mixed string template that combines literal strings with CEL expressions

--- a/src/core/references/cel.ts
+++ b/src/core/references/cel.ts
@@ -403,12 +403,12 @@ function cond<T = unknown>(
 }
 
 /**
- * Use a value when its optional CEL path is present, otherwise use a fallback.
+ * Use a value when its CEL path is present and non-null, otherwise use a fallback.
  *
- * This is shorthand for `has(value) ? value : fallback` with the same literal
- * quoting and template-marker handling as {@link cond}. Object and array
- * fallbacks are serialized as structured CEL literals, so integrations can
- * preserve `value ?? fallback` semantics without inspecting schema proxies.
+ * This is shorthand for `has(value) && value != null ? value : fallback` with
+ * the same literal quoting and template-marker handling as {@link cond}. Object
+ * and array fallbacks are serialized as structured CEL literals, so integrations
+ * can preserve `value ?? fallback` semantics without inspecting schema proxies.
  *
  * With concrete direct-mode values, this evaluates as native JavaScript `??`.
  */
@@ -433,7 +433,8 @@ function defaultValue(
   const guard = isKubernetesRef(value)
     ? (schemaSpecHasGuard(getInnerCelPath(value)) ?? has(value).expression)
     : has(value).expression;
-  const expression = `${guard} ? ${celValueForTernary(value)} : ${celValueForTernary(fallback)}`;
+  const celValue = celValueForTernary(value);
+  const expression = `${guard} && ${celValue} != null ? ${celValue} : ${celValueForTernary(fallback)}`;
 
   return {
     [CEL_EXPRESSION_BRAND]: true,
@@ -616,7 +617,7 @@ export const Cel = {
   join,
   conditional,
   cond,
-  /** Shorthand for `has(value) ? value : fallback`. */
+  /** Shorthand for `has(value) && value != null ? value : fallback`. */
   default: defaultValue,
   /** Alias for `Cel.default(...)`. */
   coalesce,

--- a/src/core/serialization/cel-references.ts
+++ b/src/core/serialization/cel-references.ts
@@ -968,7 +968,7 @@ function finalizeValueTreeCelForKro(
   return `\${${resolved}}`;
 }
 
-function celLiteralForValueTree(
+export function celLiteralForValueTree(
   value: unknown,
   context: SerializationContext | undefined,
   path: string

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -416,6 +416,8 @@ function resolveDefaultsByReExecution(
       if (defaultsRes) {
         extractDefaultsByComparison(proxyRes, defaultsRes, defaults);
         extractStructuredFallbacksByComparison(
+          compositionFn,
+          specJson,
           proxyRes,
           defaultsRes,
           id,
@@ -484,6 +486,7 @@ const FULL_MARKER_RE = new RegExp(`^${SCHEMA_MARKER_PATTERN_SOURCE}$`);
 type Leaf =
   | { kind: 'field'; field: string }
   | { kind: 'literal'; value: string | number | boolean }
+  | { kind: 'structured'; value: readonly unknown[] | Record<string, unknown> }
   | { kind: 'none' };
 
 /** Classify a single output-leaf value (marker-ref vs literal vs other). */
@@ -495,6 +498,10 @@ function classifyLeaf(value: unknown): Leaf {
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
     if (isSentinelDerivedValue(value)) return { kind: 'none' };
     return { kind: 'literal', value };
+  }
+  if (Array.isArray(value)) return { kind: 'structured', value };
+  if (value !== null && typeof value === 'object') {
+    return { kind: 'structured', value: value as Record<string, unknown> };
   }
   return { kind: 'none' };
 }
@@ -611,6 +618,8 @@ function presenceGuard(field: string): string {
  * Choosing the whole object preserves JavaScript replacement semantics.
  */
 function extractStructuredFallbacksByComparison(
+  compositionFn: (...args: unknown[]) => unknown,
+  specJson: unknown,
   proxyValue: unknown,
   fallbackValue: unknown,
   resourceId: string,
@@ -623,6 +632,8 @@ function extractStructuredFallbacksByComparison(
   // defaults nested inside helpers are captured before runtime merge lowering.
   if (isValuesMergeExpression(proxyValue) && !isValuesMergeExpression(fallbackValue)) {
     extractStructuredFallbacksByComparison(
+      compositionFn,
+      specJson,
       proxyValue.base,
       fallbackValue,
       resourceId,
@@ -645,11 +656,34 @@ function extractStructuredFallbacksByComparison(
     ) {
       try {
         const field = exactMarker.slice('spec.'.length);
+        const probeResource = runProbe(
+          compositionFn,
+          specJson,
+          new Set<string>([field]),
+          resourceId
+        );
+        const probedFallback = readAtPath(probeResource, path);
+        if (
+          !Array.isArray(probedFallback) &&
+          (probedFallback === null || typeof probedFallback !== 'object')
+        ) {
+          return;
+        }
         const fallbackCel = celLiteralForValueTree(
           fallbackValue,
           undefined,
           `structured-default.${resourceId}.${path.join('.')}`
         );
+        const probedFallbackCel = celLiteralForValueTree(
+          probedFallback,
+          undefined,
+          `structured-default.${resourceId}.${path.join('.')}`
+        );
+        // A proxy/default diff can also be produced by an unrelated conditional,
+        // for example `spec.enabled ? spec.resources : defaults`. Confirm that
+        // removing the referenced field itself selects this exact fallback before
+        // attributing the behavior to nullish coalescing.
+        if (probedFallbackCel !== fallbackCel) return;
         out.push({
           resourceId,
           path: [...path],
@@ -669,6 +703,8 @@ function extractStructuredFallbacksByComparison(
   if (Array.isArray(proxyValue) && Array.isArray(fallbackValue)) {
     for (let index = 0; index < Math.min(proxyValue.length, fallbackValue.length); index++) {
       extractStructuredFallbacksByComparison(
+        compositionFn,
+        specJson,
         proxyValue[index],
         fallbackValue[index],
         resourceId,
@@ -687,6 +723,8 @@ function extractStructuredFallbacksByComparison(
   ) {
     for (const key of Object.keys(proxyValue as Record<string, unknown>)) {
       extractStructuredFallbacksByComparison(
+        compositionFn,
+        specJson,
         (proxyValue as Record<string, unknown>)[key],
         (fallbackValue as Record<string, unknown>)[key],
         resourceId,
@@ -698,22 +736,42 @@ function extractStructuredFallbacksByComparison(
 }
 
 /** Render the chain's CEL: <guard(a)> ? a : (<guard(b)> ? b : <tail>). */
-function buildChainCel(chain: string[], tail: Leaf): string {
-  const tailCel =
-    tail.kind === 'literal'
-      ? typeof tail.value === 'string'
-        ? `"${escapeCelString(tail.value)}"`
-        : String(tail.value)
-      : tail.kind === 'field'
-        ? celField(tail.field)
-        : 'omit()';
-  let expr = tailCel;
-  let nested = false;
-  for (const f of [...chain].reverse()) {
-    expr = `${presenceGuard(f)} ? ${celField(f)} : ${nested ? `(${expr})` : expr}`;
-    nested = true;
+function buildChainCel(
+  chain: string[],
+  tail: Leaf,
+  resourceId: string,
+  path: string[]
+): string | undefined {
+  try {
+    const tailCel =
+      tail.kind === 'literal'
+        ? typeof tail.value === 'string'
+          ? `"${escapeCelString(tail.value)}"`
+          : String(tail.value)
+        : tail.kind === 'field'
+          ? celField(tail.field)
+          : tail.kind === 'structured'
+            ? `(${celLiteralForValueTree(
+                tail.value,
+                undefined,
+                `structured-coalesce.${resourceId}.${path.join('.')}`
+              )})`
+            : 'omit()';
+    let expr = tailCel;
+    let nested = false;
+    for (const f of [...chain].reverse()) {
+      expr = `${presenceGuard(f)} ? ${celField(f)} : ${nested ? `(${expr})` : expr}`;
+      nested = true;
+    }
+    return `\${${expr}}`;
+  } catch (error) {
+    logger.debug('Skipping non-serializable structured coalescing fallback', {
+      resourceId,
+      path: path.join('.'),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
   }
-  return `\${${expr}}`;
 }
 
 /**
@@ -764,8 +822,11 @@ function reconstructCrossFieldChains(
     // existing default/omit-wrapping mechanisms, so this change can't regress them.
     const [head] = chain;
     if (chain.length >= 2 && head !== undefined) {
-      delete defaults[head];
-      out.push({ resourceId, path, cel: buildChainCel(chain, tail) });
+      const cel = buildChainCel(chain, tail, resourceId, path);
+      if (cel !== undefined) {
+        delete defaults[head];
+        out.push({ resourceId, path, cel });
+      }
     }
   }
 }

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -778,6 +778,10 @@ function collectOptionalSchemaPaths(node: unknown): Set<string> {
   const paths = new Set<string>();
 
   const walk = (current: unknown, prefix: string): void => {
+    if (Array.isArray(current)) {
+      for (const branch of current) walk(branch, prefix);
+      return;
+    }
     if (current === null || typeof current !== 'object') return;
     const objectNode = current as {
       required?: Array<{ key: string; value?: unknown }>;

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -11,6 +11,7 @@ import { KUBERNETES_REF_SCHEMA_MARKER_SOURCE } from '../../shared/brands.js';
 import { escapeCelString } from '../../utils/cel-escape.js';
 import { pascalCase } from '../../utils/string.js';
 import { createCompositionContext, runWithCompositionContext } from '../composition/context.js';
+import { isValuesMergeExpression } from '../aspects/values-merge.js';
 import { getComponentLogger } from '../logging/index.js';
 import { getMetadataField } from '../metadata/index.js';
 import { createSchemaProxy } from '../references/index.js';
@@ -22,7 +23,7 @@ import type {
 import { getCompositionAnalysisMetadata } from '../composition/analysis-metadata.js';
 import type { KroCompatibleType, KroSimpleSchema, KubernetesResource } from '../types.js';
 import { separateStatusFields } from '../validation/cel-validator.js';
-import { serializeStatusMappingsToCel } from './cel-references.js';
+import { celLiteralForValueTree, serializeStatusMappingsToCel } from './cel-references.js';
 
 const logger = getComponentLogger('schema-defaults');
 const SCHEMA_MARKER_PATTERN_SOURCE = KUBERNETES_REF_SCHEMA_MARKER_SOURCE;
@@ -312,6 +313,13 @@ interface ReExecutionResult {
    * multi-field `has(...) ? ... : ...` chains it cannot express.
    */
   crossFieldOverrides: Array<{ resourceId: string; path: string[]; cel: string }>;
+  /**
+   * Structured single-field fallbacks (`spec.resources?.osd ?? DEFAULT_OSD`)
+   * captured by executing the real composition/helper graph with optionals absent.
+   * KRO SimpleSchema cannot represent object-valued defaults, so these are
+   * lowered into presence-guarded CEL at the exact resource template path.
+   */
+  structuredFallbackOverrides: Array<{ resourceId: string; path: string[]; cel: string }>;
 }
 
 /**
@@ -400,12 +408,20 @@ function resolveDefaultsByReExecution(
     }
 
     const crossFieldOverrides: ReExecutionResult['crossFieldOverrides'] = [];
+    const structuredFallbackOverrides: ReExecutionResult['structuredFallbackOverrides'] = [];
     for (const [id, proxyRes] of proxyEntries) {
       const defaultsRes = defaultsMap.get(id);
       // Literal-default + ternary extraction need the defaults-run counterpart;
       // skip them when it's absent (only in the proxy run, or the defaults run threw).
       if (defaultsRes) {
         extractDefaultsByComparison(proxyRes, defaultsRes, defaults);
+        extractStructuredFallbacksByComparison(
+          proxyRes,
+          defaultsRes,
+          id,
+          [],
+          structuredFallbackOverrides
+        );
         extractTernaryConditionals(
           proxyRes,
           defaultsRes,
@@ -429,8 +445,11 @@ function resolveDefaultsByReExecution(
     const hasResults =
       Object.keys(defaults).length > 0 ||
       ternaryConditionals.length > 0 ||
-      crossFieldOverrides.length > 0;
-    return hasResults ? { defaults, ternaryConditionals, crossFieldOverrides } : undefined;
+      crossFieldOverrides.length > 0 ||
+      structuredFallbackOverrides.length > 0;
+    return hasResults
+      ? { defaults, ternaryConditionals, crossFieldOverrides, structuredFallbackOverrides }
+      : undefined;
   } catch (err) {
     // Best-effort: composition functions with undefined spec fields may throw
     // (e.g., accessing spec.nested.field without optional chaining). Log at
@@ -583,6 +602,99 @@ const celField = (field: string): string => `schema.spec.${field}`;
 function presenceGuard(field: string): string {
   const segs = field.split('.');
   return segs.map((_, i) => `has(schema.spec.${segs.slice(0, i + 1).join('.')})`).join(' && ');
+}
+
+/**
+ * Capture object/array-valued `??` fallbacks without teaching integrations
+ * about schema proxies. The proxy run contributes the exact `spec.X` marker;
+ * the optionals-absent run contributes the concrete structured fallback.
+ * Choosing the whole object preserves JavaScript replacement semantics.
+ */
+function extractStructuredFallbacksByComparison(
+  proxyValue: unknown,
+  fallbackValue: unknown,
+  resourceId: string,
+  path: string[],
+  out: ReExecutionResult['structuredFallbackOverrides']
+): void {
+  // A graph-aware optional `values` overlay can make the proxy run a
+  // ValuesMergeExpression while the optionals-absent run remains the plain
+  // base object. Compare the authored base against that concrete fallback so
+  // defaults nested inside helpers are captured before runtime merge lowering.
+  if (isValuesMergeExpression(proxyValue) && !isValuesMergeExpression(fallbackValue)) {
+    extractStructuredFallbacksByComparison(
+      proxyValue.base,
+      fallbackValue,
+      resourceId,
+      [...path, 'base'],
+      out
+    );
+    return;
+  }
+
+  const proxyString =
+    typeof proxyValue === 'function' || typeof proxyValue === 'string'
+      ? String(proxyValue)
+      : undefined;
+  const exactMarker = proxyString?.match(FULL_MARKER_RE)?.[1];
+
+  if (exactMarker?.startsWith('spec.')) {
+    if (
+      Array.isArray(fallbackValue) ||
+      (fallbackValue !== null && typeof fallbackValue === 'object')
+    ) {
+      try {
+        const field = exactMarker.slice('spec.'.length);
+        const fallbackCel = celLiteralForValueTree(
+          fallbackValue,
+          undefined,
+          `structured-default.${resourceId}.${path.join('.')}`
+        );
+        out.push({
+          resourceId,
+          path: [...path],
+          cel: `\${${presenceGuard(field)} ? ${celField(field)} : (${fallbackCel})}`,
+        });
+      } catch (error) {
+        logger.debug('Skipping non-serializable structured fallback', {
+          resourceId,
+          path: path.join('.'),
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    return;
+  }
+
+  if (Array.isArray(proxyValue) && Array.isArray(fallbackValue)) {
+    for (let index = 0; index < Math.min(proxyValue.length, fallbackValue.length); index++) {
+      extractStructuredFallbacksByComparison(
+        proxyValue[index],
+        fallbackValue[index],
+        resourceId,
+        [...path, String(index)],
+        out
+      );
+    }
+    return;
+  }
+
+  if (
+    proxyValue !== null &&
+    typeof proxyValue === 'object' &&
+    fallbackValue !== null &&
+    typeof fallbackValue === 'object'
+  ) {
+    for (const key of Object.keys(proxyValue as Record<string, unknown>)) {
+      extractStructuredFallbacksByComparison(
+        (proxyValue as Record<string, unknown>)[key],
+        (fallbackValue as Record<string, unknown>)[key],
+        resourceId,
+        [...path, key],
+        out
+      );
+    }
+  }
 }
 
 /** Render the chain's CEL: <guard(a)> ? a : (<guard(b)> ? b : <tail>). */
@@ -1338,6 +1450,9 @@ export function arktypeToKroSchema(
     if (reExecutionResult) {
       applyNullishDefaults(specFields, reExecutionResult.defaults, true);
       ternaryConditionals.push(...reExecutionResult.ternaryConditionals);
+      for (const override of reExecutionResult.structuredFallbackOverrides) {
+        setAtResourcePath(resources[override.resourceId], override.path, override.cel);
+      }
       // Cross-field `??` chains reconstructed by probing: write each CEL conditional
       // directly at its resource path (overwriting the bare head-field marker).
       for (const ov of reExecutionResult.crossFieldOverrides) {

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -797,9 +797,48 @@ function collectSchemaFieldPaths(node: unknown): SchemaFieldPaths {
     }
     if (current === null || typeof current !== 'object') return;
     const objectNode = current as {
+      defaultables?: [unknown, unknown][];
+      sequence?: unknown;
+      proto?: unknown;
+      index?: Array<{ value?: unknown }>;
+      optionals?: unknown[];
+      postfix?: unknown[];
+      prefix?: unknown[];
       required?: Array<{ key: string; value?: unknown }>;
       optional?: Array<{ key: string; value?: unknown }>;
+      variadic?: unknown;
     };
+
+    const walkCollectionMember = (member: unknown, path: string): void => {
+      if (schemaNodeAllowsNull(member)) nullable.add(path);
+      walk(member, path);
+    };
+
+    if (objectNode.proto === 'Array' && objectNode.sequence !== undefined) {
+      const elementPath = `${prefix}[]`;
+      walkCollectionMember(objectNode.sequence, elementPath);
+    }
+
+    for (const [index, member] of (objectNode.prefix ?? []).entries()) {
+      walkCollectionMember(member, `${prefix}[${index}]`);
+    }
+    for (const [index, member] of (objectNode.optionals ?? []).entries()) {
+      walkCollectionMember(member, `${prefix}[optional:${index}]`);
+    }
+    for (const [index, entry] of (objectNode.defaultables ?? []).entries()) {
+      walkCollectionMember(entry[0], `${prefix}[defaultable:${index}]`);
+    }
+    if (objectNode.variadic !== undefined) {
+      walkCollectionMember(objectNode.variadic, `${prefix}[]`);
+    }
+    for (const [index, member] of (objectNode.postfix ?? []).entries()) {
+      walkCollectionMember(member, `${prefix}[postfix:${index}]`);
+    }
+
+    for (const entry of objectNode.index ?? []) {
+      const valuePath = prefix ? `${prefix}.*` : '*';
+      walkCollectionMember(entry.value, valuePath);
+    }
 
     for (const entry of objectNode.optional ?? []) {
       const path = prefix ? `${prefix}.${entry.key}` : entry.key;

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -352,7 +352,7 @@ function resolveDefaultsByReExecution(
     // Build the set of optional top-level field names. Only optional fields
     // can be ternary-controlled (required fields always have a value).
     const optionalFieldNames = new Set((specJson.optional ?? []).map((p) => p.key));
-    const optionalFieldPaths = collectOptionalSchemaPaths(specJson);
+    const nullishFieldPaths = collectNullishSchemaPaths(specJson);
 
     const tempCtx = createCompositionContext('defaults-extraction', {
       suppressResourceDiagnostics: true,
@@ -433,7 +433,7 @@ function resolveDefaultsByReExecution(
         specJson,
         proxyRes,
         id,
-        optionalFieldPaths,
+        nullishFieldPaths,
         ambiguousStructuredFallbacks
       );
       // Cross-field `??` chain reconstruction is independent of the defaults run —
@@ -630,7 +630,11 @@ function collectAmbiguityCandidateLeaves(
  * Driving presence this way lets a probe reveal which field a `??` chain falls
  * through to when earlier links are absent.
  */
-function buildProbeSpec(specJson: unknown, absent: Set<string>): unknown {
+function buildProbeSpec(
+  specJson: unknown,
+  absent: Set<string>,
+  overrides: ReadonlyMap<string, unknown> = new Map()
+): unknown {
   const root = (createSchemaProxy(specJson) as { spec: unknown }).spec;
   const wrap = (target: object, prefix: string): unknown =>
     new Proxy(target, {
@@ -638,8 +642,11 @@ function buildProbeSpec(specJson: unknown, absent: Set<string>): unknown {
         if (typeof prop !== 'string') return Reflect.get(t, prop);
         const full = prefix ? `${prefix}.${prop}` : prop;
         if (absent.has(full)) return undefined;
+        if (overrides.has(full)) return overrides.get(full);
         const v = (t as Record<string, unknown>)[prop];
-        const hasDeeperMutation = [...absent].some((a) => a.startsWith(`${full}.`));
+        const hasDeeperMutation =
+          [...absent].some((a) => a.startsWith(`${full}.`)) ||
+          [...overrides.keys()].some((path) => path.startsWith(`${full}.`));
         if (hasDeeperMutation && v && (typeof v === 'object' || typeof v === 'function')) {
           return wrap(v as object, full);
         }
@@ -654,14 +661,15 @@ function runProbe(
   compositionFn: (...args: unknown[]) => unknown,
   specJson: unknown,
   absent: Set<string>,
-  resourceId: string
+  resourceId: string,
+  overrides: ReadonlyMap<string, unknown> = new Map()
 ): Record<string, unknown> | undefined {
   try {
     const ctx = createCompositionContext('cross-field-probe', {
       suppressResourceDiagnostics: true,
     });
     runWithCompositionContext(ctx, () => {
-      compositionFn(buildProbeSpec(specJson, absent));
+      compositionFn(buildProbeSpec(specJson, absent, overrides));
     });
     return (ctx.resources as Record<string, Record<string, unknown>>)[resourceId];
   } catch {
@@ -774,8 +782,21 @@ interface ProbeValueRead {
   ambiguousNormalization: boolean;
 }
 
-function collectOptionalSchemaPaths(node: unknown): Set<string> {
-  const paths = new Set<string>();
+interface NullishSchemaPaths {
+  optional: Set<string>;
+  nullable: Set<string>;
+}
+
+function schemaNodeAllowsNull(node: unknown): boolean {
+  if (Array.isArray(node)) return node.some(schemaNodeAllowsNull);
+  if (node === null || typeof node !== 'object') return false;
+  const record = node as Record<string, unknown>;
+  return Object.hasOwn(record, 'unit') && record.unit === null;
+}
+
+function collectNullishSchemaPaths(node: unknown): NullishSchemaPaths {
+  const optional = new Set<string>();
+  const nullable = new Set<string>();
 
   const walk = (current: unknown, prefix: string): void => {
     if (Array.isArray(current)) {
@@ -790,24 +811,32 @@ function collectOptionalSchemaPaths(node: unknown): Set<string> {
 
     for (const entry of objectNode.optional ?? []) {
       const path = prefix ? `${prefix}.${entry.key}` : entry.key;
-      paths.add(path);
+      optional.add(path);
+      if (schemaNodeAllowsNull(entry.value)) nullable.add(path);
       walk(entry.value, path);
     }
     for (const entry of objectNode.required ?? []) {
       const path = prefix ? `${prefix}.${entry.key}` : entry.key;
+      if (schemaNodeAllowsNull(entry.value)) nullable.add(path);
       walk(entry.value, path);
     }
   };
 
   walk(node, '');
-  return paths;
+  return { optional, nullable };
 }
 
-function canSchemaFieldBeAbsent(field: string, optionalFieldPaths: ReadonlySet<string>): boolean {
-  for (const optionalPath of optionalFieldPaths) {
-    if (field === optionalPath || field.startsWith(`${optionalPath}.`)) return true;
+function matchingAncestorPath(field: string, paths: ReadonlySet<string>): string | undefined {
+  let match: string | undefined;
+  for (const path of paths) {
+    if (
+      (field === path || field.startsWith(`${path}.`)) &&
+      (match === undefined || path.length > match.length)
+    ) {
+      match = path;
+    }
   }
-  return false;
+  return match;
 }
 
 function readProbeValueAtPath(
@@ -861,7 +890,7 @@ function probeAmbiguousStructuredFallbacks(
   specJson: unknown,
   proxyResource: Record<string, unknown>,
   resourceId: string,
-  optionalFieldPaths: ReadonlySet<string>,
+  nullishFieldPaths: NullishSchemaPaths,
   out: ReExecutionResult['ambiguousStructuredFallbacks']
 ): void {
   const markerLeaves: AmbiguityCandidateLeaf[] = [];
@@ -874,20 +903,44 @@ function probeAmbiguousStructuredFallbacks(
   }
 
   for (const [field, candidates] of candidatesByField) {
-    // Removing a required leaf is not a realizable instance state and can make
-    // unrelated composition/aspect branches disappear. Only fields that are
-    // themselves optional, or descend from an optional parent, can participate
-    // in an implicit nullish fallback.
-    if (!canSchemaFieldBeAbsent(field, optionalFieldPaths)) continue;
-    const probedResource = runProbe(compositionFn, specJson, new Set([field]), resourceId);
+    // Probe only schema-valid nullish states. Optional paths use absence, while
+    // required nullable paths must remain present with a null value. A nullable
+    // ancestor is probed at that ancestor because dereferencing through it is not
+    // itself a valid runtime state. Probe both states when a field is optional
+    // and nullable: authored control flow may distinguish undefined from null
+    // even though JavaScript `??` treats them identically.
+    const optionalPath = matchingAncestorPath(field, nullishFieldPaths.optional);
+    const nullablePath = matchingAncestorPath(field, nullishFieldPaths.nullable);
+    const probedResources: Array<Record<string, unknown> | undefined> = [];
+    if (optionalPath !== undefined) {
+      probedResources.push(
+        runProbe(compositionFn, specJson, new Set([optionalPath]), resourceId)
+      );
+    }
+    if (nullablePath !== undefined) {
+      probedResources.push(
+        runProbe(
+          compositionFn,
+          specJson,
+          new Set(),
+          resourceId,
+          new Map([[nullablePath, null]])
+        )
+      );
+    }
+    if (probedResources.length === 0) continue;
+
     for (const candidate of candidates) {
-      const probeRead = readProbeValueAtPath(proxyResource, probedResource, candidate);
-      const fallbackValue = probeRead.value;
-      if (
-        probeRead.ambiguousNormalization ||
-        Array.isArray(fallbackValue) ||
-        (fallbackValue !== null && typeof fallbackValue === 'object')
-      ) {
+      const ambiguous = probedResources.some((probedResource) => {
+        const probeRead = readProbeValueAtPath(proxyResource, probedResource, candidate);
+        const fallbackValue = probeRead.value;
+        return (
+          probeRead.ambiguousNormalization ||
+          Array.isArray(fallbackValue) ||
+          (fallbackValue !== null && typeof fallbackValue === 'object')
+        );
+      });
+      if (ambiguous) {
         out.push({
           resourceId,
           path: candidate.path,

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -10,8 +10,9 @@ import type { Type } from 'arktype';
 import { KUBERNETES_REF_SCHEMA_MARKER_SOURCE } from '../../shared/brands.js';
 import { escapeCelString } from '../../utils/cel-escape.js';
 import { pascalCase } from '../../utils/string.js';
-import { createCompositionContext, runWithCompositionContext } from '../composition/context.js';
 import { isValuesMergeExpression } from '../aspects/values-merge.js';
+import { getCompositionAnalysisMetadata } from '../composition/analysis-metadata.js';
+import { createCompositionContext, runWithCompositionContext } from '../composition/context.js';
 import { getComponentLogger } from '../logging/index.js';
 import { getMetadataField } from '../metadata/index.js';
 import { createSchemaProxy } from '../references/index.js';
@@ -20,7 +21,6 @@ import type {
   SchemaDefinition,
   TernaryConditional,
 } from '../types/serialization.js';
-import { getCompositionAnalysisMetadata } from '../composition/analysis-metadata.js';
 import type { KroCompatibleType, KroSimpleSchema, KubernetesResource } from '../types.js';
 import { separateStatusFields } from '../validation/cel-validator.js';
 import { celLiteralForValueTree, serializeStatusMappingsToCel } from './cel-references.js';
@@ -643,26 +643,85 @@ interface CounterfactualProbe {
   overrides: Map<string, unknown>;
 }
 
-function isBooleanSchemaNode(node: unknown): boolean {
-  return (
-    node === 'boolean' ||
-    (Array.isArray(node) &&
-      node.some(
-        (branch) =>
-          branch !== null &&
-          typeof branch === 'object' &&
-          'unit' in branch &&
-          typeof branch.unit === 'boolean'
-      ))
-  );
+function numericBoundAdmitsZero(bound: unknown, kind: 'min' | 'max'): boolean {
+  if (bound === undefined) return true;
+  const rule =
+    typeof bound === 'number'
+      ? bound
+      : bound !== null &&
+          typeof bound === 'object' &&
+          typeof Reflect.get(bound, 'rule') === 'number'
+        ? (Reflect.get(bound, 'rule') as number)
+        : undefined;
+  if (rule === undefined) return false;
+  const exclusive =
+    bound !== null && typeof bound === 'object' && Reflect.get(bound, 'exclusive') === true;
+  return kind === 'min'
+    ? rule < 0 || (rule === 0 && !exclusive)
+    : rule > 0 || (rule === 0 && !exclusive);
+}
+
+/**
+ * Return every falsy JavaScript value that the ArkType JSON node admits.
+ * These are useful counterfactuals for required scalar guards: unlike schema
+ * proxies, real strings, numbers, booleans, and null can be falsy.
+ */
+function falsySchemaValues(node: unknown): unknown[] {
+  if (node === 'boolean') return [false];
+  if (node === 'string') return [''];
+  if (node === 'number') return [0];
+  if (node === 'unknown') return [false, 0, '', null];
+  if (node === 'null') return [null];
+  if (Array.isArray(node)) {
+    const values = node.flatMap(falsySchemaValues);
+    return values.filter(
+      (value, index) => values.findIndex((candidate) => Object.is(candidate, value)) === index
+    );
+  }
+  if (node === null || typeof node !== 'object') return [];
+
+  if ('unit' in node) {
+    const unit = Reflect.get(node, 'unit');
+    return !unit ? [unit] : [];
+  }
+  if (
+    Reflect.has(node, 'required') ||
+    Reflect.has(node, 'optional') ||
+    Reflect.get(node, 'proto') === 'Array'
+  ) {
+    return [];
+  }
+
+  const domain = Reflect.get(node, 'domain');
+  if (domain === 'boolean') return [false];
+  if (domain === 'string') {
+    const exactLength = Reflect.get(node, 'exactLength');
+    const minLength = Reflect.get(node, 'minLength');
+    const pattern = Reflect.get(node, 'pattern');
+    const admitsEmpty =
+      (exactLength === undefined || exactLength === 0) &&
+      (minLength === undefined || minLength === 0) &&
+      pattern === undefined;
+    return admitsEmpty ? [''] : [];
+  }
+  if (domain === 'number') {
+    const admitsZero =
+      numericBoundAdmitsZero(Reflect.get(node, 'min'), 'min') &&
+      numericBoundAdmitsZero(Reflect.get(node, 'max'), 'max');
+    return admitsZero ? [0] : [];
+  }
+
+  // ArkType serializes `unknown` as an empty node.
+  if (Object.keys(node).length === 0) return [false, 0, '', null];
+  return [];
 }
 
 /**
  * Build single-field counterfactuals for every schema path other than the
- * candidate and its optional ancestors. Optional fields are removed; boolean
- * fields (including required fields) are also exercised with `false`. Callers
- * ignore hybrid proxy/concrete probes that cannot execute and require every
- * executable counterfactual to preserve the candidate marker.
+ * candidate and its optional ancestors. Optional fields are removed; every
+ * scalar field is also exercised with each falsy value its schema admits.
+ * Callers ignore hybrid proxy/concrete probes that cannot execute and require
+ * every executable counterfactual to preserve the candidate marker.
  */
 function collectCounterfactualProbes(
   node: unknown,
@@ -681,8 +740,10 @@ function collectCounterfactualProbes(
 
   for (const property of objectNode.required ?? []) {
     const path = prefix ? `${prefix}.${property.key}` : property.key;
-    if (!candidateDependsOnPath(path) && isBooleanSchemaNode(property.value)) {
-      out.push({ absent: new Set(), overrides: new Map([[path, false]]) });
+    if (!candidateDependsOnPath(path)) {
+      for (const value of falsySchemaValues(property.value)) {
+        out.push({ absent: new Set(), overrides: new Map([[path, value]]) });
+      }
     }
     collectCounterfactualProbes(property.value, candidate, path, out);
   }
@@ -691,8 +752,8 @@ function collectCounterfactualProbes(
     const path = prefix ? `${prefix}.${property.key}` : property.key;
     if (!candidateDependsOnPath(path)) {
       out.push({ absent: new Set([path]), overrides: new Map() });
-      if (isBooleanSchemaNode(property.value)) {
-        out.push({ absent: new Set(), overrides: new Map([[path, false]]) });
+      for (const value of falsySchemaValues(property.value)) {
+        out.push({ absent: new Set(), overrides: new Map([[path, value]]) });
       }
     }
     collectCounterfactualProbes(property.value, candidate, path, out);

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -352,7 +352,7 @@ function resolveDefaultsByReExecution(
     // Build the set of optional top-level field names. Only optional fields
     // can be ternary-controlled (required fields always have a value).
     const optionalFieldNames = new Set((specJson.optional ?? []).map((p) => p.key));
-    const nullishFieldPaths = collectNullishSchemaPaths(specJson);
+    const optionalFieldPaths = collectSchemaFieldPaths(specJson).optional;
 
     const tempCtx = createCompositionContext('defaults-extraction', {
       suppressResourceDiagnostics: true,
@@ -433,7 +433,7 @@ function resolveDefaultsByReExecution(
         specJson,
         proxyRes,
         id,
-        nullishFieldPaths,
+        optionalFieldPaths,
         ambiguousStructuredFallbacks
       );
       // Cross-field `??` chain reconstruction is independent of the defaults run —
@@ -630,11 +630,7 @@ function collectAmbiguityCandidateLeaves(
  * Driving presence this way lets a probe reveal which field a `??` chain falls
  * through to when earlier links are absent.
  */
-function buildProbeSpec(
-  specJson: unknown,
-  absent: Set<string>,
-  overrides: ReadonlyMap<string, unknown> = new Map()
-): unknown {
+function buildProbeSpec(specJson: unknown, absent: Set<string>): unknown {
   const root = (createSchemaProxy(specJson) as { spec: unknown }).spec;
   const wrap = (target: object, prefix: string): unknown =>
     new Proxy(target, {
@@ -642,11 +638,8 @@ function buildProbeSpec(
         if (typeof prop !== 'string') return Reflect.get(t, prop);
         const full = prefix ? `${prefix}.${prop}` : prop;
         if (absent.has(full)) return undefined;
-        if (overrides.has(full)) return overrides.get(full);
         const v = (t as Record<string, unknown>)[prop];
-        const hasDeeperMutation =
-          [...absent].some((a) => a.startsWith(`${full}.`)) ||
-          [...overrides.keys()].some((path) => path.startsWith(`${full}.`));
+        const hasDeeperMutation = [...absent].some((a) => a.startsWith(`${full}.`));
         if (hasDeeperMutation && v && (typeof v === 'object' || typeof v === 'function')) {
           return wrap(v as object, full);
         }
@@ -661,15 +654,14 @@ function runProbe(
   compositionFn: (...args: unknown[]) => unknown,
   specJson: unknown,
   absent: Set<string>,
-  resourceId: string,
-  overrides: ReadonlyMap<string, unknown> = new Map()
+  resourceId: string
 ): Record<string, unknown> | undefined {
   try {
     const ctx = createCompositionContext('cross-field-probe', {
       suppressResourceDiagnostics: true,
     });
     runWithCompositionContext(ctx, () => {
-      compositionFn(buildProbeSpec(specJson, absent, overrides));
+      compositionFn(buildProbeSpec(specJson, absent));
     });
     return (ctx.resources as Record<string, Record<string, unknown>>)[resourceId];
   } catch {
@@ -782,7 +774,7 @@ interface ProbeValueRead {
   ambiguousNormalization: boolean;
 }
 
-interface NullishSchemaPaths {
+interface SchemaFieldPaths {
   optional: Set<string>;
   nullable: Set<string>;
 }
@@ -794,7 +786,7 @@ function schemaNodeAllowsNull(node: unknown): boolean {
   return Object.hasOwn(record, 'unit') && record.unit === null;
 }
 
-function collectNullishSchemaPaths(node: unknown): NullishSchemaPaths {
+function collectSchemaFieldPaths(node: unknown): SchemaFieldPaths {
   const optional = new Set<string>();
   const nullable = new Set<string>();
 
@@ -890,7 +882,7 @@ function probeAmbiguousStructuredFallbacks(
   specJson: unknown,
   proxyResource: Record<string, unknown>,
   resourceId: string,
-  nullishFieldPaths: NullishSchemaPaths,
+  optionalFieldPaths: ReadonlySet<string>,
   out: ReExecutionResult['ambiguousStructuredFallbacks']
 ): void {
   const markerLeaves: AmbiguityCandidateLeaf[] = [];
@@ -903,44 +895,27 @@ function probeAmbiguousStructuredFallbacks(
   }
 
   for (const [field, candidates] of candidatesByField) {
-    // Probe only schema-valid nullish states. Optional paths use absence, while
-    // required nullable paths must remain present with a null value. A nullable
-    // ancestor is probed at that ancestor because dereferencing through it is not
-    // itself a valid runtime state. Probe both states when a field is optional
-    // and nullable: authored control flow may distinguish undefined from null
-    // even though JavaScript `??` treats them identically.
-    const optionalPath = matchingAncestorPath(field, nullishFieldPaths.optional);
-    const nullablePath = matchingAncestorPath(field, nullishFieldPaths.nullable);
-    const probedResources: Array<Record<string, unknown> | undefined> = [];
-    if (optionalPath !== undefined) {
-      probedResources.push(
-        runProbe(compositionFn, specJson, new Set([optionalPath]), resourceId)
-      );
-    }
-    if (nullablePath !== undefined) {
-      probedResources.push(
-        runProbe(
-          compositionFn,
-          specJson,
-          new Set(),
-          resourceId,
-          new Map([[nullablePath, null]])
-        )
-      );
-    }
-    if (probedResources.length === 0) continue;
+    // Removing a required leaf is not a realizable KRO instance state. Probe
+    // only a field that is optional itself or descends from an optional parent.
+    // Nullable fields are rejected at the ArkType → KRO schema boundary because
+    // SimpleSchema cannot represent explicit null.
+    const optionalPath = matchingAncestorPath(field, optionalFieldPaths);
+    if (optionalPath === undefined) continue;
+    const probedResource = runProbe(
+      compositionFn,
+      specJson,
+      new Set([optionalPath]),
+      resourceId
+    );
 
     for (const candidate of candidates) {
-      const ambiguous = probedResources.some((probedResource) => {
-        const probeRead = readProbeValueAtPath(proxyResource, probedResource, candidate);
-        const fallbackValue = probeRead.value;
-        return (
-          probeRead.ambiguousNormalization ||
-          Array.isArray(fallbackValue) ||
-          (fallbackValue !== null && typeof fallbackValue === 'object')
-        );
-      });
-      if (ambiguous) {
+      const probeRead = readProbeValueAtPath(proxyResource, probedResource, candidate);
+      const fallbackValue = probeRead.value;
+      if (
+        probeRead.ambiguousNormalization ||
+        Array.isArray(fallbackValue) ||
+        (fallbackValue !== null && typeof fallbackValue === 'object')
+      ) {
         out.push({
           resourceId,
           path: candidate.path,
@@ -1639,6 +1614,20 @@ export function arktypeToKroSchema(
   nestedStatusCel?: Record<string, string>,
   schemaFieldValidations?: Readonly<Record<string, string>>
 ): KroSimpleSchemaWithMetadata {
+  const nullableField = collectSchemaFieldPaths(schemaDefinition.spec.json).nullable
+    .values()
+    .next().value;
+  if (nullableField !== undefined) {
+    throw new TypeKroError(
+      `KRO SimpleSchema cannot represent nullable field schema.spec.${nullableField}. ` +
+        "TypeKro cannot preserve an ArkType 'T | null' contract by silently converting null " +
+        'to omission or a non-nullable field. Model the KRO input as optional and use ' +
+        'Cel.default(...) for omission, or use direct mode when explicit null is required.',
+      'KRO_NULLABLE_SCHEMA_UNSUPPORTED',
+      { field: nullableField }
+    );
+  }
+
   const specFields = arktypeJsonToKroFields(schemaDefinition.spec.json);
 
   if (!specFields.name) {

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -413,13 +413,6 @@ function resolveDefaultsByReExecution(
       // skip them when it's absent (only in the proxy run, or the defaults run threw).
       if (defaultsRes) {
         extractDefaultsByComparison(proxyRes, defaultsRes, defaults);
-        collectAmbiguousStructuredFallbacks(
-          proxyRes,
-          defaultsRes,
-          id,
-          [],
-          ambiguousStructuredFallbacks
-        );
         extractTernaryConditionals(
           proxyRes,
           defaultsRes,
@@ -428,6 +421,18 @@ function resolveDefaultsByReExecution(
           ternaryConditionFieldHints
         );
       }
+      // Ambiguity detection cannot depend on the all-defaults resource existing:
+      // an optional guard may remove the entire resource from that execution.
+      // Probe each bare structured schema marker with only that marker absent.
+      // A concrete structured value then proves only that black-box execution is
+      // ambiguous—not that the source was `??`—so compilation fails closed.
+      probeAmbiguousStructuredFallbacks(
+        compositionFn,
+        specJson,
+        proxyRes,
+        id,
+        ambiguousStructuredFallbacks
+      );
       // Cross-field `??` chain reconstruction is independent of the defaults run —
       // it does its own presence-probing — so it always runs.
       reconstructCrossFieldChains(
@@ -551,6 +556,41 @@ function collectMarkerLeaves(
 }
 
 /**
+ * Collect bare schema markers that have no explicit structured-expression
+ * provenance. ValuesMergeExpression already records its base/overlay semantics,
+ * so probing values inside that wrapper would misclassify an authored merge as
+ * an implicit fallback.
+ */
+function collectAmbiguityCandidateLeaves(
+  node: unknown,
+  path: string[],
+  out: Array<{ path: string[]; field: string }>
+): void {
+  if (isValuesMergeExpression(node)) return;
+
+  const classified = classifyLeaf(node);
+  if (classified.kind === 'field') {
+    out.push({ path: [...path], field: classified.field });
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((value, index) =>
+      collectAmbiguityCandidateLeaves(value, [...path, String(index)], out)
+    );
+    return;
+  }
+  if (node && typeof node === 'object') {
+    for (const key of Object.keys(node as Record<string, unknown>)) {
+      collectAmbiguityCandidateLeaves(
+        (node as Record<string, unknown>)[key],
+        [...path, key],
+        out
+      );
+    }
+  }
+}
+
+/**
  * Build a probe `spec`: the magic schema proxy (so any field access emits its
  * `spec.X` marker) wrapped so the dotted paths in `absent` resolve to `undefined`.
  * Driving presence this way lets a probe reveal which field a `??` chain falls
@@ -598,72 +638,62 @@ function runProbe(
 const celField = (field: string): string => `schema.spec.${field}`;
 
 /**
- * Detect structured proxy/default differences without pretending black-box
- * re-execution proves a `??` operation. Explicit `Cel.default()` values carry
- * their own CEL provenance and therefore do not appear as bare schema markers.
+ * Read a probed resource using a path captured from the proxy run. Values-merge
+ * wrappers may disappear when the probed field is absent, so their `base` path
+ * segment is transparent in that case.
  */
-function collectAmbiguousStructuredFallbacks(
-  proxyValue: unknown,
-  fallbackValue: unknown,
+function readProbeValueAtPath(obj: unknown, path: string[]): unknown {
+  let current = obj;
+  for (const key of path) {
+    if (key === 'base' && !isValuesMergeExpression(current)) continue;
+    if (current === null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+/**
+ * Detect a bare structured schema marker that becomes a concrete object/array
+ * when that exact field is absent. This targeted probe does not infer `??`
+ * semantics; it establishes that black-box execution is ambiguous and must
+ * fail closed. Explicit `Cel.default()` values carry CEL provenance and do not
+ * appear as bare schema-marker leaves.
+ */
+function probeAmbiguousStructuredFallbacks(
+  compositionFn: (...args: unknown[]) => unknown,
+  specJson: unknown,
+  proxyResource: Record<string, unknown>,
   resourceId: string,
-  path: string[],
   out: ReExecutionResult['ambiguousStructuredFallbacks']
 ): void {
-  if (isValuesMergeExpression(proxyValue) && !isValuesMergeExpression(fallbackValue)) {
-    collectAmbiguousStructuredFallbacks(
-      proxyValue.base,
-      fallbackValue,
-      resourceId,
-      [...path, 'base'],
-      out
+  const markerLeaves: Array<{ path: string[]; field: string }> = [];
+  collectAmbiguityCandidateLeaves(proxyResource, [], markerLeaves);
+  const pathsByField = new Map<string, string[][]>();
+  for (const marker of markerLeaves) {
+    const paths = pathsByField.get(marker.field) ?? [];
+    paths.push(marker.path);
+    pathsByField.set(marker.field, paths);
+  }
+
+  for (const [field, paths] of pathsByField) {
+    const probedResource = runProbe(
+      compositionFn,
+      specJson,
+      new Set([field]),
+      resourceId
     );
-    return;
-  }
-
-  const proxyString =
-    typeof proxyValue === 'function' || typeof proxyValue === 'string'
-      ? String(proxyValue)
-      : undefined;
-  const exactMarker = proxyString?.match(FULL_MARKER_RE)?.[1];
-  if (
-    exactMarker?.startsWith('spec.') &&
-    (Array.isArray(fallbackValue) || (fallbackValue !== null && typeof fallbackValue === 'object'))
-  ) {
-    out.push({
-      resourceId,
-      path: [...path],
-      field: exactMarker.slice('spec.'.length),
-    });
-    return;
-  }
-
-  if (Array.isArray(proxyValue) && Array.isArray(fallbackValue)) {
-    for (let index = 0; index < Math.min(proxyValue.length, fallbackValue.length); index++) {
-      collectAmbiguousStructuredFallbacks(
-        proxyValue[index],
-        fallbackValue[index],
-        resourceId,
-        [...path, String(index)],
-        out
-      );
-    }
-    return;
-  }
-
-  if (
-    proxyValue !== null &&
-    typeof proxyValue === 'object' &&
-    fallbackValue !== null &&
-    typeof fallbackValue === 'object'
-  ) {
-    for (const key of Object.keys(proxyValue as Record<string, unknown>)) {
-      collectAmbiguousStructuredFallbacks(
-        (proxyValue as Record<string, unknown>)[key],
-        (fallbackValue as Record<string, unknown>)[key],
-        resourceId,
-        [...path, key],
-        out
-      );
+    for (const path of paths) {
+      const fallbackValue = readProbeValueAtPath(probedResource, path);
+      if (
+        Array.isArray(fallbackValue) ||
+        (fallbackValue !== null && typeof fallbackValue === 'object')
+      ) {
+        out.push({
+          resourceId,
+          path,
+          field,
+        });
+      }
     }
   }
 }

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -557,25 +557,55 @@ function collectMarkerLeaves(
 
 /**
  * Collect bare schema markers that have no explicit structured-expression
- * provenance. ValuesMergeExpression already records its base/overlay semantics,
- * so probing values inside that wrapper would misclassify an authored merge as
- * an implicit fallback.
+ * provenance. A ValuesMergeExpression records only the merge operation's
+ * provenance; its base and overlays may still contain implicit fallbacks. Keep
+ * those operands as explicit path segments so a probe compares the same operand
+ * rather than mistaking a normalized final merge result for its former base.
  */
+interface AmbiguityCandidateLeaf {
+  path: string[];
+  field: string;
+  mergeShapes: Array<{ path: string[]; overlayCount: number }>;
+}
+
 function collectAmbiguityCandidateLeaves(
   node: unknown,
   path: string[],
-  out: Array<{ path: string[]; field: string }>
+  out: AmbiguityCandidateLeaf[],
+  mergeShapes: AmbiguityCandidateLeaf['mergeShapes'] = []
 ): void {
-  if (isValuesMergeExpression(node)) return;
+  if (isValuesMergeExpression(node)) {
+    const nestedMergeShapes = [
+      ...mergeShapes,
+      { path: [...path], overlayCount: node.overlays.length },
+    ];
+    collectAmbiguityCandidateLeaves(node.base, [...path, 'base'], out, nestedMergeShapes);
+    node.overlays.forEach((overlay, index) =>
+      collectAmbiguityCandidateLeaves(
+        overlay,
+        [...path, 'overlays', String(index)],
+        out,
+        nestedMergeShapes
+      )
+    );
+    return;
+  }
 
   const classified = classifyLeaf(node);
   if (classified.kind === 'field') {
-    out.push({ path: [...path], field: classified.field });
+    out.push({
+      path: [...path],
+      field: classified.field,
+      mergeShapes: mergeShapes.map((shape) => ({
+        path: [...shape.path],
+        overlayCount: shape.overlayCount,
+      })),
+    });
     return;
   }
   if (Array.isArray(node)) {
     node.forEach((value, index) =>
-      collectAmbiguityCandidateLeaves(value, [...path, String(index)], out)
+      collectAmbiguityCandidateLeaves(value, [...path, String(index)], out, mergeShapes)
     );
     return;
   }
@@ -584,7 +614,8 @@ function collectAmbiguityCandidateLeaves(
       collectAmbiguityCandidateLeaves(
         (node as Record<string, unknown>)[key],
         [...path, key],
-        out
+        out,
+        mergeShapes
       );
     }
   }
@@ -639,17 +670,30 @@ const celField = (field: string): string => `schema.spec.${field}`;
 
 /**
  * Read a probed resource using a path captured from the proxy run. Values-merge
- * wrappers may disappear when the probed field is absent, so their `base` path
- * segment is transparent in that case.
+ * operand segments intentionally are not transparent: if removing a candidate
+ * causes the wrapper to normalize away, the resulting merged object is not
+ * evidence that the original operand contained an implicit fallback.
  */
-function readProbeValueAtPath(obj: unknown, path: string[]): unknown {
+function readRawValueAtPath(obj: unknown, path: string[]): unknown {
   let current = obj;
   for (const key of path) {
-    if (key === 'base' && !isValuesMergeExpression(current)) continue;
     if (current === null || typeof current !== 'object') return undefined;
     current = (current as Record<string, unknown>)[key];
   }
   return current;
+}
+
+function readProbeValueAtPath(obj: unknown, candidate: AmbiguityCandidateLeaf): unknown {
+  for (const shape of candidate.mergeShapes) {
+    const probedMerge = readRawValueAtPath(obj, shape.path);
+    if (
+      !isValuesMergeExpression(probedMerge) ||
+      probedMerge.overlays.length !== shape.overlayCount
+    ) {
+      return undefined;
+    }
+  }
+  return readRawValueAtPath(obj, candidate.path);
 }
 
 /**
@@ -666,31 +710,26 @@ function probeAmbiguousStructuredFallbacks(
   resourceId: string,
   out: ReExecutionResult['ambiguousStructuredFallbacks']
 ): void {
-  const markerLeaves: Array<{ path: string[]; field: string }> = [];
+  const markerLeaves: AmbiguityCandidateLeaf[] = [];
   collectAmbiguityCandidateLeaves(proxyResource, [], markerLeaves);
-  const pathsByField = new Map<string, string[][]>();
+  const candidatesByField = new Map<string, AmbiguityCandidateLeaf[]>();
   for (const marker of markerLeaves) {
-    const paths = pathsByField.get(marker.field) ?? [];
-    paths.push(marker.path);
-    pathsByField.set(marker.field, paths);
+    const candidates = candidatesByField.get(marker.field) ?? [];
+    candidates.push(marker);
+    candidatesByField.set(marker.field, candidates);
   }
 
-  for (const [field, paths] of pathsByField) {
-    const probedResource = runProbe(
-      compositionFn,
-      specJson,
-      new Set([field]),
-      resourceId
-    );
-    for (const path of paths) {
-      const fallbackValue = readProbeValueAtPath(probedResource, path);
+  for (const [field, candidates] of candidatesByField) {
+    const probedResource = runProbe(compositionFn, specJson, new Set([field]), resourceId);
+    for (const candidate of candidates) {
+      const fallbackValue = readProbeValueAtPath(probedResource, candidate);
       if (
         Array.isArray(fallbackValue) ||
         (fallbackValue !== null && typeof fallbackValue === 'object')
       ) {
         out.push({
           resourceId,
-          path,
+          path: candidate.path,
           field,
         });
       }

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -560,7 +560,11 @@ function collectMarkerLeaves(
  * Driving presence this way lets a probe reveal which field a `??` chain falls
  * through to when earlier links are absent.
  */
-function buildProbeSpec(specJson: unknown, absent: Set<string>): unknown {
+function buildProbeSpec(
+  specJson: unknown,
+  absent: Set<string>,
+  overrides: ReadonlyMap<string, unknown> = new Map()
+): unknown {
   const root = (createSchemaProxy(specJson) as { spec: unknown }).spec;
   const wrap = (target: object, prefix: string): unknown =>
     new Proxy(target, {
@@ -568,9 +572,12 @@ function buildProbeSpec(specJson: unknown, absent: Set<string>): unknown {
         if (typeof prop !== 'string') return Reflect.get(t, prop);
         const full = prefix ? `${prefix}.${prop}` : prop;
         if (absent.has(full)) return undefined;
+        if (overrides.has(full)) return overrides.get(full);
         const v = (t as Record<string, unknown>)[prop];
-        const hasDeeperAbsent = [...absent].some((a) => a.startsWith(`${full}.`));
-        if (hasDeeperAbsent && v && (typeof v === 'object' || typeof v === 'function')) {
+        const hasDeeperMutation =
+          [...absent].some((a) => a.startsWith(`${full}.`)) ||
+          [...overrides.keys()].some((a) => a.startsWith(`${full}.`));
+        if (hasDeeperMutation && v && (typeof v === 'object' || typeof v === 'function')) {
           return wrap(v as object, full);
         }
         return v;
@@ -579,22 +586,42 @@ function buildProbeSpec(specJson: unknown, absent: Set<string>): unknown {
   return wrap(root as object, '');
 }
 
+interface ProbeResult {
+  completed: boolean;
+  resource: Record<string, unknown> | undefined;
+}
+
+/** Run the composition with a probe spec and retain whether execution completed. */
+function runProbeWithResult(
+  compositionFn: (...args: unknown[]) => unknown,
+  specJson: unknown,
+  absent: Set<string>,
+  resourceId: string,
+  overrides: ReadonlyMap<string, unknown> = new Map()
+): ProbeResult {
+  try {
+    const ctx = createCompositionContext('cross-field-probe');
+    runWithCompositionContext(ctx, () => {
+      compositionFn(buildProbeSpec(specJson, absent, overrides));
+    });
+    return {
+      completed: true,
+      resource: (ctx.resources as Record<string, Record<string, unknown>>)[resourceId],
+    };
+  } catch {
+    return { completed: false, resource: undefined };
+  }
+}
+
 /** Run the composition with a probe spec; return the resource matching `resourceId`. */
 function runProbe(
   compositionFn: (...args: unknown[]) => unknown,
   specJson: unknown,
   absent: Set<string>,
-  resourceId: string
+  resourceId: string,
+  overrides: ReadonlyMap<string, unknown> = new Map()
 ): Record<string, unknown> | undefined {
-  try {
-    const ctx = createCompositionContext('cross-field-probe');
-    runWithCompositionContext(ctx, () => {
-      compositionFn(buildProbeSpec(specJson, absent));
-    });
-    return (ctx.resources as Record<string, Record<string, unknown>>)[resourceId];
-  } catch {
-    return undefined;
-  }
+  return runProbeWithResult(compositionFn, specJson, absent, resourceId, overrides).resource;
 }
 
 const celField = (field: string): string => `schema.spec.${field}`;
@@ -609,6 +636,91 @@ const celField = (field: string): string => `schema.spec.${field}`;
 function presenceGuard(field: string): string {
   const segs = field.split('.');
   return segs.map((_, i) => `has(schema.spec.${segs.slice(0, i + 1).join('.')})`).join(' && ');
+}
+
+interface CounterfactualProbe {
+  absent: Set<string>;
+  overrides: Map<string, unknown>;
+}
+
+function isBooleanSchemaNode(node: unknown): boolean {
+  return (
+    node === 'boolean' ||
+    (Array.isArray(node) &&
+      node.some(
+        (branch) =>
+          branch !== null &&
+          typeof branch === 'object' &&
+          'unit' in branch &&
+          typeof branch.unit === 'boolean'
+      ))
+  );
+}
+
+/**
+ * Build single-field counterfactuals for every schema path other than the
+ * candidate and its optional ancestors. Optional fields are removed; boolean
+ * fields (including required fields) are also exercised with `false`. Callers
+ * ignore hybrid proxy/concrete probes that cannot execute and require every
+ * executable counterfactual to preserve the candidate marker.
+ */
+function collectCounterfactualProbes(
+  node: unknown,
+  candidate: string,
+  prefix = '',
+  out: CounterfactualProbe[] = []
+): CounterfactualProbe[] {
+  if (node === null || typeof node !== 'object' || Array.isArray(node)) return out;
+
+  const objectNode = node as {
+    required?: Array<{ key: string; value: unknown }>;
+    optional?: Array<{ key: string; value: unknown }>;
+  };
+  const candidateDependsOnPath = (path: string): boolean =>
+    candidate === path || candidate.startsWith(`${path}.`);
+
+  for (const property of objectNode.required ?? []) {
+    const path = prefix ? `${prefix}.${property.key}` : property.key;
+    if (!candidateDependsOnPath(path) && isBooleanSchemaNode(property.value)) {
+      out.push({ absent: new Set(), overrides: new Map([[path, false]]) });
+    }
+    collectCounterfactualProbes(property.value, candidate, path, out);
+  }
+
+  for (const property of objectNode.optional ?? []) {
+    const path = prefix ? `${prefix}.${property.key}` : property.key;
+    if (!candidateDependsOnPath(path)) {
+      out.push({ absent: new Set([path]), overrides: new Map() });
+      if (isBooleanSchemaNode(property.value)) {
+        out.push({ absent: new Set(), overrides: new Map([[path, false]]) });
+      }
+    }
+    collectCounterfactualProbes(property.value, candidate, path, out);
+  }
+
+  return out;
+}
+
+/**
+ * ValuesMergeExpression is an authoring-time wrapper. When a counterfactual
+ * removes the overlay that created it, the same authored base appears directly.
+ * Treat `base` segments introduced by that wrapper as transparent for probes.
+ */
+function readAuthoredValueAtPath(obj: unknown, path: string[]): unknown {
+  let current: unknown = obj;
+  for (const key of path) {
+    if (key === 'base' && !isValuesMergeExpression(current)) continue;
+    if (current === null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+function exactSchemaField(value: unknown): string | undefined {
+  const valueString =
+    typeof value === 'function' || typeof value === 'string' ? String(value) : undefined;
+  const marker = valueString?.match(FULL_MARKER_RE)?.[1];
+  return marker?.startsWith('spec.') ? marker.slice('spec.'.length) : undefined;
 }
 
 /**
@@ -662,7 +774,7 @@ function extractStructuredFallbacksByComparison(
           new Set<string>([field]),
           resourceId
         );
-        const probedFallback = readAtPath(probeResource, path);
+        const probedFallback = readAuthoredValueAtPath(probeResource, path);
         if (
           !Array.isArray(probedFallback) &&
           (probedFallback === null || typeof probedFallback !== 'object')
@@ -684,6 +796,37 @@ function extractStructuredFallbacksByComparison(
         // removing the referenced field itself selects this exact fallback before
         // attributing the behavior to nullish coalescing.
         if (probedFallbackCel !== fallbackCel) return;
+        // The referenced field must also remain the selected marker under every
+        // other single-field counterfactual. This rejects control flow such as
+        // `enabled && resources ? resources : defaults`, including when enabled
+        // is a required boolean and therefore cannot be tested by absence alone.
+        for (const counterfactual of collectCounterfactualProbes(specJson, field)) {
+          const counterfactualResult = runProbeWithResult(
+            compositionFn,
+            specJson,
+            counterfactual.absent,
+            resourceId,
+            counterfactual.overrides
+          );
+          // Some helpers legitimately cannot operate on a hybrid proxy/concrete
+          // input (for example structuredClone after an optional overlay becomes
+          // undefined). Such a probe carries no semantic evidence either way.
+          if (!counterfactualResult.completed) continue;
+          const observedField = exactSchemaField(
+            readAuthoredValueAtPath(counterfactualResult.resource, path)
+          );
+          if (observedField !== field) {
+            logger.debug('Structured fallback candidate rejected by counterfactual probe', {
+              resourceId,
+              path: path.join('.'),
+              field,
+              observedField,
+              absent: [...counterfactual.absent],
+              overrides: Object.fromEntries(counterfactual.overrides),
+            });
+            return;
+          }
+        }
         out.push({
           resourceId,
           path: [...path],

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -10,6 +10,7 @@ import type { Type } from 'arktype';
 import { KUBERNETES_REF_SCHEMA_MARKER_SOURCE } from '../../shared/brands.js';
 import { escapeCelString } from '../../utils/cel-escape.js';
 import { pascalCase } from '../../utils/string.js';
+import { isCelExpression, isKubernetesRef } from '../../utils/type-guards.js';
 import { isValuesMergeExpression } from '../aspects/values-merge.js';
 import { getCompositionAnalysisMetadata } from '../composition/analysis-metadata.js';
 import { createCompositionContext, runWithCompositionContext } from '../composition/context.js';
@@ -351,6 +352,7 @@ function resolveDefaultsByReExecution(
     // Build the set of optional top-level field names. Only optional fields
     // can be ternary-controlled (required fields always have a value).
     const optionalFieldNames = new Set((specJson.optional ?? []).map((p) => p.key));
+    const optionalFieldPaths = collectOptionalSchemaPaths(specJson);
 
     const tempCtx = createCompositionContext('defaults-extraction', {
       suppressResourceDiagnostics: true,
@@ -431,6 +433,7 @@ function resolveDefaultsByReExecution(
         specJson,
         proxyRes,
         id,
+        optionalFieldPaths,
         ambiguousStructuredFallbacks
       );
       // Cross-field `??` chain reconstruction is independent of the defaults run —
@@ -683,17 +686,163 @@ function readRawValueAtPath(obj: unknown, path: string[]): unknown {
   return current;
 }
 
-function readProbeValueAtPath(obj: unknown, candidate: AmbiguityCandidateLeaf): unknown {
+function replaceValueAtPath(root: unknown, path: string[], value: unknown): unknown {
+  const [head, ...tail] = path;
+  if (head === undefined) return value;
+
+  if (Array.isArray(root)) {
+    const index = Number(head);
+    if (!Number.isInteger(index) || index < 0 || index >= root.length) return root;
+    const copy = [...root];
+    copy[index] = replaceValueAtPath(copy[index], tail, value);
+    return copy;
+  }
+
+  if (root === null || typeof root !== 'object') return root;
+  const record = root as Record<string, unknown>;
+  return {
+    ...record,
+    [head]: replaceValueAtPath(record[head], tail, value),
+  };
+}
+
+/**
+ * Canonicalize only ordinary value-tree containers. References and CEL nodes
+ * are semantic leaves, while merge expressions retain their explicit operand
+ * ordering. Kubernetes object maps are unordered, so sorting their keys keeps
+ * semantically identical normalization paths from differing solely because a
+ * helper inserted properties in a different order.
+ */
+function canonicalizeValueTree(value: unknown): unknown {
+  if (isKubernetesRef(value) || isCelExpression(value)) return value;
+  if (isValuesMergeExpression(value)) {
+    let base = canonicalizeValueTree(value.base);
+    let overlays = value.overlays.map(canonicalizeValueTree);
+    while (isValuesMergeExpression(base)) {
+      overlays = [...base.overlays, ...overlays];
+      base = base.base;
+    }
+    overlays = overlays.filter(
+      (overlay) =>
+        overlay !== undefined &&
+        !(
+          overlay !== null &&
+          typeof overlay === 'object' &&
+          !Array.isArray(overlay) &&
+          Object.getPrototypeOf(overlay) === Object.prototype &&
+          Object.keys(overlay).length === 0
+        )
+    );
+    if (overlays.length === 0) return base;
+    return {
+      __typekroValuesMerge: true,
+      base,
+      overlays,
+    };
+  }
+  if (Array.isArray(value)) return value.map(canonicalizeValueTree);
+  if (value === null || typeof value !== 'object') return value;
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return value;
+
+  const record = value as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.keys(record)
+      .sort()
+      .flatMap((key) => {
+        const canonical = canonicalizeValueTree(record[key]);
+        return canonical === undefined ? [] : [[key, canonical]];
+      })
+  );
+}
+
+function valueTreeFingerprint(value: unknown): string | undefined {
+  try {
+    return celLiteralForValueTree(
+      canonicalizeValueTree(value),
+      undefined,
+      'structured-fallback-normalization'
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+interface ProbeValueRead {
+  value: unknown;
+  ambiguousNormalization: boolean;
+}
+
+function collectOptionalSchemaPaths(node: unknown): Set<string> {
+  const paths = new Set<string>();
+
+  const walk = (current: unknown, prefix: string): void => {
+    if (current === null || typeof current !== 'object') return;
+    const objectNode = current as {
+      required?: Array<{ key: string; value?: unknown }>;
+      optional?: Array<{ key: string; value?: unknown }>;
+    };
+
+    for (const entry of objectNode.optional ?? []) {
+      const path = prefix ? `${prefix}.${entry.key}` : entry.key;
+      paths.add(path);
+      walk(entry.value, path);
+    }
+    for (const entry of objectNode.required ?? []) {
+      const path = prefix ? `${prefix}.${entry.key}` : entry.key;
+      walk(entry.value, path);
+    }
+  };
+
+  walk(node, '');
+  return paths;
+}
+
+function canSchemaFieldBeAbsent(field: string, optionalFieldPaths: ReadonlySet<string>): boolean {
+  for (const optionalPath of optionalFieldPaths) {
+    if (field === optionalPath || field.startsWith(`${optionalPath}.`)) return true;
+  }
+  return false;
+}
+
+function readProbeValueAtPath(
+  proxyResource: Record<string, unknown>,
+  probedResource: unknown,
+  candidate: AmbiguityCandidateLeaf
+): ProbeValueRead {
   for (const shape of candidate.mergeShapes) {
-    const probedMerge = readRawValueAtPath(obj, shape.path);
+    const probedMerge = readRawValueAtPath(probedResource, shape.path);
     if (
       !isValuesMergeExpression(probedMerge) ||
       probedMerge.overlays.length !== shape.overlayCount
     ) {
-      return undefined;
+      const originalMerge = readRawValueAtPath(proxyResource, shape.path);
+      if (!isValuesMergeExpression(originalMerge)) {
+        return { value: undefined, ambiguousNormalization: true };
+      }
+
+      const expectedWithoutCandidate = replaceValueAtPath(
+        originalMerge,
+        candidate.path.slice(shape.path.length),
+        undefined
+      );
+      const actualFingerprint = valueTreeFingerprint(probedMerge);
+      const expectedFingerprint = valueTreeFingerprint(expectedWithoutCandidate);
+      const ambiguousNormalization =
+        actualFingerprint === undefined ||
+        expectedFingerprint === undefined ||
+        actualFingerprint !== expectedFingerprint;
+      return {
+        value: ambiguousNormalization ? probedMerge : undefined,
+        ambiguousNormalization,
+      };
     }
   }
-  return readRawValueAtPath(obj, candidate.path);
+  return {
+    value: readRawValueAtPath(probedResource, candidate.path),
+    ambiguousNormalization: false,
+  };
 }
 
 /**
@@ -708,6 +857,7 @@ function probeAmbiguousStructuredFallbacks(
   specJson: unknown,
   proxyResource: Record<string, unknown>,
   resourceId: string,
+  optionalFieldPaths: ReadonlySet<string>,
   out: ReExecutionResult['ambiguousStructuredFallbacks']
 ): void {
   const markerLeaves: AmbiguityCandidateLeaf[] = [];
@@ -720,10 +870,17 @@ function probeAmbiguousStructuredFallbacks(
   }
 
   for (const [field, candidates] of candidatesByField) {
+    // Removing a required leaf is not a realizable instance state and can make
+    // unrelated composition/aspect branches disappear. Only fields that are
+    // themselves optional, or descend from an optional parent, can participate
+    // in an implicit nullish fallback.
+    if (!canSchemaFieldBeAbsent(field, optionalFieldPaths)) continue;
     const probedResource = runProbe(compositionFn, specJson, new Set([field]), resourceId);
     for (const candidate of candidates) {
-      const fallbackValue = readProbeValueAtPath(probedResource, candidate);
+      const probeRead = readProbeValueAtPath(proxyResource, probedResource, candidate);
+      const fallbackValue = probeRead.value;
       if (
+        probeRead.ambiguousNormalization ||
         Array.isArray(fallbackValue) ||
         (fallbackValue !== null && typeof fallbackValue === 'object')
       ) {

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -13,6 +13,7 @@ import { pascalCase } from '../../utils/string.js';
 import { isValuesMergeExpression } from '../aspects/values-merge.js';
 import { getCompositionAnalysisMetadata } from '../composition/analysis-metadata.js';
 import { createCompositionContext, runWithCompositionContext } from '../composition/context.js';
+import { TypeKroError } from '../errors.js';
 import { getComponentLogger } from '../logging/index.js';
 import { getMetadataField } from '../metadata/index.js';
 import { createSchemaProxy } from '../references/index.js';
@@ -313,13 +314,8 @@ interface ReExecutionResult {
    * multi-field `has(...) ? ... : ...` chains it cannot express.
    */
   crossFieldOverrides: Array<{ resourceId: string; path: string[]; cel: string }>;
-  /**
-   * Structured single-field fallbacks (`spec.resources?.osd ?? DEFAULT_OSD`)
-   * captured by executing the real composition/helper graph with optionals absent.
-   * KRO SimpleSchema cannot represent object-valued defaults, so these are
-   * lowered into presence-guarded CEL at the exact resource template path.
-   */
-  structuredFallbackOverrides: Array<{ resourceId: string; path: string[]; cel: string }>;
+  /** Structured proxy/default diffs that lack explicit nullish provenance. */
+  ambiguousStructuredFallbacks: Array<{ resourceId: string; path: string[]; field: string }>;
 }
 
 /**
@@ -356,7 +352,9 @@ function resolveDefaultsByReExecution(
     // can be ternary-controlled (required fields always have a value).
     const optionalFieldNames = new Set((specJson.optional ?? []).map((p) => p.key));
 
-    const tempCtx = createCompositionContext('defaults-extraction');
+    const tempCtx = createCompositionContext('defaults-extraction', {
+      suppressResourceDiagnostics: true,
+    });
     // The all-undefined defaults run can throw when a composition dereferences an
     // absent optional parent (`spec.settings.tier` with settings undefined). Contain
     // it: literal-default extraction is then simply empty, but cross-field probing
@@ -408,21 +406,19 @@ function resolveDefaultsByReExecution(
     }
 
     const crossFieldOverrides: ReExecutionResult['crossFieldOverrides'] = [];
-    const structuredFallbackOverrides: ReExecutionResult['structuredFallbackOverrides'] = [];
+    const ambiguousStructuredFallbacks: ReExecutionResult['ambiguousStructuredFallbacks'] = [];
     for (const [id, proxyRes] of proxyEntries) {
       const defaultsRes = defaultsMap.get(id);
       // Literal-default + ternary extraction need the defaults-run counterpart;
       // skip them when it's absent (only in the proxy run, or the defaults run threw).
       if (defaultsRes) {
         extractDefaultsByComparison(proxyRes, defaultsRes, defaults);
-        extractStructuredFallbacksByComparison(
-          compositionFn,
-          specJson,
+        collectAmbiguousStructuredFallbacks(
           proxyRes,
           defaultsRes,
           id,
           [],
-          structuredFallbackOverrides
+          ambiguousStructuredFallbacks
         );
         extractTernaryConditionals(
           proxyRes,
@@ -448,9 +444,9 @@ function resolveDefaultsByReExecution(
       Object.keys(defaults).length > 0 ||
       ternaryConditionals.length > 0 ||
       crossFieldOverrides.length > 0 ||
-      structuredFallbackOverrides.length > 0;
+      ambiguousStructuredFallbacks.length > 0;
     return hasResults
-      ? { defaults, ternaryConditionals, crossFieldOverrides, structuredFallbackOverrides }
+      ? { defaults, ternaryConditionals, crossFieldOverrides, ambiguousStructuredFallbacks }
       : undefined;
   } catch (err) {
     // Best-effort: composition functions with undefined spec fields may throw
@@ -560,11 +556,7 @@ function collectMarkerLeaves(
  * Driving presence this way lets a probe reveal which field a `??` chain falls
  * through to when earlier links are absent.
  */
-function buildProbeSpec(
-  specJson: unknown,
-  absent: Set<string>,
-  overrides: ReadonlyMap<string, unknown> = new Map()
-): unknown {
+function buildProbeSpec(specJson: unknown, absent: Set<string>): unknown {
   const root = (createSchemaProxy(specJson) as { spec: unknown }).spec;
   const wrap = (target: object, prefix: string): unknown =>
     new Proxy(target, {
@@ -572,11 +564,8 @@ function buildProbeSpec(
         if (typeof prop !== 'string') return Reflect.get(t, prop);
         const full = prefix ? `${prefix}.${prop}` : prop;
         if (absent.has(full)) return undefined;
-        if (overrides.has(full)) return overrides.get(full);
         const v = (t as Record<string, unknown>)[prop];
-        const hasDeeperMutation =
-          [...absent].some((a) => a.startsWith(`${full}.`)) ||
-          [...overrides.keys()].some((a) => a.startsWith(`${full}.`));
+        const hasDeeperMutation = [...absent].some((a) => a.startsWith(`${full}.`));
         if (hasDeeperMutation && v && (typeof v === 'object' || typeof v === 'function')) {
           return wrap(v as object, full);
         }
@@ -586,227 +575,42 @@ function buildProbeSpec(
   return wrap(root as object, '');
 }
 
-interface ProbeResult {
-  completed: boolean;
-  resource: Record<string, unknown> | undefined;
-}
-
-/** Run the composition with a probe spec and retain whether execution completed. */
-function runProbeWithResult(
-  compositionFn: (...args: unknown[]) => unknown,
-  specJson: unknown,
-  absent: Set<string>,
-  resourceId: string,
-  overrides: ReadonlyMap<string, unknown> = new Map()
-): ProbeResult {
-  try {
-    const ctx = createCompositionContext('cross-field-probe');
-    runWithCompositionContext(ctx, () => {
-      compositionFn(buildProbeSpec(specJson, absent, overrides));
-    });
-    return {
-      completed: true,
-      resource: (ctx.resources as Record<string, Record<string, unknown>>)[resourceId],
-    };
-  } catch {
-    return { completed: false, resource: undefined };
-  }
-}
-
 /** Run the composition with a probe spec; return the resource matching `resourceId`. */
 function runProbe(
   compositionFn: (...args: unknown[]) => unknown,
   specJson: unknown,
   absent: Set<string>,
-  resourceId: string,
-  overrides: ReadonlyMap<string, unknown> = new Map()
+  resourceId: string
 ): Record<string, unknown> | undefined {
-  return runProbeWithResult(compositionFn, specJson, absent, resourceId, overrides).resource;
+  try {
+    const ctx = createCompositionContext('cross-field-probe', {
+      suppressResourceDiagnostics: true,
+    });
+    runWithCompositionContext(ctx, () => {
+      compositionFn(buildProbeSpec(specJson, absent));
+    });
+    return (ctx.resources as Record<string, Record<string, unknown>>)[resourceId];
+  } catch {
+    return undefined;
+  }
 }
 
 const celField = (field: string): string => `schema.spec.${field}`;
 
 /**
- * Presence guard for a (possibly nested) optional field — every ancestor must be
- * present too. `userDeployments.enableSubchart` →
- * `has(schema.spec.userDeployments) && has(schema.spec.userDeployments.enableSubchart)`.
- * Matches the optional-chain guard the inline analyzer emits, so a bare nested ref is
- * never read through an absent parent.
+ * Detect structured proxy/default differences without pretending black-box
+ * re-execution proves a `??` operation. Explicit `Cel.default()` values carry
+ * their own CEL provenance and therefore do not appear as bare schema markers.
  */
-function presenceGuard(field: string): string {
-  const segs = field.split('.');
-  return segs.map((_, i) => `has(schema.spec.${segs.slice(0, i + 1).join('.')})`).join(' && ');
-}
-
-interface CounterfactualProbe {
-  absent: Set<string>;
-  overrides: Map<string, unknown>;
-}
-
-function numericBoundAdmitsZero(bound: unknown, kind: 'min' | 'max'): boolean {
-  if (bound === undefined) return true;
-  const rule =
-    typeof bound === 'number'
-      ? bound
-      : bound !== null &&
-          typeof bound === 'object' &&
-          typeof Reflect.get(bound, 'rule') === 'number'
-        ? (Reflect.get(bound, 'rule') as number)
-        : undefined;
-  if (rule === undefined) return false;
-  const exclusive =
-    bound !== null && typeof bound === 'object' && Reflect.get(bound, 'exclusive') === true;
-  return kind === 'min'
-    ? rule < 0 || (rule === 0 && !exclusive)
-    : rule > 0 || (rule === 0 && !exclusive);
-}
-
-/**
- * Return every falsy JavaScript value that the ArkType JSON node admits.
- * These are useful counterfactuals for required scalar guards: unlike schema
- * proxies, real strings, numbers, booleans, and null can be falsy.
- */
-function falsySchemaValues(node: unknown): unknown[] {
-  if (node === 'boolean') return [false];
-  if (node === 'string') return [''];
-  if (node === 'number') return [0];
-  if (node === 'unknown') return [false, 0, '', null];
-  if (node === 'null') return [null];
-  if (Array.isArray(node)) {
-    const values = node.flatMap(falsySchemaValues);
-    return values.filter(
-      (value, index) => values.findIndex((candidate) => Object.is(candidate, value)) === index
-    );
-  }
-  if (node === null || typeof node !== 'object') return [];
-
-  if ('unit' in node) {
-    const unit = Reflect.get(node, 'unit');
-    return !unit ? [unit] : [];
-  }
-  if (
-    Reflect.has(node, 'required') ||
-    Reflect.has(node, 'optional') ||
-    Reflect.get(node, 'proto') === 'Array'
-  ) {
-    return [];
-  }
-
-  const domain = Reflect.get(node, 'domain');
-  if (domain === 'boolean') return [false];
-  if (domain === 'string') {
-    const exactLength = Reflect.get(node, 'exactLength');
-    const minLength = Reflect.get(node, 'minLength');
-    const pattern = Reflect.get(node, 'pattern');
-    const admitsEmpty =
-      (exactLength === undefined || exactLength === 0) &&
-      (minLength === undefined || minLength === 0) &&
-      pattern === undefined;
-    return admitsEmpty ? [''] : [];
-  }
-  if (domain === 'number') {
-    const admitsZero =
-      numericBoundAdmitsZero(Reflect.get(node, 'min'), 'min') &&
-      numericBoundAdmitsZero(Reflect.get(node, 'max'), 'max');
-    return admitsZero ? [0] : [];
-  }
-
-  // ArkType serializes `unknown` as an empty node.
-  if (Object.keys(node).length === 0) return [false, 0, '', null];
-  return [];
-}
-
-/**
- * Build single-field counterfactuals for every schema path other than the
- * candidate and its optional ancestors. Optional fields are removed; every
- * scalar field is also exercised with each falsy value its schema admits.
- * Callers ignore hybrid proxy/concrete probes that cannot execute and require
- * every executable counterfactual to preserve the candidate marker.
- */
-function collectCounterfactualProbes(
-  node: unknown,
-  candidate: string,
-  prefix = '',
-  out: CounterfactualProbe[] = []
-): CounterfactualProbe[] {
-  if (node === null || typeof node !== 'object' || Array.isArray(node)) return out;
-
-  const objectNode = node as {
-    required?: Array<{ key: string; value: unknown }>;
-    optional?: Array<{ key: string; value: unknown }>;
-  };
-  const candidateDependsOnPath = (path: string): boolean =>
-    candidate === path || candidate.startsWith(`${path}.`);
-
-  for (const property of objectNode.required ?? []) {
-    const path = prefix ? `${prefix}.${property.key}` : property.key;
-    if (!candidateDependsOnPath(path)) {
-      for (const value of falsySchemaValues(property.value)) {
-        out.push({ absent: new Set(), overrides: new Map([[path, value]]) });
-      }
-    }
-    collectCounterfactualProbes(property.value, candidate, path, out);
-  }
-
-  for (const property of objectNode.optional ?? []) {
-    const path = prefix ? `${prefix}.${property.key}` : property.key;
-    if (!candidateDependsOnPath(path)) {
-      out.push({ absent: new Set([path]), overrides: new Map() });
-      for (const value of falsySchemaValues(property.value)) {
-        out.push({ absent: new Set(), overrides: new Map([[path, value]]) });
-      }
-    }
-    collectCounterfactualProbes(property.value, candidate, path, out);
-  }
-
-  return out;
-}
-
-/**
- * ValuesMergeExpression is an authoring-time wrapper. When a counterfactual
- * removes the overlay that created it, the same authored base appears directly.
- * Treat `base` segments introduced by that wrapper as transparent for probes.
- */
-function readAuthoredValueAtPath(obj: unknown, path: string[]): unknown {
-  let current: unknown = obj;
-  for (const key of path) {
-    if (key === 'base' && !isValuesMergeExpression(current)) continue;
-    if (current === null || typeof current !== 'object') return undefined;
-    current = (current as Record<string, unknown>)[key];
-  }
-  return current;
-}
-
-function exactSchemaField(value: unknown): string | undefined {
-  const valueString =
-    typeof value === 'function' || typeof value === 'string' ? String(value) : undefined;
-  const marker = valueString?.match(FULL_MARKER_RE)?.[1];
-  return marker?.startsWith('spec.') ? marker.slice('spec.'.length) : undefined;
-}
-
-/**
- * Capture object/array-valued `??` fallbacks without teaching integrations
- * about schema proxies. The proxy run contributes the exact `spec.X` marker;
- * the optionals-absent run contributes the concrete structured fallback.
- * Choosing the whole object preserves JavaScript replacement semantics.
- */
-function extractStructuredFallbacksByComparison(
-  compositionFn: (...args: unknown[]) => unknown,
-  specJson: unknown,
+function collectAmbiguousStructuredFallbacks(
   proxyValue: unknown,
   fallbackValue: unknown,
   resourceId: string,
   path: string[],
-  out: ReExecutionResult['structuredFallbackOverrides']
+  out: ReExecutionResult['ambiguousStructuredFallbacks']
 ): void {
-  // A graph-aware optional `values` overlay can make the proxy run a
-  // ValuesMergeExpression while the optionals-absent run remains the plain
-  // base object. Compare the authored base against that concrete fallback so
-  // defaults nested inside helpers are captured before runtime merge lowering.
   if (isValuesMergeExpression(proxyValue) && !isValuesMergeExpression(fallbackValue)) {
-    extractStructuredFallbacksByComparison(
-      compositionFn,
-      specJson,
+    collectAmbiguousStructuredFallbacks(
       proxyValue.base,
       fallbackValue,
       resourceId,
@@ -821,94 +625,21 @@ function extractStructuredFallbacksByComparison(
       ? String(proxyValue)
       : undefined;
   const exactMarker = proxyString?.match(FULL_MARKER_RE)?.[1];
-
-  if (exactMarker?.startsWith('spec.')) {
-    if (
-      Array.isArray(fallbackValue) ||
-      (fallbackValue !== null && typeof fallbackValue === 'object')
-    ) {
-      try {
-        const field = exactMarker.slice('spec.'.length);
-        const probeResource = runProbe(
-          compositionFn,
-          specJson,
-          new Set<string>([field]),
-          resourceId
-        );
-        const probedFallback = readAuthoredValueAtPath(probeResource, path);
-        if (
-          !Array.isArray(probedFallback) &&
-          (probedFallback === null || typeof probedFallback !== 'object')
-        ) {
-          return;
-        }
-        const fallbackCel = celLiteralForValueTree(
-          fallbackValue,
-          undefined,
-          `structured-default.${resourceId}.${path.join('.')}`
-        );
-        const probedFallbackCel = celLiteralForValueTree(
-          probedFallback,
-          undefined,
-          `structured-default.${resourceId}.${path.join('.')}`
-        );
-        // A proxy/default diff can also be produced by an unrelated conditional,
-        // for example `spec.enabled ? spec.resources : defaults`. Confirm that
-        // removing the referenced field itself selects this exact fallback before
-        // attributing the behavior to nullish coalescing.
-        if (probedFallbackCel !== fallbackCel) return;
-        // The referenced field must also remain the selected marker under every
-        // other single-field counterfactual. This rejects control flow such as
-        // `enabled && resources ? resources : defaults`, including when enabled
-        // is a required boolean and therefore cannot be tested by absence alone.
-        for (const counterfactual of collectCounterfactualProbes(specJson, field)) {
-          const counterfactualResult = runProbeWithResult(
-            compositionFn,
-            specJson,
-            counterfactual.absent,
-            resourceId,
-            counterfactual.overrides
-          );
-          // Some helpers legitimately cannot operate on a hybrid proxy/concrete
-          // input (for example structuredClone after an optional overlay becomes
-          // undefined). Such a probe carries no semantic evidence either way.
-          if (!counterfactualResult.completed) continue;
-          const observedField = exactSchemaField(
-            readAuthoredValueAtPath(counterfactualResult.resource, path)
-          );
-          if (observedField !== field) {
-            logger.debug('Structured fallback candidate rejected by counterfactual probe', {
-              resourceId,
-              path: path.join('.'),
-              field,
-              observedField,
-              absent: [...counterfactual.absent],
-              overrides: Object.fromEntries(counterfactual.overrides),
-            });
-            return;
-          }
-        }
-        out.push({
-          resourceId,
-          path: [...path],
-          cel: `\${${presenceGuard(field)} ? ${celField(field)} : (${fallbackCel})}`,
-        });
-      } catch (error) {
-        logger.debug('Skipping non-serializable structured fallback', {
-          resourceId,
-          path: path.join('.'),
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
+  if (
+    exactMarker?.startsWith('spec.') &&
+    (Array.isArray(fallbackValue) || (fallbackValue !== null && typeof fallbackValue === 'object'))
+  ) {
+    out.push({
+      resourceId,
+      path: [...path],
+      field: exactMarker.slice('spec.'.length),
+    });
     return;
   }
 
   if (Array.isArray(proxyValue) && Array.isArray(fallbackValue)) {
     for (let index = 0; index < Math.min(proxyValue.length, fallbackValue.length); index++) {
-      extractStructuredFallbacksByComparison(
-        compositionFn,
-        specJson,
+      collectAmbiguousStructuredFallbacks(
         proxyValue[index],
         fallbackValue[index],
         resourceId,
@@ -926,9 +657,7 @@ function extractStructuredFallbacksByComparison(
     typeof fallbackValue === 'object'
   ) {
     for (const key of Object.keys(proxyValue as Record<string, unknown>)) {
-      extractStructuredFallbacksByComparison(
-        compositionFn,
-        specJson,
+      collectAmbiguousStructuredFallbacks(
         (proxyValue as Record<string, unknown>)[key],
         (fallbackValue as Record<string, unknown>)[key],
         resourceId,
@@ -937,6 +666,36 @@ function extractStructuredFallbacksByComparison(
       );
     }
   }
+}
+
+function assertNoAmbiguousStructuredFallbacks(result: ReExecutionResult | undefined): void {
+  const [ambiguous] = result?.ambiguousStructuredFallbacks ?? [];
+  if (!ambiguous) return;
+
+  throw new TypeKroError(
+    `Cannot prove structured fallback semantics for schema.spec.${ambiguous.field} at ` +
+      `${ambiguous.resourceId}.${ambiguous.path.join('.')}. ` +
+      'Black-box re-execution cannot distinguish nullish coalescing from value-based control flow. ' +
+      'Use Cel.default(value, fallback) or Cel.coalesce(value, fallback) to make the graph semantics explicit.',
+    'AMBIGUOUS_STRUCTURED_FALLBACK',
+    {
+      resourceId: ambiguous.resourceId,
+      path: ambiguous.path.join('.'),
+      field: ambiguous.field,
+    }
+  );
+}
+
+/**
+ * Presence guard for a (possibly nested) optional field — every ancestor must be
+ * present too. `userDeployments.enableSubchart` →
+ * `has(schema.spec.userDeployments) && has(schema.spec.userDeployments.enableSubchart)`.
+ * Matches the optional-chain guard the inline analyzer emits, so a bare nested ref is
+ * never read through an absent parent.
+ */
+function presenceGuard(field: string): string {
+  const segs = field.split('.');
+  return segs.map((_, i) => `has(schema.spec.${segs.slice(0, i + 1).join('.')})`).join(' && ');
 }
 
 /** Render the chain's CEL: <guard(a)> ? a : (<guard(b)> ? b : <tail>). */
@@ -1681,6 +1440,7 @@ export function arktypeToKroSchema(
               nestedResources
             )
           : undefined;
+      assertNoAmbiguousStructuredFallbacks(reExecutionResult);
       const reExecutionDefaults = reExecutionResult?.defaults ?? {};
       const innerDefaults = remapNullishDefaults(
         { ...extractedDefaults, ...reExecutionDefaults },
@@ -1713,11 +1473,9 @@ export function arktypeToKroSchema(
       resources
     );
     if (reExecutionResult) {
+      assertNoAmbiguousStructuredFallbacks(reExecutionResult);
       applyNullishDefaults(specFields, reExecutionResult.defaults, true);
       ternaryConditionals.push(...reExecutionResult.ternaryConditionals);
-      for (const override of reExecutionResult.structuredFallbackOverrides) {
-        setAtResourcePath(resources[override.resourceId], override.path, override.cel);
-      }
       // Cross-field `??` chains reconstructed by probing: write each CEL conditional
       // directly at its resource path (overwriting the bare head-field marker).
       for (const ov of reExecutionResult.crossFieldOverrides) {

--- a/src/factories/apisix/compositions/apisix-bootstrap.ts
+++ b/src/factories/apisix/compositions/apisix-bootstrap.ts
@@ -1,6 +1,7 @@
 import { getCurrentCompositionContext } from '../../../core/composition/context.js';
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
+import { Cel } from '../../../core/references/cel.js';
 import { singleton } from '../../../core/singleton/singleton.js';
 import type {
   DirectResourceFactory,
@@ -93,7 +94,7 @@ function createApisixBootstrap(requireDefinitionCredentials = false) {
       // Global defaults
       global: {
         ...spec.global,
-        imagePullSecrets: spec.global?.imagePullSecrets || [],
+        imagePullSecrets: Cel.default(spec.global?.imagePullSecrets, []),
         imageRegistry: spec.global?.imageRegistry || '',
       },
 
@@ -115,12 +116,12 @@ function createApisixBootstrap(requireDefinitionCredentials = false) {
         },
       },
 
-    // Ingress config compatibility defaults. The chart subchart remains disabled below.
+      // Ingress config compatibility defaults. The chart subchart remains disabled below.
       ingressController: {
         ...spec.ingressController,
         enabled:
           spec.ingressController?.enabled !== undefined ? spec.ingressController.enabled : true,
-        extraArgs: spec.ingressController?.extraArgs || [],
+        extraArgs: Cel.default(spec.ingressController?.extraArgs, []),
         config: {
           ...spec.ingressController?.config,
           kubernetes: {

--- a/src/factories/clickstack/utils/helm-values-mapper.ts
+++ b/src/factories/clickstack/utils/helm-values-mapper.ts
@@ -127,7 +127,7 @@ function resolve<T>(value: T | undefined, fallback: NonNullable<T>): NonNullable
     return Cel.default(
       value as Parameters<typeof Cel.default>[0],
       fallback as Parameters<typeof Cel.default>[1]
-    ) as NonNullable<T>;
+    ) as unknown as NonNullable<T>;
   }
   return (value ?? fallback) as NonNullable<T>;
 }

--- a/src/factories/ory/utils/helm-values-mapper.ts
+++ b/src/factories/ory/utils/helm-values-mapper.ts
@@ -5,7 +5,11 @@ import {
 } from '../../../core/aspects/values-merge.js';
 import { Cel } from '../../../core/references/cel.js';
 import type { TypeKroChartValue, TypeKroChartValues } from '../../../core/types/common.js';
-import { isCelExpression, isKubernetesRef } from '../../../utils/type-guards.js';
+import {
+  containsKubernetesRefs,
+  isCelExpression,
+  isKubernetesRef,
+} from '../../../utils/type-guards.js';
 import type {
   OryConfigValidationResult,
   OryDependencySource,
@@ -91,7 +95,12 @@ function mergeValues<T extends object>(
   if (isValuesMergeExpression(base)) {
     return mergeValuesExpression(base, typed) as unknown as T;
   }
-  if (isKubernetesRef(typed) || isCelExpression(typed) || isValuesMergeExpression(typed)) {
+  if (
+    containsKubernetesRefs(base) ||
+    isKubernetesRef(typed) ||
+    isCelExpression(typed) ||
+    isValuesMergeExpression(typed)
+  ) {
     return mergeValuesExpression(base, typed) as unknown as T;
   }
   return (typed === undefined ? base : deepMergeValue(base, typed)) as T;
@@ -646,7 +655,7 @@ export const mapOryConfigToHelmValues: OryHelmValuesMapper = (config) => {
     ),
   };
 
-  if (isKubernetesRef(config.global)) {
+  if (containsKubernetesRefs(config)) {
     const graphGlobal = config.global ? { global: config.global } : undefined;
     values.hydra = mergeValues(values.hydra, graphGlobal);
     values.kratos = mergeValues(values.kratos, graphGlobal);

--- a/src/factories/rook/types.ts
+++ b/src/factories/rook/types.ts
@@ -327,6 +327,14 @@ const cephDaemonResourcesSchemaShape = {
   rgw: resourceRequirementsSchemaShape,
 } as const;
 
+const optionalCephDaemonResourcesSchemaShape = {
+  'mon?': resourceRequirementsSchemaShape,
+  'mgr?': resourceRequirementsSchemaShape,
+  'osd?': resourceRequirementsSchemaShape,
+  'prepareosd?': resourceRequirementsSchemaShape,
+  'rgw?': resourceRequirementsSchemaShape,
+} as const;
+
 const rookCephClusterCommonSchemaShape = {
   name: 'string',
   'namespace?': 'string',
@@ -349,6 +357,7 @@ export const RookCephSingleNodePlatformConfigSchema = type({
   ...rookCephClusterCommonSchemaShape,
   profile: '"single-node-development"',
   'storageSize?': 'string',
+  'resources?': optionalCephDaemonResourcesSchemaShape,
 });
 
 export type RookCephSingleNodePlatformConfig = typeof RookCephSingleNodePlatformConfigSchema.infer;
@@ -371,6 +380,7 @@ export const RookCephExternalOperatorSingleNodePlatformConfigSchema = type({
   operatorNamespace: 'string',
   'operatorDeploymentName?': 'string',
   'storageSize?': 'string',
+  'resources?': optionalCephDaemonResourcesSchemaShape,
 });
 
 export type RookCephExternalOperatorSingleNodePlatformConfig =

--- a/src/factories/rook/utils/helm-values-mapper.ts
+++ b/src/factories/rook/utils/helm-values-mapper.ts
@@ -5,7 +5,6 @@ import {
   mergeValuesExpression,
   type ValuesMergeExpression,
 } from '../../../core/aspects/values-merge.js';
-import { Cel } from '../../../core/references/cel.js';
 import { isCelExpression, isKubernetesRef } from '../../../utils/type-guards.js';
 import type {
   CephObjectStoreConfig,
@@ -152,36 +151,13 @@ const singleNodeResources = {
   rgw: { requests: { cpu: '100m', memory: '256Mi' }, limits: { memory: '1Gi' } },
 };
 
-type SingleNodeResourceMap = NonNullable<RookCephSingleNodePlatformConfig['resources']>;
-type SingleNodeDaemon = keyof SingleNodeResourceMap;
-type SingleNodeResourceRequirements = NonNullable<SingleNodeResourceMap[SingleNodeDaemon]>;
-
-function resolveSingleNodeDaemonResources(
-  config: RookCephSingleNodePlatformConfig,
-  daemon: SingleNodeDaemon,
-  fallback: SingleNodeResourceRequirements
-): SingleNodeResourceRequirements {
-  if (!isKubernetesRef(config.name)) {
-    return config.resources?.[daemon] ?? fallback;
-  }
-
-  const path = `schema.spec.resources.${daemon}`;
-  return Cel.expr<SingleNodeResourceRequirements>(
-    `has(schema.spec.resources) && has(${path}) ? ${path} : ${JSON.stringify(fallback)}`
-  );
-}
-
 function resolveSingleNodeResources(config: RookCephSingleNodePlatformConfig) {
   return {
-    mon: resolveSingleNodeDaemonResources(config, 'mon', singleNodeResources.mon),
-    mgr: resolveSingleNodeDaemonResources(config, 'mgr', singleNodeResources.mgr),
-    osd: resolveSingleNodeDaemonResources(config, 'osd', singleNodeResources.osd),
-    prepareosd: resolveSingleNodeDaemonResources(
-      config,
-      'prepareosd',
-      singleNodeResources.prepareosd
-    ),
-    rgw: resolveSingleNodeDaemonResources(config, 'rgw', singleNodeResources.rgw),
+    mon: config.resources?.mon ?? singleNodeResources.mon,
+    mgr: config.resources?.mgr ?? singleNodeResources.mgr,
+    osd: config.resources?.osd ?? singleNodeResources.osd,
+    prepareosd: config.resources?.prepareosd ?? singleNodeResources.prepareosd,
+    rgw: config.resources?.rgw ?? singleNodeResources.rgw,
   };
 }
 

--- a/src/factories/rook/utils/helm-values-mapper.ts
+++ b/src/factories/rook/utils/helm-values-mapper.ts
@@ -151,10 +151,21 @@ const singleNodeResources = {
   rgw: { requests: { cpu: '100m', memory: '256Mi' }, limits: { memory: '1Gi' } },
 };
 
+function resolveSingleNodeResources(config: RookCephSingleNodePlatformConfig) {
+  return {
+    mon: config.resources?.mon ?? singleNodeResources.mon,
+    mgr: config.resources?.mgr ?? singleNodeResources.mgr,
+    osd: config.resources?.osd ?? singleNodeResources.osd,
+    prepareosd: config.resources?.prepareosd ?? singleNodeResources.prepareosd,
+    rgw: config.resources?.rgw ?? singleNodeResources.rgw,
+  };
+}
+
 /** Canonical single-node RGW spec shared by chart and composition materialization. */
 export function mapRookCephSingleNodeObjectStoreSpec(
-  _config: RookCephSingleNodePlatformConfig
+  config: RookCephSingleNodePlatformConfig
 ): CephObjectStoreConfig['spec'] {
+  const resources = resolveSingleNodeResources(config);
   return {
     metadataPool: {
       failureDomain: 'osd',
@@ -165,7 +176,7 @@ export function mapRookCephSingleNodeObjectStoreSpec(
       replicated: { size: 1, requireSafeReplicaSize: false },
     },
     preservePoolsOnDelete: true,
-    gateway: { port: 80, instances: 1, resources: singleNodeResources.rgw },
+    gateway: { port: 80, instances: 1, resources: resources.rgw },
   };
 }
 
@@ -226,7 +237,7 @@ export function mapRookCephSingleNodePlatformToHelmValues(
 ): RookCephClusterChartValues | ValuesMergeExpression {
   const objectStoreName = config.objectStoreName ?? 'harbor-object-store';
   const storageClassName = config.bucketStorageClassName ?? 'harbor-ceph-bucket-retain';
-  const resources = singleNodeResources;
+  const resources = resolveSingleNodeResources(config);
   const values: RookCephClusterChartValues = {
     operatorNamespace: config.operatorNamespace ?? 'rook-ceph-operator',
     clusterName: config.name,

--- a/src/factories/rook/utils/helm-values-mapper.ts
+++ b/src/factories/rook/utils/helm-values-mapper.ts
@@ -6,7 +6,11 @@ import {
   type ValuesMergeExpression,
 } from '../../../core/aspects/values-merge.js';
 import { Cel } from '../../../core/references/cel.js';
-import { isCelExpression, isKubernetesRef } from '../../../utils/type-guards.js';
+import {
+  containsKubernetesRefs,
+  isCelExpression,
+  isKubernetesRef,
+} from '../../../utils/type-guards.js';
 import type {
   CephObjectStoreConfig,
   RookCephOperatorBootstrapConfig,
@@ -70,9 +74,8 @@ function mergeValuesLast<T extends Record<string, unknown>>(
   base: T,
   overrides: unknown
 ): T | ValuesMergeExpression {
-  if (overrides === undefined) return base;
-
   if (
+    containsKubernetesRefs(base) ||
     isKubernetesRef(overrides) ||
     isCelExpression(overrides) ||
     isValuesMergeExpression(overrides)
@@ -80,6 +83,7 @@ function mergeValuesLast<T extends Record<string, unknown>>(
     return mergeValuesExpression(base, overrides);
   }
 
+  if (overrides === undefined) return base;
   if (isPlainObject(overrides)) deepMerge(base, overrides);
   return base;
 }

--- a/src/factories/rook/utils/helm-values-mapper.ts
+++ b/src/factories/rook/utils/helm-values-mapper.ts
@@ -5,6 +5,7 @@ import {
   mergeValuesExpression,
   type ValuesMergeExpression,
 } from '../../../core/aspects/values-merge.js';
+import { Cel } from '../../../core/references/cel.js';
 import { isCelExpression, isKubernetesRef } from '../../../utils/type-guards.js';
 import type {
   CephObjectStoreConfig,
@@ -151,13 +152,36 @@ const singleNodeResources = {
   rgw: { requests: { cpu: '100m', memory: '256Mi' }, limits: { memory: '1Gi' } },
 };
 
+type SingleNodeResourceMap = NonNullable<RookCephSingleNodePlatformConfig['resources']>;
+type SingleNodeDaemon = keyof SingleNodeResourceMap;
+type SingleNodeResourceRequirements = NonNullable<SingleNodeResourceMap[SingleNodeDaemon]>;
+
+function resolveSingleNodeDaemonResources(
+  config: RookCephSingleNodePlatformConfig,
+  daemon: SingleNodeDaemon,
+  fallback: SingleNodeResourceRequirements
+): SingleNodeResourceRequirements {
+  if (!isKubernetesRef(config.name)) {
+    return config.resources?.[daemon] ?? fallback;
+  }
+
+  const path = `schema.spec.resources.${daemon}`;
+  return Cel.expr<SingleNodeResourceRequirements>(
+    `has(schema.spec.resources) && has(${path}) ? ${path} : ${JSON.stringify(fallback)}`
+  );
+}
+
 function resolveSingleNodeResources(config: RookCephSingleNodePlatformConfig) {
   return {
-    mon: config.resources?.mon ?? singleNodeResources.mon,
-    mgr: config.resources?.mgr ?? singleNodeResources.mgr,
-    osd: config.resources?.osd ?? singleNodeResources.osd,
-    prepareosd: config.resources?.prepareosd ?? singleNodeResources.prepareosd,
-    rgw: config.resources?.rgw ?? singleNodeResources.rgw,
+    mon: resolveSingleNodeDaemonResources(config, 'mon', singleNodeResources.mon),
+    mgr: resolveSingleNodeDaemonResources(config, 'mgr', singleNodeResources.mgr),
+    osd: resolveSingleNodeDaemonResources(config, 'osd', singleNodeResources.osd),
+    prepareosd: resolveSingleNodeDaemonResources(
+      config,
+      'prepareosd',
+      singleNodeResources.prepareosd
+    ),
+    rgw: resolveSingleNodeDaemonResources(config, 'rgw', singleNodeResources.rgw),
   };
 }
 

--- a/src/factories/rook/utils/helm-values-mapper.ts
+++ b/src/factories/rook/utils/helm-values-mapper.ts
@@ -5,6 +5,7 @@ import {
   mergeValuesExpression,
   type ValuesMergeExpression,
 } from '../../../core/aspects/values-merge.js';
+import { Cel } from '../../../core/references/cel.js';
 import { isCelExpression, isKubernetesRef } from '../../../utils/type-guards.js';
 import type {
   CephObjectStoreConfig,
@@ -153,11 +154,11 @@ const singleNodeResources = {
 
 function resolveSingleNodeResources(config: RookCephSingleNodePlatformConfig) {
   return {
-    mon: config.resources?.mon ?? singleNodeResources.mon,
-    mgr: config.resources?.mgr ?? singleNodeResources.mgr,
-    osd: config.resources?.osd ?? singleNodeResources.osd,
-    prepareosd: config.resources?.prepareosd ?? singleNodeResources.prepareosd,
-    rgw: config.resources?.rgw ?? singleNodeResources.rgw,
+    mon: Cel.default(config.resources?.mon, singleNodeResources.mon),
+    mgr: Cel.default(config.resources?.mgr, singleNodeResources.mgr),
+    osd: Cel.default(config.resources?.osd, singleNodeResources.osd),
+    prepareosd: Cel.default(config.resources?.prepareosd, singleNodeResources.prepareosd),
+    rgw: Cel.default(config.resources?.rgw, singleNodeResources.rgw),
   };
 }
 

--- a/test/core/cel.test.ts
+++ b/test/core/cel.test.ts
@@ -233,7 +233,7 @@ describe('CEL Expression Builder', () => {
       const managed = Cel.expr<boolean>(mode, ' == "managed"');
 
       expect(managed.expression).toBe(
-        '(has(schema.spec.dependencySources.hydra.database.dsn.mode) ? (schema.spec.dependencySources.hydra.database.dsn.mode) : "managed") == "managed"'
+        '(has(schema.spec.dependencySources.hydra.database.dsn.mode) && (schema.spec.dependencySources.hydra.database.dsn.mode) != null ? (schema.spec.dependencySources.hydra.database.dsn.mode) : "managed") == "managed"'
       );
     });
   });

--- a/test/factories/clickstack/factory-modes.test.ts
+++ b/test/factories/clickstack/factory-modes.test.ts
@@ -433,8 +433,8 @@ describe('clickstackK8sTelemetry factory modes', () => {
       expect(secretRefs).toHaveLength(2);
       expect(secretRefs.every((ref) => ref.optional === false)).toBe(true);
       expect(secretRefs.map((ref) => ref.key)).toEqual([
-        '${has(schema.spec.apiKeySecret) && has(schema.spec.apiKeySecret.key) ? schema.spec.apiKeySecret.key : "HYPERDX_API_KEY"}',
-        '${has(schema.spec.apiKeySecret) && has(schema.spec.apiKeySecret.key) ? schema.spec.apiKeySecret.key : "HYPERDX_API_KEY"}',
+        '${has(schema.spec.apiKeySecret) && has(schema.spec.apiKeySecret.key) && schema.spec.apiKeySecret.key != null ? schema.spec.apiKeySecret.key : "HYPERDX_API_KEY"}',
+        '${has(schema.spec.apiKeySecret) && has(schema.spec.apiKeySecret.key) && schema.spec.apiKeySecret.key != null ? schema.spec.apiKeySecret.key : "HYPERDX_API_KEY"}',
       ]);
 
       // Status contract: ready/phase over BOTH owned HelmReleases.

--- a/test/factories/ory/platform-composition.test.ts
+++ b/test/factories/ory/platform-composition.test.ts
@@ -223,7 +223,7 @@ describe('Ory platform stack composition', () => {
     expect(renderedYaml).not.toContain('? has(schema.spec.kratos.identitySchema) ?');
     expect(renderedYaml).toContain('["identitySchemas"]).merge');
     expect(renderedYaml).toContain(
-      'has(schema.spec.kratos) && has(schema.spec.kratos.identitySchema) ? schema.spec.kratos.identitySchema'
+      'has(schema.spec.kratos) && has(schema.spec.kratos.identitySchema) && schema.spec.kratos.identitySchema != null ? schema.spec.kratos.identitySchema'
     );
     expect(renderedYaml).toContain('has(schema.spec.maester.hydra.enabledNamespaces)');
     expect(renderedYaml).not.toContain('"enabledNamespaces": schema.spec.maester.hydra.enabledNamespaces');

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -74,6 +74,38 @@ describe('official Rook Ceph cluster chart platform', () => {
     });
   });
 
+  it('overrides individual development daemon resources without restating every daemon', () => {
+    const osd = {
+      requests: { cpu: '500m', memory: '2Gi' },
+      limits: { memory: '4Gi' },
+    };
+    const rgw = {
+      requests: { cpu: '250m', memory: '512Mi' },
+      limits: { memory: '2Gi' },
+    };
+    const values = mapRookCephSingleNodePlatformToHelmValues({
+      name: 'rook-local',
+      profile: 'single-node-development',
+      storageClassName: 'local-path',
+      resources: { osd, rgw },
+    });
+    expect(values).toMatchObject({
+      cephClusterSpec: {
+        resources: {
+          mon: {
+            requests: { cpu: '100m', memory: '256Mi' },
+            limits: { memory: '1Gi' },
+          },
+          osd,
+        },
+        storage: {
+          storageClassDeviceSets: [{ resources: osd }],
+        },
+      },
+      cephObjectStores: [{ spec: { gateway: { resources: rgw } } }],
+    });
+  });
+
   it('deep-merges raw chart values last without erasing unrelated safe defaults', () => {
     const values = mapRookCephSingleNodePlatformToHelmValues({
       name: 'rook-local',
@@ -170,6 +202,43 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(yaml).toContain('kind: CephObjectStore');
     expect(yaml).toContain('kind: StorageClass');
     expectCleanYaml(yaml);
+  });
+
+  it('admits and renders development daemon resource overrides in direct and KRO modes', () => {
+    const config = {
+      name: 'rook-local',
+      profile: 'single-node-development' as const,
+      storageClassName: 'local-path',
+      resources: {
+        osd: {
+          requests: { cpu: '500m', memory: '2Gi' },
+          limits: { memory: '4Gi' },
+        },
+        rgw: {
+          requests: { memory: '512Mi' },
+          limits: { memory: '2Gi' },
+        },
+      },
+    };
+    const factory = rookCephSingleNodePlatform.factory('kro', {
+      namespace: 'typekro-control',
+    });
+    const directYaml = rookCephSingleNodePlatform
+      .factory('direct', { namespace: 'typekro-control' })
+      .toYaml(config);
+    const kroYaml = factory.toYaml(config);
+    const rgdYaml = factory.toYaml();
+
+    for (const yaml of [directYaml, kroYaml]) {
+      expect(yaml).toContain('memory: 4Gi');
+      expect(yaml).toContain('memory: 2Gi');
+      expect(yaml).toContain('memory: 512Mi');
+      expectCleanYaml(yaml);
+    }
+    expect(rgdYaml).toContain('resources:');
+    expect(rgdYaml).toContain('osd:');
+    expect(rgdYaml).toContain('rgw:');
+    expectCleanYaml(rgdYaml);
   });
 
   it('renders production singleton booleans as admission-enforced booleans', () => {

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -245,14 +245,11 @@ describe('official Rook Ceph cluster chart platform', () => {
       prepareosd: '{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"memory":"1Gi"}}',
       rgw: '{"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}}',
     };
+    const compactRgd = rgdYaml.replaceAll(' ', '');
     for (const [daemon, fallback] of Object.entries(expectedFallbacks)) {
       const path = `schema.spec.resources.${daemon}`;
-      expect(rgdYaml).toContain(
-        `has(schema.spec.resources) && has(${path}) ? ${path} : ${fallback}`
-      );
-      expect(rgdYaml).not.toContain(
-        `has(schema.spec.resources) && has(${path}) ? ${path} : omit()`
-      );
+      const guard = `has(schema.spec.resources)&&has(${path})?${path}:`;
+      expect(compactRgd).toContain(`${guard}(${fallback})`);
     }
     expectCleanYaml(rgdYaml);
   });

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -249,7 +249,7 @@ describe('official Rook Ceph cluster chart platform', () => {
     for (const [daemon, fallback] of Object.entries(expectedFallbacks)) {
       const path = `schema.spec.resources.${daemon}`;
       const guard = `has(schema.spec.resources)&&has(${path})?${path}:`;
-      expect(compactRgd).toContain(`${guard}(${fallback})`);
+      expect(compactRgd).toContain(`${guard}${fallback}`);
     }
     expectCleanYaml(rgdYaml);
   });

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -248,7 +248,7 @@ describe('official Rook Ceph cluster chart platform', () => {
     const compactRgd = rgdYaml.replaceAll(' ', '');
     for (const [daemon, fallback] of Object.entries(expectedFallbacks)) {
       const path = `schema.spec.resources.${daemon}`;
-      const guard = `has(schema.spec.resources)&&has(${path})?${path}:`;
+      const guard = `has(schema.spec.resources)&&has(${path})&&${path}!=null?${path}:`;
       expect(compactRgd).toContain(`${guard}${fallback}`);
     }
     expectCleanYaml(rgdYaml);

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -238,6 +238,22 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(rgdYaml).toContain('resources:');
     expect(rgdYaml).toContain('osd:');
     expect(rgdYaml).toContain('rgw:');
+    const expectedFallbacks = {
+      mon: '{"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}}',
+      mgr: '{"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}}',
+      osd: '{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}',
+      prepareosd: '{"requests":{"cpu":"100m","memory":"128Mi"},"limits":{"memory":"1Gi"}}',
+      rgw: '{"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}}',
+    };
+    for (const [daemon, fallback] of Object.entries(expectedFallbacks)) {
+      const path = `schema.spec.resources.${daemon}`;
+      expect(rgdYaml).toContain(
+        `has(schema.spec.resources) && has(${path}) ? ${path} : ${fallback}`
+      );
+      expect(rgdYaml).not.toContain(
+        `has(schema.spec.resources) && has(${path}) ? ${path} : omit()`
+      );
+    }
     expectCleanYaml(rgdYaml);
   });
 

--- a/test/integration/rook/ceph-platform.test.ts
+++ b/test/integration/rook/ceph-platform.test.ts
@@ -52,6 +52,22 @@ const osdResources = {
   requests: { cpu: '500m', memory: '1Gi' },
   limits: { memory: '4Gi' },
 };
+const monResources = {
+  requests: { cpu: '100m', memory: '256Mi' },
+  limits: { memory: '1Gi' },
+};
+const mgrResources = {
+  requests: { cpu: '100m', memory: '256Mi' },
+  limits: { memory: '1Gi' },
+};
+const prepareOsdResources = {
+  requests: { cpu: '100m', memory: '128Mi' },
+  limits: { memory: '1Gi' },
+};
+const rgwResources = {
+  requests: { cpu: '100m', memory: '256Mi' },
+  limits: { memory: '1Gi' },
+};
 const localBlock = createOrbStackLocalBlockFixture({
   name: `typekro-${suffix}-ceph-block`.slice(0, 48),
   namespace: controlNamespace,
@@ -283,12 +299,28 @@ describeOrSkip('official Rook/Ceph platform over a shared operator', () => {
       metadata: { name: clusterName, namespace: platformNamespace },
     })) as {
       spec?: {
-        resources?: { osd?: typeof osdResources };
+        resources?: {
+          mon?: typeof monResources;
+          mgr?: typeof mgrResources;
+          osd?: typeof osdResources;
+          prepareosd?: typeof prepareOsdResources;
+        };
         storage?: { storageClassDeviceSets?: Array<{ resources?: typeof osdResources }> };
       };
     };
+    expect(cluster.spec?.resources?.mon).toEqual(monResources);
+    expect(cluster.spec?.resources?.mgr).toEqual(mgrResources);
     expect(cluster.spec?.resources?.osd).toEqual(osdResources);
+    expect(cluster.spec?.resources?.prepareosd).toEqual(prepareOsdResources);
     expect(cluster.spec?.storage?.storageClassDeviceSets?.[0]?.resources).toEqual(osdResources);
+    const objectStore = (await objectApi.read({
+      apiVersion: 'ceph.rook.io/v1',
+      kind: 'CephObjectStore',
+      metadata: { name: objectStoreName, namespace: platformNamespace },
+    })) as {
+      spec?: { gateway?: { resources?: typeof rgwResources } };
+    };
+    expect(objectStore.spec?.gateway?.resources).toEqual(rgwResources);
   });
 
   it('binds an application claim and performs S3 put/get/delete', async () => {

--- a/test/integration/rook/ceph-platform.test.ts
+++ b/test/integration/rook/ceph-platform.test.ts
@@ -48,6 +48,10 @@ const objectStoreName = 'harbor-object-store';
 const retainedStorageClass = `typekro-${suffix}-bucket-retain`.slice(0, 63);
 const disposableStorageClass = `typekro-${suffix}-bucket-delete`.slice(0, 63);
 const operatorNamespace = 'typekro-rook-e2e-operator';
+const osdResources = {
+  requests: { cpu: '500m', memory: '1Gi' },
+  limits: { memory: '4Gi' },
+};
 const localBlock = createOrbStackLocalBlockFixture({
   name: `typekro-${suffix}-ceph-block`.slice(0, 48),
   namespace: controlNamespace,
@@ -240,6 +244,7 @@ describeOrSkip('official Rook/Ceph platform over a shared operator', () => {
         storageSize: '8Gi',
         objectStoreName,
         bucketStorageClassName: retainedStorageClass,
+        resources: { osd: osdResources },
       });
     } catch (error) {
       platformNamespaceLease = await captureTestNamespaceLease(platformNamespace, kubeConfig);
@@ -265,12 +270,25 @@ describeOrSkip('official Rook/Ceph platform over a shared operator', () => {
     });
     expect(platform.status.endpoint).not.toBe('');
     expect(['HEALTH_OK', 'HEALTH_WARN']).toContain(platform.status.cephHealth);
-    const storageClass = (await createKubernetesObjectApiClient(kubeConfig).read({
+    const objectApi = createKubernetesObjectApiClient(kubeConfig);
+    const storageClass = (await objectApi.read({
       apiVersion: 'storage.k8s.io/v1',
       kind: 'StorageClass',
       metadata: { name: retainedStorageClass },
     })) as { reclaimPolicy?: string };
     expect(storageClass.reclaimPolicy).toBe('Retain');
+    const cluster = (await objectApi.read({
+      apiVersion: 'ceph.rook.io/v1',
+      kind: 'CephCluster',
+      metadata: { name: clusterName, namespace: platformNamespace },
+    })) as {
+      spec?: {
+        resources?: { osd?: typeof osdResources };
+        storage?: { storageClassDeviceSets?: Array<{ resources?: typeof osdResources }> };
+      };
+    };
+    expect(cluster.spec?.resources?.osd).toEqual(osdResources);
+    expect(cluster.spec?.storage?.storageClassDeviceSets?.[0]?.resources).toEqual(osdResources);
   });
 
   it('binds an application claim and performs S3 put/get/delete', async () => {

--- a/test/unit/analysis-resource-diagnostics.test.ts
+++ b/test/unit/analysis-resource-diagnostics.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+describe('analysis-only resource diagnostics', () => {
+  it('does not emit namespace warnings from Rook counterfactual executions', () => {
+    const moduleUrl = pathToFileURL(
+      resolve(import.meta.dir, '../../src/factories/rook/index.ts')
+    ).href;
+    const result = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        '-e',
+        `import { rookCephSingleNodePlatform } from ${JSON.stringify(moduleUrl)}; rookCephSingleNodePlatform.factory('kro').toYaml();`,
+      ],
+      cwd: resolve(import.meta.dir, '../..'),
+      env: { ...process.env, TYPEKRO_LOG_LEVEL: 'warn' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const output =
+      new TextDecoder().decode(result.stdout) + new TextDecoder().decode(result.stderr);
+
+    expect(result.exitCode).toBe(0);
+    expect(output).not.toContain('no namespace specified');
+    expect(output).not.toContain('CephCluster');
+    expect(output).not.toContain('CephObjectStore');
+  });
+});

--- a/test/unit/compile-time-types.test.ts
+++ b/test/unit/compile-time-types.test.ts
@@ -218,6 +218,11 @@ describe('CelExpression<T> compile-time types', () => {
 
       // @ts-expect-error — string fallback is not valid for a numeric ref
       Cel.default(phantom<KubernetesRef<number | undefined>>(), 'fallback');
+
+      const structuredRef = phantom<KubernetesRef<{ limits?: { memory?: string } } | undefined>>();
+      assertType<{ limits?: { memory?: string } }>(
+        Cel.default(structuredRef, { limits: { memory: '2Gi' } })
+      );
     }
 
     expect(true).toBe(true);

--- a/test/unit/crd-manager.test.ts
+++ b/test/unit/crd-manager.test.ts
@@ -598,26 +598,54 @@ describe('CRDManager', () => {
 
   describe('ensureFluxCRDsPatched', () => {
     it('should only patch once (caches the promise)', async () => {
-      // ensureFluxCRDsPatched lazy-imports crd-patcher. We can't easily mock that,
-      // but we can verify it caches by calling twice and checking the promise identity.
-      // The import will fail in unit test context (no real cluster), but the error
-      // should be caught and logged as a warning.
+      const fluxCRDPatcher = mock(() => Promise.resolve());
+      crdManager = new CRDManager(
+        mockApi,
+        mockKubeConfig,
+        abortableDelay,
+        withAbortSignal,
+        fluxCRDPatcher
+      );
 
       const options: DeploymentOptions = {
         mode: 'direct',
         autoFix: { logLevel: 'debug' },
       };
 
-      // First call — will fail on dynamic import but catch the error
+      await Promise.all([
+        crdManager.ensureFluxCRDsPatched(options, mockLogger),
+        crdManager.ensureFluxCRDsPatched(options, mockLogger),
+      ]);
       await crdManager.ensureFluxCRDsPatched(options, mockLogger);
 
-      // Second call — should reuse or re-attempt (depending on whether first failed)
+      expect(fluxCRDPatcher).toHaveBeenCalledTimes(1);
+      expect(fluxCRDPatcher).toHaveBeenCalledWith(mockKubeConfig);
+      expect(mockLogger.debug).toHaveBeenCalledTimes(2);
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('should retry after a patch failure', async () => {
+      const fluxCRDPatcher = mock()
+        .mockRejectedValueOnce(new Error('temporary patch failure'))
+        .mockResolvedValueOnce(undefined);
+      crdManager = new CRDManager(
+        mockApi,
+        mockKubeConfig,
+        abortableDelay,
+        withAbortSignal,
+        fluxCRDPatcher
+      );
+
+      const options: DeploymentOptions = {
+        mode: 'direct',
+        autoFix: { logLevel: 'info' },
+      };
+
+      await crdManager.ensureFluxCRDsPatched(options, mockLogger);
       await crdManager.ensureFluxCRDsPatched(options, mockLogger);
 
-      // The logger should have been called (either success or warning)
-      const debugCalls = (mockLogger.debug as MockFn).mock.calls;
-      const warnCalls = (mockLogger.warn as MockFn).mock.calls;
-      expect(debugCalls.length + warnCalls.length).toBeGreaterThan(0);
+      expect(fluxCRDPatcher).toHaveBeenCalledTimes(2);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/test/unit/kro-v08-features-serialization.test.ts
+++ b/test/unit/kro-v08-features-serialization.test.ts
@@ -2213,7 +2213,9 @@ describe('Kro RGD Feature Serialization (requires KRO 0.9+ at runtime)', () => {
       );
 
       const yamlStr = graph.toYaml();
-      expect(yamlStr).toContain('${has(schema.spec.region) ? schema.spec.region');
+      expect(yamlStr).toContain(
+        '${has(schema.spec.region) && schema.spec.region != null ? schema.spec.region'
+      );
       expect(yamlStr).toContain('us-east-1');
     });
 
@@ -2239,7 +2241,9 @@ describe('Kro RGD Feature Serialization (requires KRO 0.9+ at runtime)', () => {
       );
 
       const yamlStr = graph.toYaml();
-      expect(yamlStr).toContain('${has(schema.spec.region) ? schema.spec.region');
+      expect(yamlStr).toContain(
+        '${has(schema.spec.region) && schema.spec.region != null ? schema.spec.region'
+      );
       expect(yamlStr).toContain('us-east-1');
     });
 
@@ -2320,9 +2324,11 @@ describe('Kro RGD Feature Serialization (requires KRO 0.9+ at runtime)', () => {
       const value = findResource(parsed, 'app').template.spec.template.spec.containers[0].env[0]
         .value as string;
       expect(value).toContain(
-        'has(schema.spec.primary) ? schema.spec.primary : (has(schema.spec.secondary)'
+        'has(schema.spec.primary) && schema.spec.primary != null ? schema.spec.primary : (has(schema.spec.secondary)'
       );
-      expect(value).toContain('? schema.spec.secondary : "fallback")');
+      expect(value).toContain(
+        '&& schema.spec.secondary != null ? schema.spec.secondary : "fallback")'
+      );
     });
 
     it('observedResource() serializes with the externalRef primitive', () => {

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -33,6 +33,14 @@ const ConditionalResourcesSpecSchema = type({
 
 type ConditionalResourcesSpec = typeof ConditionalResourcesSpecSchema.infer;
 
+const ScalarConditionalResourcesSpecSchema = type({
+  name: 'string',
+  mode: 'string',
+  'resources?': ResourceRequirementsSchema,
+});
+
+type ScalarConditionalResourcesSpec = typeof ScalarConditionalResourcesSpecSchema.infer;
+
 const StructuredChainSpecSchema = type({
   name: 'string',
   'primary?': ResourceRequirementsSchema,
@@ -96,6 +104,29 @@ const conditionalResourcesComposition = kubernetesComposition(
   },
   (spec: ConditionalResourcesSpec) => {
     const resources = resolveConditionalResources(spec);
+    Deployment({
+      name: spec.name,
+      image: 'nginx:1.29',
+      ...(resources === undefined ? {} : { resources }),
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
+function resolveScalarConditionalResources(spec: ScalarConditionalResourcesSpec) {
+  return spec.mode && spec.resources ? spec.resources : defaultOsdResources;
+}
+
+const scalarConditionalResourcesComposition = kubernetesComposition(
+  {
+    name: 'scalar-conditional-structured-resources',
+    kind: 'ScalarConditionalStructuredResources',
+    spec: ScalarConditionalResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: ScalarConditionalResourcesSpec) => {
+    const resources = resolveScalarConditionalResources(spec);
     Deployment({
       name: spec.name,
       image: 'nginx:1.29',
@@ -218,6 +249,33 @@ describe('structured nullish defaults', () => {
       resources: { limits: { memory: '4Gi' } },
     });
     const enabled = deploymentSection(enabledYaml, 'enabled');
+    expect(enabled).toContain('memory: 4Gi');
+    expect(enabled).not.toContain('memory: 2Gi');
+  });
+
+  it('does not erase a required scalar guard while inferring a structured fallback', () => {
+    const yaml = scalarConditionalResourcesComposition.factory('kro').toYaml();
+    const compact = yaml.replaceAll(' ', '');
+
+    expect(compact).not.toContain(
+      'has(schema.spec.resources)?schema.spec.resources:({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
+    );
+
+    const disabledYaml = scalarConditionalResourcesComposition.factory('direct').toYaml({
+      name: 'empty-mode',
+      mode: '',
+      resources: { limits: { memory: '4Gi' } },
+    });
+    const disabled = deploymentSection(disabledYaml, 'empty-mode');
+    expect(disabled).toContain('memory: 2Gi');
+    expect(disabled).not.toContain('memory: 4Gi');
+
+    const enabledYaml = scalarConditionalResourcesComposition.factory('direct').toYaml({
+      name: 'enabled-mode',
+      mode: 'enabled',
+      resources: { limits: { memory: '4Gi' } },
+    });
+    const enabled = deploymentSection(enabledYaml, 'enabled-mode');
     expect(enabled).toContain('memory: 4Gi');
     expect(enabled).not.toContain('memory: 2Gi');
   });

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -50,6 +50,14 @@ const StructuredChainSpecSchema = type({
 
 type StructuredChainSpec = typeof StructuredChainSpecSchema.infer;
 
+const GuardedResourcesSpecSchema = type({
+  name: 'string',
+  'enabled?': 'boolean',
+  'resources?': ResourceRequirementsSchema,
+});
+
+type GuardedResourcesSpec = typeof GuardedResourcesSpecSchema.infer;
+
 const defaultOsdResources = {
   requests: { cpu: '250m', memory: '1Gi' },
   limits: { memory: '2Gi' },
@@ -156,6 +164,66 @@ const structuredChainComposition = kubernetesComposition(
       resources: resolveStructuredChain(spec),
       id: 'workload',
     });
+    return { ready: true };
+  }
+);
+
+const guardedNativeFallbackComposition = kubernetesComposition(
+  {
+    name: 'guarded-native-structured-fallback',
+    kind: 'GuardedNativeStructuredFallback',
+    spec: GuardedResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: GuardedResourcesSpec) => {
+    if (spec.enabled) {
+      Deployment({
+        name: spec.name,
+        image: 'nginx:1.29',
+        resources: spec.resources ?? defaultOsdResources,
+        id: 'workload',
+      });
+    }
+    return { ready: true };
+  }
+);
+
+const guardedExplicitFallbackComposition = kubernetesComposition(
+  {
+    name: 'guarded-explicit-structured-fallback',
+    kind: 'GuardedExplicitStructuredFallback',
+    spec: GuardedResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: GuardedResourcesSpec) => {
+    if (spec.enabled) {
+      Deployment({
+        name: spec.name,
+        image: 'nginx:1.29',
+        resources: Cel.default(spec.resources, defaultOsdResources),
+        id: 'workload',
+      });
+    }
+    return { ready: true };
+  }
+);
+
+const guardedOptionalPassthroughComposition = kubernetesComposition(
+  {
+    name: 'guarded-optional-structured-passthrough',
+    kind: 'GuardedOptionalStructuredPassthrough',
+    spec: GuardedResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: GuardedResourcesSpec) => {
+    if (spec.enabled) {
+      Deployment({
+        name: spec.name,
+        image: 'nginx:1.29',
+        ...(spec.resources === undefined ? {} : { resources: spec.resources }),
+        id: 'workload',
+      });
+    }
     return { ready: true };
   }
 );
@@ -273,6 +341,34 @@ describe('structured nullish defaults', () => {
     const enabled = deploymentSection(enabledYaml, 'enabled-mode');
     expect(enabled).toContain('memory: 4Gi');
     expect(enabled).not.toContain('memory: 2Gi');
+  });
+
+  it('fails closed when the all-defaults execution omits the guarded resource', () => {
+    expect(() => guardedNativeFallbackComposition.factory('kro').toYaml()).toThrow(
+      /Cannot prove structured fallback semantics.*Cel\.default/
+    );
+  });
+
+  it('preserves an explicit fallback when the all-defaults execution omits the resource', () => {
+    const yaml = guardedExplicitFallbackComposition.factory('kro').toYaml();
+    const compact = yaml.replaceAll(' ', '');
+
+    expect(compact).toContain('includeWhen:');
+    expect(compact).toContain(
+      'has(schema.spec.resources)?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+    );
+    expect(compact).not.toContain(
+      'has(schema.spec.resources)?schema.spec.resources:omit()'
+    );
+  });
+
+  it('retains an authored optional passthrough on a guarded resource', () => {
+    const yaml = guardedOptionalPassthroughComposition.factory('kro').toYaml();
+    const compact = yaml.replaceAll(' ', '');
+
+    expect(compact).toContain(
+      'has(schema.spec.resources)?schema.spec.resources:omit()'
+    );
   });
 
   it('preserves a structured terminal fallback in a cross-field chain', () => {

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -27,7 +27,7 @@ type StructuredDefaultsSpec = typeof StructuredDefaultsSpecSchema.infer;
 
 const ConditionalResourcesSpecSchema = type({
   name: 'string',
-  'enabled?': 'boolean',
+  enabled: 'boolean',
   'resources?': ResourceRequirementsSchema,
 });
 
@@ -84,7 +84,7 @@ const structuredDefaultsComposition = kubernetesComposition(
 );
 
 function resolveConditionalResources(spec: ConditionalResourcesSpec) {
-  return spec.enabled ? spec.resources : defaultOsdResources;
+  return spec.enabled && spec.resources ? spec.resources : defaultOsdResources;
 }
 
 const conditionalResourcesComposition = kubernetesComposition(
@@ -202,6 +202,24 @@ describe('structured nullish defaults', () => {
     expect(compact).not.toContain(
       'has(schema.spec.resources)?schema.spec.resources:({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
     );
+
+    const disabledYaml = conditionalResourcesComposition.factory('direct').toYaml({
+      name: 'disabled',
+      enabled: false,
+      resources: { limits: { memory: '4Gi' } },
+    });
+    const disabled = deploymentSection(disabledYaml, 'disabled');
+    expect(disabled).toContain('memory: 2Gi');
+    expect(disabled).not.toContain('memory: 4Gi');
+
+    const enabledYaml = conditionalResourcesComposition.factory('direct').toYaml({
+      name: 'enabled',
+      enabled: true,
+      resources: { limits: { memory: '4Gi' } },
+    });
+    const enabled = deploymentSection(enabledYaml, 'enabled');
+    expect(enabled).toContain('memory: 4Gi');
+    expect(enabled).not.toContain('memory: 2Gi');
   });
 
   it('preserves a structured terminal fallback in a cross-field chain', () => {

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import type { V1ResourceRequirements } from '@kubernetes/client-node';
 import { type } from 'arktype';
 import { kubernetesComposition } from '../../src/core/composition/imperative.js';
+import { Cel } from '../../src/core/references/cel.js';
 import { Deployment } from '../../src/factories/simple/index.js';
 
 const ResourceRequirementsSchema = type({
@@ -61,8 +62,8 @@ const defaultMonResources = {
 
 function resolveDaemonResources(spec: StructuredDefaultsSpec) {
   return {
-    osd: spec.resources?.osd ?? defaultOsdResources,
-    mon: spec.resources?.mon ?? defaultMonResources,
+    osd: Cel.default(spec.resources?.osd, defaultOsdResources),
+    mon: Cel.default(spec.resources?.mon, defaultMonResources),
   };
 }
 
@@ -115,7 +116,7 @@ const conditionalResourcesComposition = kubernetesComposition(
 );
 
 function resolveScalarConditionalResources(spec: ScalarConditionalResourcesSpec) {
-  return spec.mode && spec.resources ? spec.resources : defaultOsdResources;
+  return spec.mode !== 'disabled' && spec.resources ? spec.resources : defaultOsdResources;
 }
 
 const scalarConditionalResourcesComposition = kubernetesComposition(
@@ -138,7 +139,7 @@ const scalarConditionalResourcesComposition = kubernetesComposition(
 );
 
 function resolveStructuredChain(spec: StructuredChainSpec) {
-  return spec.primary ?? spec.secondary ?? defaultOsdResources;
+  return Cel.default(spec.primary, Cel.default(spec.secondary, defaultOsdResources));
 }
 
 const structuredChainComposition = kubernetesComposition(
@@ -167,15 +168,15 @@ function deploymentSection(yaml: string, name: string): string {
 }
 
 describe('structured nullish defaults', () => {
-  it('lowers helper-returned object fallbacks into guarded KRO expressions', () => {
+  it('lowers explicit helper-returned structured defaults into guarded KRO expressions', () => {
     const yaml = structuredDefaultsComposition.factory('kro').toYaml();
     const compact = yaml.replaceAll(' ', '');
 
     expect(compact).toContain(
-      'has(schema.spec.resources)&&has(schema.spec.resources.osd)?schema.spec.resources.osd:({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
+      'has(schema.spec.resources)&&has(schema.spec.resources.osd)?schema.spec.resources.osd:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
     );
     expect(compact).toContain(
-      'has(schema.spec.resources)&&has(schema.spec.resources.mon)?schema.spec.resources.mon:({"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}})'
+      'has(schema.spec.resources)&&has(schema.spec.resources.mon)?schema.spec.resources.mon:{"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}}'
     );
   });
 
@@ -227,11 +228,8 @@ describe('structured nullish defaults', () => {
   });
 
   it('does not infer a nullish fallback from an unrelated conditional', () => {
-    const yaml = conditionalResourcesComposition.factory('kro').toYaml();
-    const compact = yaml.replaceAll(' ', '');
-
-    expect(compact).not.toContain(
-      'has(schema.spec.resources)?schema.spec.resources:({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
+    expect(() => conditionalResourcesComposition.factory('kro').toYaml()).toThrow(
+      /Cannot prove structured fallback semantics.*Cel\.default/
     );
 
     const disabledYaml = conditionalResourcesComposition.factory('direct').toYaml({
@@ -253,20 +251,17 @@ describe('structured nullish defaults', () => {
     expect(enabled).not.toContain('memory: 2Gi');
   });
 
-  it('does not erase a required scalar guard while inferring a structured fallback', () => {
-    const yaml = scalarConditionalResourcesComposition.factory('kro').toYaml();
-    const compact = yaml.replaceAll(' ', '');
-
-    expect(compact).not.toContain(
-      'has(schema.spec.resources)?schema.spec.resources:({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
+  it('fails closed instead of erasing a value-based scalar guard', () => {
+    expect(() => scalarConditionalResourcesComposition.factory('kro').toYaml()).toThrow(
+      /Cannot prove structured fallback semantics.*Cel\.default/
     );
 
     const disabledYaml = scalarConditionalResourcesComposition.factory('direct').toYaml({
-      name: 'empty-mode',
-      mode: '',
+      name: 'disabled-mode',
+      mode: 'disabled',
       resources: { limits: { memory: '4Gi' } },
     });
-    const disabled = deploymentSection(disabledYaml, 'empty-mode');
+    const disabled = deploymentSection(disabledYaml, 'disabled-mode');
     expect(disabled).toContain('memory: 2Gi');
     expect(disabled).not.toContain('memory: 4Gi');
 
@@ -285,7 +280,7 @@ describe('structured nullish defaults', () => {
     const compact = yaml.replaceAll(' ', '');
 
     expect(compact).toContain(
-      'has(schema.spec.primary)?schema.spec.primary:(has(schema.spec.secondary)?schema.spec.secondary:({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}))'
+      'has(schema.spec.primary)?schema.spec.primary:(has(schema.spec.secondary)?schema.spec.secondary:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
     );
   });
 

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import type { V1ResourceRequirements } from '@kubernetes/client-node';
 import { type } from 'arktype';
+import { mergeValuesExpression } from '../../src/core/aspects/values-merge.js';
 import { kubernetesComposition } from '../../src/core/composition/imperative.js';
 import { Cel } from '../../src/core/references/cel.js';
+import { helmRelease } from '../../src/factories/helm/helm-release.js';
 import { Deployment } from '../../src/factories/simple/index.js';
 
 const ResourceRequirementsSchema = type({
@@ -228,6 +230,86 @@ const guardedOptionalPassthroughComposition = kubernetesComposition(
   }
 );
 
+const mergedNativeFallbackComposition = kubernetesComposition(
+  {
+    name: 'merged-native-structured-fallback',
+    kind: 'MergedNativeStructuredFallback',
+    spec: GuardedResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: GuardedResourcesSpec) => {
+    helmRelease({
+      name: spec.name,
+      chart: { repository: 'https://example.com/charts', name: 'example' },
+      values: mergeValuesExpression(spec.resources ?? defaultOsdResources, {
+        replicaCount: 1,
+      }),
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
+const mergedExplicitFallbackComposition = kubernetesComposition(
+  {
+    name: 'merged-explicit-structured-fallback',
+    kind: 'MergedExplicitStructuredFallback',
+    spec: GuardedResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: GuardedResourcesSpec) => {
+    helmRelease({
+      name: spec.name,
+      chart: { repository: 'https://example.com/charts', name: 'example' },
+      values: mergeValuesExpression(Cel.default(spec.resources, defaultOsdResources), {
+        replicaCount: 1,
+      }),
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
+const mergedOverlayNativeFallbackComposition = kubernetesComposition(
+  {
+    name: 'merged-overlay-native-structured-fallback',
+    kind: 'MergedOverlayNativeStructuredFallback',
+    spec: GuardedResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: GuardedResourcesSpec) => {
+    helmRelease({
+      name: spec.name,
+      chart: { repository: 'https://example.com/charts', name: 'example' },
+      values: mergeValuesExpression({ replicaCount: 1 }, spec.resources ?? defaultOsdResources),
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
+function mergeOptionalValues(base: unknown, overlay: Record<string, unknown>) {
+  return base === undefined ? overlay : mergeValuesExpression(base, overlay);
+}
+
+const normalizedValuesMergeComposition = kubernetesComposition(
+  {
+    name: 'normalized-values-merge',
+    kind: 'NormalizedValuesMerge',
+    spec: GuardedResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: GuardedResourcesSpec) => {
+    helmRelease({
+      name: spec.name,
+      chart: { repository: 'https://example.com/charts', name: 'example' },
+      values: mergeOptionalValues(spec.resources, { replicaCount: 1 }),
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
 function deploymentSection(yaml: string, name: string): string {
   const start = yaml.indexOf(`name: ${name}`);
   expect(start).toBeGreaterThanOrEqual(0);
@@ -357,18 +439,45 @@ describe('structured nullish defaults', () => {
     expect(compact).toContain(
       'has(schema.spec.resources)?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
     );
-    expect(compact).not.toContain(
-      'has(schema.spec.resources)?schema.spec.resources:omit()'
-    );
+    expect(compact).not.toContain('has(schema.spec.resources)?schema.spec.resources:omit()');
   });
 
   it('retains an authored optional passthrough on a guarded resource', () => {
     const yaml = guardedOptionalPassthroughComposition.factory('kro').toYaml();
     const compact = yaml.replaceAll(' ', '');
 
-    expect(compact).toContain(
-      'has(schema.spec.resources)?schema.spec.resources:omit()'
+    expect(compact).toContain('has(schema.spec.resources)?schema.spec.resources:omit()');
+  });
+
+  it('fails closed for an implicit structured fallback inside a values-merge operand', () => {
+    expect(() => mergedNativeFallbackComposition.factory('kro').toYaml()).toThrow(
+      /Cannot prove structured fallback semantics.*Cel\.default/
     );
+  });
+
+  it('preserves an explicit structured fallback inside a values-merge operand', () => {
+    const yaml = mergedExplicitFallbackComposition.factory('kro').toYaml();
+    const compact = yaml.replaceAll(' ', '');
+
+    expect(compact).toContain(
+      'has(schema.spec.resources)?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+    );
+    expect(compact).toContain('"replicaCount":1');
+    expect(compact).not.toContain('has(schema.spec.resources)?schema.spec.resources:omit()');
+  });
+
+  it('fails closed for an implicit structured fallback inside a values-merge overlay', () => {
+    expect(() => mergedOverlayNativeFallbackComposition.factory('kro').toYaml()).toThrow(
+      /Cannot prove structured fallback semantics.*Cel\.default/
+    );
+  });
+
+  it('does not confuse a normalized-away values merge with a base fallback', () => {
+    const yaml = normalizedValuesMergeComposition.factory('kro').toYaml();
+    const compact = yaml.replaceAll(' ', '');
+
+    expect(compact).toContain('schema.spec.resources');
+    expect(compact).toContain('"replicaCount":1');
   });
 
   it('preserves a structured terminal fallback in a cross-field chain', () => {

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -95,10 +95,11 @@ const conditionalResourcesComposition = kubernetesComposition(
     status: type({ ready: 'boolean' }),
   },
   (spec: ConditionalResourcesSpec) => {
+    const resources = resolveConditionalResources(spec);
     Deployment({
       name: spec.name,
       image: 'nginx:1.29',
-      resources: resolveConditionalResources(spec),
+      ...(resources === undefined ? {} : { resources }),
       id: 'workload',
     });
     return { ready: true };

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -25,6 +25,22 @@ const StructuredDefaultsSpecSchema = type({
 
 type StructuredDefaultsSpec = typeof StructuredDefaultsSpecSchema.infer;
 
+const ConditionalResourcesSpecSchema = type({
+  name: 'string',
+  'enabled?': 'boolean',
+  'resources?': ResourceRequirementsSchema,
+});
+
+type ConditionalResourcesSpec = typeof ConditionalResourcesSpecSchema.infer;
+
+const StructuredChainSpecSchema = type({
+  name: 'string',
+  'primary?': ResourceRequirementsSchema,
+  'secondary?': ResourceRequirementsSchema,
+});
+
+type StructuredChainSpec = typeof StructuredChainSpecSchema.infer;
+
 const defaultOsdResources = {
   requests: { cpu: '250m', memory: '1Gi' },
   limits: { memory: '2Gi' },
@@ -62,6 +78,50 @@ const structuredDefaultsComposition = kubernetesComposition(
       image: 'nginx:1.29',
       resources: resources.mon,
       id: 'mon',
+    });
+    return { ready: true };
+  }
+);
+
+function resolveConditionalResources(spec: ConditionalResourcesSpec) {
+  return spec.enabled ? spec.resources : defaultOsdResources;
+}
+
+const conditionalResourcesComposition = kubernetesComposition(
+  {
+    name: 'conditional-structured-resources',
+    kind: 'ConditionalStructuredResources',
+    spec: ConditionalResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: ConditionalResourcesSpec) => {
+    Deployment({
+      name: spec.name,
+      image: 'nginx:1.29',
+      resources: resolveConditionalResources(spec),
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
+function resolveStructuredChain(spec: StructuredChainSpec) {
+  return spec.primary ?? spec.secondary ?? defaultOsdResources;
+}
+
+const structuredChainComposition = kubernetesComposition(
+  {
+    name: 'structured-coalesce-chain',
+    kind: 'StructuredCoalesceChain',
+    spec: StructuredChainSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: StructuredChainSpec) => {
+    Deployment({
+      name: spec.name,
+      image: 'nginx:1.29',
+      resources: resolveStructuredChain(spec),
+      id: 'workload',
     });
     return { ready: true };
   }
@@ -132,5 +192,45 @@ describe('structured nullish defaults', () => {
     expect(yaml).toContain('memory: 4Gi');
     expect(yaml).not.toContain('cpu: 250m');
     expect(yaml).not.toContain('cpu: 100m');
+  });
+
+  it('does not infer a nullish fallback from an unrelated conditional', () => {
+    const yaml = conditionalResourcesComposition.factory('kro').toYaml();
+    const compact = yaml.replaceAll(' ', '');
+
+    expect(compact).not.toContain(
+      'has(schema.spec.resources)?schema.spec.resources:({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
+    );
+  });
+
+  it('preserves a structured terminal fallback in a cross-field chain', () => {
+    const yaml = structuredChainComposition.factory('kro').toYaml();
+    const compact = yaml.replaceAll(' ', '');
+
+    expect(compact).toContain(
+      'has(schema.spec.primary)?schema.spec.primary:(has(schema.spec.secondary)?schema.spec.secondary:({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}))'
+    );
+  });
+
+  it('keeps direct-mode replacement order for a structured cross-field chain', () => {
+    const fallbackYaml = structuredChainComposition.factory('direct').toYaml({ name: 'fallback' });
+    expect(deploymentSection(fallbackYaml, 'fallback')).toContain('memory: 2Gi');
+
+    const secondaryYaml = structuredChainComposition.factory('direct').toYaml({
+      name: 'secondary',
+      secondary: { limits: { memory: '3Gi' } },
+    });
+    const secondary = deploymentSection(secondaryYaml, 'secondary');
+    expect(secondary).toContain('memory: 3Gi');
+    expect(secondary).not.toContain('memory: 2Gi');
+
+    const primaryYaml = structuredChainComposition.factory('direct').toYaml({
+      name: 'primary',
+      primary: { limits: { memory: '4Gi' } },
+      secondary: { limits: { memory: '3Gi' } },
+    });
+    const primary = deploymentSection(primaryYaml, 'primary');
+    expect(primary).toContain('memory: 4Gi');
+    expect(primary).not.toContain('memory: 3Gi');
   });
 });

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import type { V1ResourceRequirements } from '@kubernetes/client-node';
 import { type } from 'arktype';
+import type { Type } from 'arktype';
 import { mergeValuesExpression } from '../../src/core/aspects/values-merge.js';
 import { kubernetesComposition } from '../../src/core/composition/imperative.js';
 import { Cel } from '../../src/core/references/cel.js';
@@ -103,6 +104,31 @@ const NullableUnionSettingsSpecSchema = type({
 });
 
 type NullableUnionSettingsSpec = typeof NullableUnionSettingsSpecSchema.infer;
+
+const NullableArrayMemberSpecSchema = type({
+  name: 'string',
+  items: type('string | null').array(),
+});
+
+const NullableRecordValueSpecSchema = type({
+  name: 'string',
+  values: 'Record<string, string | null>',
+});
+
+const NestedNullableArrayMemberSpecSchema = type({
+  name: 'string',
+  groups: type('string | null').array().array(),
+});
+
+const NullableTupleMemberSpecSchema = type({
+  name: 'string',
+  items: ['string | null', 'number'],
+});
+
+const NullableArrayObjectPropertySpecSchema = type({
+  name: 'string',
+  items: type({ value: 'string | null' }).array(),
+});
 
 const defaultOsdResources = {
   requests: { cpu: '250m', memory: '1Gi' },
@@ -474,6 +500,59 @@ const nullableUnionBranchComposition = kubernetesComposition(
   }
 );
 
+function nullableCollectionComposition<TSpec extends { name: string }>(
+  name: string,
+  kind: string,
+  spec: Type<TSpec>
+) {
+  return kubernetesComposition(
+    {
+      name,
+      kind,
+      spec,
+      status: type({ ready: 'boolean' }),
+    },
+    (value: { name: string }) => {
+      Deployment({
+        name: value.name,
+        image: 'nginx:1.29',
+        id: 'workload',
+      });
+      return { ready: true };
+    }
+  );
+}
+
+const nullableArrayMemberComposition = nullableCollectionComposition(
+  'nullable-array-member',
+  'NullableArrayMember',
+  NullableArrayMemberSpecSchema
+);
+
+const nullableRecordValueComposition = nullableCollectionComposition(
+  'nullable-record-value',
+  'NullableRecordValue',
+  NullableRecordValueSpecSchema
+);
+
+const nestedNullableArrayMemberComposition = nullableCollectionComposition(
+  'nested-nullable-array-member',
+  'NestedNullableArrayMember',
+  NestedNullableArrayMemberSpecSchema
+);
+
+const nullableTupleMemberComposition = nullableCollectionComposition(
+  'nullable-tuple-member',
+  'NullableTupleMember',
+  NullableTupleMemberSpecSchema
+);
+
+const nullableArrayObjectPropertyComposition = nullableCollectionComposition(
+  'nullable-array-object-property',
+  'NullableArrayObjectProperty',
+  NullableArrayObjectPropertySpecSchema
+);
+
 function deploymentSection(yaml: string, name: string): string {
   const start = yaml.indexOf(`name: ${name}`);
   expect(start).toBeGreaterThanOrEqual(0);
@@ -683,6 +762,30 @@ describe('structured nullish defaults', () => {
   it('finds unrepresentable nullable fields nested inside union branches', () => {
     expect(() => nullableUnionBranchComposition.factory('kro').toYaml()).toThrow(
       /KRO SimpleSchema cannot represent nullable field schema\.spec\.settings\.resources/
+    );
+  });
+
+  it('finds unrepresentable nullable array members through sequence wrappers', () => {
+    expect(() => nullableArrayMemberComposition.factory('kro').toYaml()).toThrow(
+      /KRO SimpleSchema cannot represent nullable field schema\.spec\.items\[\]/
+    );
+  });
+
+  it('finds unrepresentable nullable record values through index wrappers', () => {
+    expect(() => nullableRecordValueComposition.factory('kro').toYaml()).toThrow(
+      /KRO SimpleSchema cannot represent nullable field schema\.spec\.values\.\*/
+    );
+  });
+
+  it('recurses through nested collection wrappers', () => {
+    expect(() => nestedNullableArrayMemberComposition.factory('kro').toYaml()).toThrow(
+      /KRO SimpleSchema cannot represent nullable field schema\.spec\.groups\[\]\[\]/
+    );
+    expect(() => nullableTupleMemberComposition.factory('kro').toYaml()).toThrow(
+      /KRO SimpleSchema cannot represent nullable field schema\.spec\.items\[\]\[0\]/
+    );
+    expect(() => nullableArrayObjectPropertyComposition.factory('kro').toYaml()).toThrow(
+      /KRO SimpleSchema cannot represent nullable field schema\.spec\.items\[\]\.value/
     );
   });
 

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -89,6 +89,21 @@ const OptionalNullableResourcesSpecSchema = type({
 
 type OptionalNullableResourcesSpec = typeof OptionalNullableResourcesSpecSchema.infer;
 
+const NullableUnionSettingsSchema = type({
+  mode: "'standard'",
+  resources: ResourceRequirementsSchema.or('null'),
+}).or({
+  mode: "'intensive'",
+  resources: ResourceRequirementsSchema.or('null'),
+});
+
+const NullableUnionSettingsSpecSchema = type({
+  name: 'string',
+  settings: NullableUnionSettingsSchema,
+});
+
+type NullableUnionSettingsSpec = typeof NullableUnionSettingsSpecSchema.infer;
+
 const defaultOsdResources = {
   requests: { cpu: '250m', memory: '1Gi' },
   limits: { memory: '2Gi' },
@@ -441,6 +456,24 @@ const optionalNullableNullBranchComposition = kubernetesComposition(
   }
 );
 
+const nullableUnionBranchComposition = kubernetesComposition(
+  {
+    name: 'nullable-union-branch',
+    kind: 'NullableUnionBranch',
+    spec: NullableUnionSettingsSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: NullableUnionSettingsSpec) => {
+    Deployment({
+      name: spec.name,
+      image: 'nginx:1.29',
+      resources: spec.settings.resources ?? defaultOsdResources,
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
 function deploymentSection(yaml: string, name: string): string {
   const start = yaml.indexOf(`name: ${name}`);
   expect(start).toBeGreaterThanOrEqual(0);
@@ -623,18 +656,15 @@ describe('structured nullish defaults', () => {
     );
   });
 
-  it('fails closed for a native fallback on a required nullable structured field', () => {
+  it('rejects a required nullable field that KRO SimpleSchema cannot represent', () => {
     expect(() => requiredNullableNativeFallbackComposition.factory('kro').toYaml()).toThrow(
-      /schema\.spec\.resources.*Cel\.default/
+      /KRO SimpleSchema cannot represent nullable field schema\.spec\.resources/
     );
   });
 
-  it('preserves explicit nullish semantics for a required nullable structured field', () => {
-    const yaml = requiredNullableExplicitFallbackComposition.factory('kro').toYaml();
-    const compact = yaml.replaceAll(' ', '');
-
-    expect(compact).toContain(
-      'has(schema.spec.resources)&&schema.spec.resources!=null?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+  it('does not let Cel.default conceal an unrepresentable nullable KRO schema', () => {
+    expect(() => requiredNullableExplicitFallbackComposition.factory('kro').toYaml()).toThrow(
+      /KRO SimpleSchema cannot represent nullable field schema\.spec\.resources/
     );
 
     const directYaml = requiredNullableExplicitFallbackComposition.factory('direct').toYaml({
@@ -644,9 +674,15 @@ describe('structured nullish defaults', () => {
     expect(deploymentSection(directYaml, 'nullable-direct')).toContain('cpu: 250m');
   });
 
-  it('probes null independently when an optional structured field is also nullable', () => {
+  it('rejects optional-plus-nullable because omission cannot preserve explicit null', () => {
     expect(() => optionalNullableNullBranchComposition.factory('kro').toYaml()).toThrow(
-      /schema\.spec\.resources.*Cel\.default/
+      /KRO SimpleSchema cannot represent nullable field schema\.spec\.resources/
+    );
+  });
+
+  it('finds unrepresentable nullable fields nested inside union branches', () => {
+    expect(() => nullableUnionBranchComposition.factory('kro').toYaml()).toThrow(
+      /KRO SimpleSchema cannot represent nullable field schema\.spec\.settings\.resources/
     );
   });
 

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -60,6 +60,21 @@ const GuardedResourcesSpecSchema = type({
 
 type GuardedResourcesSpec = typeof GuardedResourcesSpecSchema.infer;
 
+const UnionSettingsSchema = type({
+  mode: "'standard'",
+  'resources?': ResourceRequirementsSchema,
+}).or({
+  mode: "'intensive'",
+  'resources?': ResourceRequirementsSchema,
+});
+
+const UnionSettingsSpecSchema = type({
+  name: 'string',
+  settings: UnionSettingsSchema,
+});
+
+type UnionSettingsSpec = typeof UnionSettingsSpecSchema.infer;
+
 const defaultOsdResources = {
   requests: { cpu: '250m', memory: '1Gi' },
   limits: { memory: '2Gi' },
@@ -337,6 +352,26 @@ const conditionalMergeFallbackComposition = kubernetesComposition(
   }
 );
 
+const unionBranchNativeFallbackComposition = kubernetesComposition(
+  {
+    name: 'union-branch-native-structured-fallback',
+    kind: 'UnionBranchNativeStructuredFallback',
+    spec: UnionSettingsSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: UnionSettingsSpec) => {
+    Deployment({
+      name: spec.name,
+      image: 'nginx:1.29',
+      resources: spec.settings.resources ?? {
+        requests: { cpu: '250m' },
+      },
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
 function deploymentSection(yaml: string, name: string): string {
   const start = yaml.indexOf(`name: ${name}`);
   expect(start).toBeGreaterThanOrEqual(0);
@@ -510,6 +545,12 @@ describe('structured nullish defaults', () => {
   it('fails closed when merge normalization reveals a different fallback branch', () => {
     expect(() => conditionalMergeFallbackComposition.factory('kro').toYaml()).toThrow(
       /Cannot prove structured fallback semantics.*Cel\.default/
+    );
+  });
+
+  it('fails closed for an optional structured fallback inside a required union', () => {
+    expect(() => unionBranchNativeFallbackComposition.factory('kro').toYaml()).toThrow(
+      /schema\.spec\.settings\.resources.*Cel\.default/
     );
   });
 

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -310,6 +310,33 @@ const normalizedValuesMergeComposition = kubernetesComposition(
   }
 );
 
+function conditionallyMergeResourceDefaults(spec: GuardedResourcesSpec) {
+  return spec.resources
+    ? mergeValuesExpression({ replicaCount: 1 }, { resources: spec.resources })
+    : {
+        replicaCount: 1,
+        resources: defaultOsdResources,
+      };
+}
+
+const conditionalMergeFallbackComposition = kubernetesComposition(
+  {
+    name: 'conditional-values-merge-fallback',
+    kind: 'ConditionalValuesMergeFallback',
+    spec: GuardedResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: GuardedResourcesSpec) => {
+    helmRelease({
+      name: spec.name,
+      chart: { repository: 'https://example.com/charts', name: 'example' },
+      values: conditionallyMergeResourceDefaults(spec),
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
 function deploymentSection(yaml: string, name: string): string {
   const start = yaml.indexOf(`name: ${name}`);
   expect(start).toBeGreaterThanOrEqual(0);
@@ -478,6 +505,12 @@ describe('structured nullish defaults', () => {
 
     expect(compact).toContain('schema.spec.resources');
     expect(compact).toContain('"replicaCount":1');
+  });
+
+  it('fails closed when merge normalization reveals a different fallback branch', () => {
+    expect(() => conditionalMergeFallbackComposition.factory('kro').toYaml()).toThrow(
+      /Cannot prove structured fallback semantics.*Cel\.default/
+    );
   });
 
   it('preserves a structured terminal fallback in a cross-field chain', () => {

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -75,6 +75,20 @@ const UnionSettingsSpecSchema = type({
 
 type UnionSettingsSpec = typeof UnionSettingsSpecSchema.infer;
 
+const RequiredNullableResourcesSpecSchema = type({
+  name: 'string',
+  resources: ResourceRequirementsSchema.or('null'),
+});
+
+type RequiredNullableResourcesSpec = typeof RequiredNullableResourcesSpecSchema.infer;
+
+const OptionalNullableResourcesSpecSchema = type({
+  name: 'string',
+  'resources?': ResourceRequirementsSchema.or('null'),
+});
+
+type OptionalNullableResourcesSpec = typeof OptionalNullableResourcesSpecSchema.infer;
+
 const defaultOsdResources = {
   requests: { cpu: '250m', memory: '1Gi' },
   limits: { memory: '2Gi' },
@@ -372,6 +386,61 @@ const unionBranchNativeFallbackComposition = kubernetesComposition(
   }
 );
 
+const requiredNullableNativeFallbackComposition = kubernetesComposition(
+  {
+    name: 'required-nullable-native-structured-fallback',
+    kind: 'RequiredNullableNativeStructuredFallback',
+    spec: RequiredNullableResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: RequiredNullableResourcesSpec) => {
+    Deployment({
+      name: spec.name,
+      image: 'nginx:1.29',
+      resources: spec.resources ?? defaultOsdResources,
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
+const requiredNullableExplicitFallbackComposition = kubernetesComposition(
+  {
+    name: 'required-nullable-explicit-structured-fallback',
+    kind: 'RequiredNullableExplicitStructuredFallback',
+    spec: RequiredNullableResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: RequiredNullableResourcesSpec) => {
+    Deployment({
+      name: spec.name,
+      image: 'nginx:1.29',
+      resources: Cel.default(spec.resources, defaultOsdResources),
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
+const optionalNullableNullBranchComposition = kubernetesComposition(
+  {
+    name: 'optional-nullable-null-branch',
+    kind: 'OptionalNullableNullBranch',
+    spec: OptionalNullableResourcesSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: OptionalNullableResourcesSpec) => {
+    const resources = spec.resources === null ? defaultOsdResources : spec.resources;
+    Deployment({
+      name: spec.name,
+      image: 'nginx:1.29',
+      ...(resources === undefined ? {} : { resources }),
+      id: 'workload',
+    });
+    return { ready: true };
+  }
+);
+
 function deploymentSection(yaml: string, name: string): string {
   const start = yaml.indexOf(`name: ${name}`);
   expect(start).toBeGreaterThanOrEqual(0);
@@ -385,10 +454,10 @@ describe('structured nullish defaults', () => {
     const compact = yaml.replaceAll(' ', '');
 
     expect(compact).toContain(
-      'has(schema.spec.resources)&&has(schema.spec.resources.osd)?schema.spec.resources.osd:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+      'has(schema.spec.resources)&&has(schema.spec.resources.osd)&&schema.spec.resources.osd!=null?schema.spec.resources.osd:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
     );
     expect(compact).toContain(
-      'has(schema.spec.resources)&&has(schema.spec.resources.mon)?schema.spec.resources.mon:{"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}}'
+      'has(schema.spec.resources)&&has(schema.spec.resources.mon)&&schema.spec.resources.mon!=null?schema.spec.resources.mon:{"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}}'
     );
   });
 
@@ -499,7 +568,7 @@ describe('structured nullish defaults', () => {
 
     expect(compact).toContain('includeWhen:');
     expect(compact).toContain(
-      'has(schema.spec.resources)?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+      'has(schema.spec.resources)&&schema.spec.resources!=null?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
     );
     expect(compact).not.toContain('has(schema.spec.resources)?schema.spec.resources:omit()');
   });
@@ -522,7 +591,7 @@ describe('structured nullish defaults', () => {
     const compact = yaml.replaceAll(' ', '');
 
     expect(compact).toContain(
-      'has(schema.spec.resources)?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+      'has(schema.spec.resources)&&schema.spec.resources!=null?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
     );
     expect(compact).toContain('"replicaCount":1');
     expect(compact).not.toContain('has(schema.spec.resources)?schema.spec.resources:omit()');
@@ -554,12 +623,39 @@ describe('structured nullish defaults', () => {
     );
   });
 
+  it('fails closed for a native fallback on a required nullable structured field', () => {
+    expect(() => requiredNullableNativeFallbackComposition.factory('kro').toYaml()).toThrow(
+      /schema\.spec\.resources.*Cel\.default/
+    );
+  });
+
+  it('preserves explicit nullish semantics for a required nullable structured field', () => {
+    const yaml = requiredNullableExplicitFallbackComposition.factory('kro').toYaml();
+    const compact = yaml.replaceAll(' ', '');
+
+    expect(compact).toContain(
+      'has(schema.spec.resources)&&schema.spec.resources!=null?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+    );
+
+    const directYaml = requiredNullableExplicitFallbackComposition.factory('direct').toYaml({
+      name: 'nullable-direct',
+      resources: null,
+    });
+    expect(deploymentSection(directYaml, 'nullable-direct')).toContain('cpu: 250m');
+  });
+
+  it('probes null independently when an optional structured field is also nullable', () => {
+    expect(() => optionalNullableNullBranchComposition.factory('kro').toYaml()).toThrow(
+      /schema\.spec\.resources.*Cel\.default/
+    );
+  });
+
   it('preserves a structured terminal fallback in a cross-field chain', () => {
     const yaml = structuredChainComposition.factory('kro').toYaml();
     const compact = yaml.replaceAll(' ', '');
 
     expect(compact).toContain(
-      'has(schema.spec.primary)?schema.spec.primary:(has(schema.spec.secondary)?schema.spec.secondary:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
+      'has(schema.spec.primary)&&schema.spec.primary!=null?schema.spec.primary:(has(schema.spec.secondary)&&schema.spec.secondary!=null?schema.spec.secondary:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
     );
   });
 

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'bun:test';
+import type { V1ResourceRequirements } from '@kubernetes/client-node';
+import { type } from 'arktype';
+import { kubernetesComposition } from '../../src/core/composition/imperative.js';
+import { Deployment } from '../../src/factories/simple/index.js';
+
+const ResourceRequirementsSchema = type({
+  'requests?': {
+    'cpu?': 'string',
+    'memory?': 'string',
+  },
+  'limits?': {
+    'cpu?': 'string',
+    'memory?': 'string',
+  },
+});
+
+const StructuredDefaultsSpecSchema = type({
+  name: 'string',
+  'resources?': {
+    'osd?': ResourceRequirementsSchema,
+    'mon?': ResourceRequirementsSchema,
+  },
+});
+
+type StructuredDefaultsSpec = typeof StructuredDefaultsSpecSchema.infer;
+
+const defaultOsdResources = {
+  requests: { cpu: '250m', memory: '1Gi' },
+  limits: { memory: '2Gi' },
+} satisfies V1ResourceRequirements;
+
+const defaultMonResources = {
+  requests: { cpu: '100m', memory: '256Mi' },
+  limits: { memory: '1Gi' },
+} satisfies V1ResourceRequirements;
+
+function resolveDaemonResources(spec: StructuredDefaultsSpec) {
+  return {
+    osd: spec.resources?.osd ?? defaultOsdResources,
+    mon: spec.resources?.mon ?? defaultMonResources,
+  };
+}
+
+const structuredDefaultsComposition = kubernetesComposition(
+  {
+    name: 'structured-nullish-defaults',
+    kind: 'StructuredNullishDefaults',
+    spec: StructuredDefaultsSpecSchema,
+    status: type({ ready: 'boolean' }),
+  },
+  (spec: StructuredDefaultsSpec) => {
+    const resources = resolveDaemonResources(spec);
+    Deployment({
+      name: `${spec.name}-osd`,
+      image: 'nginx:1.29',
+      resources: resources.osd,
+      id: 'osd',
+    });
+    Deployment({
+      name: `${spec.name}-mon`,
+      image: 'nginx:1.29',
+      resources: resources.mon,
+      id: 'mon',
+    });
+    return { ready: true };
+  }
+);
+
+function deploymentSection(yaml: string, name: string): string {
+  const start = yaml.indexOf(`name: ${name}`);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const nextDocument = yaml.indexOf('\n---', start);
+  return yaml.slice(start, nextDocument === -1 ? undefined : nextDocument);
+}
+
+describe('structured nullish defaults', () => {
+  it('lowers helper-returned object fallbacks into guarded KRO expressions', () => {
+    const yaml = structuredDefaultsComposition.factory('kro').toYaml();
+    const compact = yaml.replaceAll(' ', '');
+
+    expect(compact).toContain(
+      'has(schema.spec.resources)&&has(schema.spec.resources.osd)?schema.spec.resources.osd:({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
+    );
+    expect(compact).toContain(
+      'has(schema.spec.resources)&&has(schema.spec.resources.mon)?schema.spec.resources.mon:({"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}})'
+    );
+  });
+
+  it('keeps direct-mode JavaScript defaults when the optional parent is omitted', () => {
+    const yaml = structuredDefaultsComposition.factory('direct').toYaml({ name: 'omitted-parent' });
+
+    const osd = deploymentSection(yaml, 'omitted-parent-osd');
+    expect(osd).toContain('cpu: 250m');
+    expect(osd).toContain('memory: 2Gi');
+
+    const mon = deploymentSection(yaml, 'omitted-parent-mon');
+    expect(mon).toContain('cpu: 100m');
+    expect(mon).toContain('memory: 256Mi');
+  });
+
+  it('defaults untouched siblings while replacing a supplied object completely', () => {
+    const yaml = structuredDefaultsComposition.factory('direct').toYaml({
+      name: 'partial-parent',
+      resources: {
+        osd: {
+          limits: { memory: '4Gi' },
+        },
+      },
+    });
+
+    const osd = deploymentSection(yaml, 'partial-parent-osd');
+    expect(osd).toContain('memory: 4Gi');
+    expect(osd).not.toContain('cpu: 250m');
+    expect(osd).not.toContain('memory: 1Gi');
+
+    const mon = deploymentSection(yaml, 'partial-parent-mon');
+    expect(mon).toContain('cpu: 100m');
+    expect(mon).toContain('memory: 256Mi');
+  });
+
+  it('keeps KRO instance input partial and delegates default selection to the RGD', () => {
+    const yaml = structuredDefaultsComposition.factory('kro').toYaml({
+      name: 'partial-parent',
+      resources: {
+        osd: {
+          limits: { memory: '4Gi' },
+        },
+      },
+    });
+
+    expect(yaml).toContain('memory: 4Gi');
+    expect(yaml).not.toContain('cpu: 250m');
+    expect(yaml).not.toContain('cpu: 100m');
+  });
+});


### PR DESCRIPTION
## Summary

- add optional per-daemon `resources` to the managed and external-operator single-node Rook/Ceph platform schemas
- add an explicit, typed structured-fallback primitive to TypeKro core through `Cel.default` / `Cel.coalesce`
- fail closed when black-box re-execution sees an ambiguous structured proxy/default difference
- detect ambiguity even when an optional guard removes the complete resource from the all-defaults execution or the fallback is nested inside a values-merge operand
- suppress resource-construction diagnostics in internal analysis executions while preserving authored-graph warnings
- propagate OSD sizing to both `CephCluster.spec.resources.osd` and the storage device set
- propagate RGW sizing to the separately materialized `CephObjectStore`
- preserve whole-object replacement semantics and extend the opt-in live KRO test to assert defaults and the supplied override
- isolate Flux CRD patch caching tests from the network and verify deterministic retry behavior

## Why

The single-node profile currently fixes OSD memory at a 2Gi limit. Real local workloads can exceed that limit, repeatedly OOM-killing the OSD and leaving RGW without a Ready endpoint. Consumers cannot safely patch the KRO-owned HelmRelease out of band, so daemon sizing needs to be part of the typed platform contract.

The initial implementation exposed a TypeKro core gap: in graph mode, a nested optional proxy such as `config.resources?.osd` survives JavaScript evaluation as a proxy, causing native `??` to lose its fallback during serialization. Fixing that in every integration would leak CEL and proxy detection into otherwise normal TypeScript.

Earlier revisions attempted to infer a structured nullish fallback by re-executing the authored function with counterfactual values. That is fundamentally unable to prove semantics: equality, membership, ranges, or arbitrary helper logic can make another field control the branch even when every finite sample happens to retain the schema marker.

This revision removes that inference. `Cel.default(value, fallback)` and its `Cel.coalesce` alias are now the explicit core structured-fallback primitive:

- schema/resource references lower to presence-guarded CEL;
- every optional schema ancestor is guarded;
- object and array fallbacks use the canonical CEL value-tree serializer;
- nested calls express cross-field chains without losing the terminal structured default;
- a supplied object replaces its default wholesale;
- concrete direct-mode values evaluate with native JavaScript `??` semantics;
- overloads preserve structured TypeScript types.

The Rook mapper therefore remains clean and framework-level:

```ts
osd: Cel.default(config.resources?.osd, singleNodeResources.osd)
```

It does not inspect schema proxies or hand-author CEL. Existing APISIX structured defaults were migrated to the same primitive.

If re-execution instead observes a bare schema marker in the proxy run and a concrete object/array in the absent-value run, TypeKro now throws `AMBIGUOUS_STRUCTURED_FALLBACK`. The diagnostic identifies the resource path and directs authors to `Cel.default` / `Cel.coalesce`. This deliberately fails closed for expressions such as:

```ts
spec.mode !== 'disabled' && spec.resources
  ? spec.resources
  : defaults
```

Direct mode still evaluates that expression exactly as authored.

Ambiguity detection is independent of the all-defaults resource set. For every bare schema-marker field, core performs one targeted candidate-absent execution while keeping the rest of the spec symbolic. If an optional resource guard removes that resource from the all-defaults run but the targeted execution exposes a concrete structured fallback, KRO compilation still fails closed instead of silently emitting `omit()`. Explicit `Cel.default` expressions serialize normally and genuine optional passthroughs retain `omit()`.

`ValuesMergeExpression` provides provenance for the merge operation, not for arbitrary expressions nested in its operands. Core therefore traverses the merge base and every overlay and retains the operand path and enclosing merge shape during targeted probes. An implicit object fallback inside either operand fails closed; the explicit `Cel.default` equivalent serializes normally. If removing a candidate causes a merge wrapper or overlay position to normalize away, the final merged object is not misclassified as the original operand's fallback.

Internal defaults-extraction and cross-field analysis contexts now suppress resource-construction warnings, including through nested compositions. Authored graph construction retains the existing diagnostics. A subprocess regression executes `rookCephSingleNodePlatform.factory('kro').toYaml()` at warning level and proves that internal probes emit no misleading Ceph namespace warnings.

Core regression coverage includes an omitted optional parent, a partial parent, object-valued fallback serialization, helper assembly, replacement semantics, direct/KRO parity, nested explicit coalescing, ambiguous unrelated conditionals, the exact value-based string guard above, a resource omitted by its all-defaults guard, an explicit fallback under the same guard, a genuine optional passthrough, implicit fallbacks in values-merge bases and overlays, explicit merge-operand fallbacks, normalized-away merge wrappers, compile-time structured types, generated-RGD literal defaults, and isolated analysis diagnostics. Rook RGD tests assert the override reference and concrete fallback for `mon`, `mgr`, `osd`, `prepareosd`, and `rgw`.

The randomized CI failure was caused by a unit test invoking the real Flux CRD patcher and its network/cluster path. `CRDManager` retains the lazy production import but now accepts an internal patcher seam, allowing the test to prove concurrent promise caching and retry-after-failure deterministically.

## Verification

- `bun run build`
- `bun run typecheck`
- commit hook full suite: 5,109 passed, 13 skipped, 1 todo
- `bun run test:randomized` (`--seed=1`): 5,101 passed, 13 skipped, 1 todo
- focused structured fallback + Rook + diagnostics suites: 152 passed, 1 todo
- `TYPEKRO_LOG_LEVEL=warn bun -e '…rookCephSingleNodePlatform.factory("kro").toYaml()'`: no output
- `git diff --check`

The latest opt-in OrbStack attempt was blocked before Ceph creation by the pre-existing hard-coded `/dev/loop63` collision with the retained Harbor/Ceph fixture. Cleanup completed without leaked test resources. The test asserts untouched `mon`, `mgr`, `prepareosd`, and `rgw` defaults plus the supplied OSD override in a healthy block-device environment.
