### PR TITLE
fix(alchemy): stop leaking `unknown` into materializeAlchemyResources' requirement channel

### DIFF
--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -15,6 +15,7 @@
  */
 
 import type { KubeConfig } from '@kubernetes/client-node';
+import type { Input } from 'alchemy/Input';
 import * as Output from 'alchemy/Output';
 import * as ProviderMod from 'alchemy/Provider';
 import type { Resource as ResourceT } from 'alchemy/Resource';
@@ -196,7 +197,11 @@ export function materializeAlchemyResources(
   kroResource: typeof KroResource,
   declarations: readonly AlchemyResourceDeclaration[],
   options: MaterializeAlchemyResourcesOptions = {}
-) {
+): Effect.Effect<
+  Record<string, KroResourceR>,
+  never,
+  ProviderMod.Provider<KroResourceR>
+> {
   return Effect.gen(function* () {
     // Keyed by declaration id → the instantiated alchemy resource HANDLE (what `Output.of` consumes
     // and what carries the dependency edge); its resolved attributes are a `TypeKroResource`.
@@ -237,9 +242,14 @@ export function materializeAlchemyResources(
       // Cast: `props` carries an `Output` for `dependencies` that the `KroResource` constructor
       // accepts as an `Input<…>` and alchemy resolves before reconcile — the field's static type
       // is the resolved (post-evaluation) shape.
+      //
+      // Target the PLAIN-props overload explicitly. `Parameters<typeof kroResource>[1]` resolves to
+      // the LAST call signature — the one taking `Effect<InputProps<…>, never, PropsReq>` — so casting
+      // to it selected the Effect-props overload and returned `Effect<R, never, PropsReq | Req>` with
+      // `PropsReq` unresolved, leaking `unknown` into this function's public requirement channel.
       handles[decl.id] = yield* kroResource(
         decl.id,
-        props as unknown as Parameters<typeof kroResource>[1]
+        props as unknown as { [K in keyof KroResourceR['Props']]: Input<KroResourceR['Props'][K]> }
       );
     }
     return handles;


### PR DESCRIPTION
`materializeAlchemyResources` is published as:

```ts
Effect.Effect<Record<string, KroResourceR>, never, unknown>
```

That `unknown` is unintentional, and it makes the function awkward to embed in an alchemy Stack body: alchemy infers the body's `Req` strictly, and `unknown` satisfies no inferred requirement — so consumers have to erase the requirement channel by hand at every call site.

## Root cause
The props cast at the `kroResource(...)` call site:

```ts
props as unknown as Parameters<typeof kroResource>[1]
```

`ResourceConstructor` is an overloaded callable, and `Parameters<T>` resolves to the **last** call signature — the one taking `Effect<InputProps<R["Props"]>, never, PropsReq>`. Casting the props to that type selected the Effect-props overload, whose return type is `Effect<R, never, PropsReq | Req>` with `PropsReq` left unresolved. The `unknown` then propagated out of `Effect.gen` into the public signature.

## Fix
- Cast to the **plain-props** shape (`{ [K in keyof KroResourceR['Props']]: Input<...> }`) so the intended overload is selected. The cast's original purpose is unchanged and its comment is kept — `dependencies` carries an `Output` that alchemy resolves before reconcile.
- Declare the return type explicitly, now that it's accurate: the function requires **`Provider<KroResourceR>`**, which is exactly what `ResourceClass` derives for a resource whose `Providers` parameter is `undefined`. (`never` would be wrong — the KRO provider genuinely has to be in context.)

Published signature becomes:

```ts
Effect.Effect<Record<string, KroResourceR>, never, ProviderMod.Provider<KroResourceR>>
```

## Validation
`bun run typecheck` (lib + tests + examples), `bun run lint`, `bun run check:effect-cohort` — all clean. Unit suite: **5120 pass / 0 fail** across 300 files.

No behavioural change — types only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)