### PR TITLE
ci: report every gate instead of stopping at the first failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,15 @@ jobs:
         run: bun run build
 
       - name: Typecheck
+        if: ${{ !cancelled() }}
         run: bun run typecheck
 
       - name: Lint
+        if: ${{ !cancelled() }}
         run: bun run lint
 
       - name: Docs validation
+        if: ${{ !cancelled() }}
         run: |
           bun run docs:validate
           bun run docs:check-lines
@@ -40,21 +43,27 @@ jobs:
           bun run docs:build
 
       - name: Circular dependency check
+        if: ${{ !cancelled() }}
         run: bunx madge --circular --extensions ts src/
 
       - name: Effect dependency cohort
+        if: ${{ !cancelled() }}
         run: bun run check:effect-cohort
 
       - name: Packed artifact budgets and imports
+        if: ${{ !cancelled() }}
         run: bun run test:packed-imports
 
       - name: Randomized unit test isolation
+        if: ${{ !cancelled() }}
         run: bun run test:randomized
 
       - name: Unit tests with coverage
+        if: ${{ !cancelled() }}
         run: bun run test:coverage
 
       - name: Integration YAML tests
+        if: ${{ !cancelled() }}
         run: bun run test:integration:yaml
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,19 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build
+        id: build
         run: bun run build
 
       - name: Typecheck
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run typecheck
 
       - name: Lint
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run lint
 
       - name: Docs validation
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           bun run docs:validate
           bun run docs:check-lines
@@ -43,27 +44,27 @@ jobs:
           bun run docs:build
 
       - name: Circular dependency check
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bunx madge --circular --extensions ts src/
 
       - name: Effect dependency cohort
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run check:effect-cohort
 
       - name: Packed artifact budgets and imports
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run test:packed-imports
 
       - name: Randomized unit test isolation
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run test:randomized
 
       - name: Unit tests with coverage
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run test:coverage
 
       - name: Integration YAML tests
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run test:integration:yaml
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
A failing step skips every later step, so a single red gate hides the rest of the signal. This bit us concretely: the **Effect dependency cohort** gate failed and masked a **failing packed-artifact budget** behind it — CI never even reached the packaging gate, so the budget failure was invisible until run locally. Each fix/push cycle then only reveals the next problem.

## Change
Add `if: ${{ !cancelled() }}` to the verification gates after `Build`, so all of them run and report in one pass:

Typecheck · Lint · Docs validation · Circular dependency check · Effect dependency cohort · Packed artifact budgets · Randomized unit test isolation · Unit tests with coverage · Integration YAML tests

Semantics are unchanged otherwise:
- the job still **fails** if any gate fails (each step's own status stands),
- `Build` stays a hard gate — packaging and tests need `dist/`, so continuing past a broken build produces noise, not signal,
- the Codecov upload keeps `if: success()`, so it still only uploads on a fully green run.

Net effect: one CI run tells you everything that's broken instead of one thing at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)