### PR TITLE
[TEMP PROBE — do not merge] verify CI gates skip when Build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,15 @@ jobs:
         run: bun run build
 
       - name: Typecheck
+        if: ${{ !cancelled() }}
         run: bun run typecheck
 
       - name: Lint
+        if: ${{ !cancelled() }}
         run: bun run lint
 
       - name: Docs validation
+        if: ${{ !cancelled() }}
         run: |
           bun run docs:validate
           bun run docs:check-lines
@@ -40,21 +43,27 @@ jobs:
           bun run docs:build
 
       - name: Circular dependency check
+        if: ${{ !cancelled() }}
         run: bunx madge --circular --extensions ts src/
 
       - name: Effect dependency cohort
+        if: ${{ !cancelled() }}
         run: bun run check:effect-cohort
 
       - name: Packed artifact budgets and imports
+        if: ${{ !cancelled() }}
         run: bun run test:packed-imports
 
       - name: Randomized unit test isolation
+        if: ${{ !cancelled() }}
         run: bun run test:randomized
 
       - name: Unit tests with coverage
+        if: ${{ !cancelled() }}
         run: bun run test:coverage
 
       - name: Integration YAML tests
+        if: ${{ !cancelled() }}
         run: bun run test:integration:yaml
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,19 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build
+        id: build
         run: bun run build
 
       - name: Typecheck
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run typecheck
 
       - name: Lint
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run lint
 
       - name: Docs validation
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: |
           bun run docs:validate
           bun run docs:check-lines
@@ -43,27 +44,27 @@ jobs:
           bun run docs:build
 
       - name: Circular dependency check
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bunx madge --circular --extensions ts src/
 
       - name: Effect dependency cohort
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run check:effect-cohort
 
       - name: Packed artifact budgets and imports
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run test:packed-imports
 
       - name: Randomized unit test isolation
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run test:randomized
 
       - name: Unit tests with coverage
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run test:coverage
 
       - name: Integration YAML tests
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
         run: bun run test:integration:yaml
 
       - name: Upload coverage to Codecov

--- a/scripts/check-effect-cohort.ts
+++ b/scripts/check-effect-cohort.ts
@@ -1,4 +1,4 @@
-const EXPECTED_EFFECT_VERSION = '4.0.0-beta.84';
+const EXPECTED_EFFECT_VERSION = '4.0.0-beta.999';
 const COHORT_PACKAGES = [
   'effect',
   '@effect/platform-bun',


### PR DESCRIPTION
Throwaway draft to exercise the failure path for #122 (the review noted CI only proves the success path). Build is forced to exit 1; expectation is that all 9 verification gates report **skipped**, not failed. Will be closed and the branch deleted as soon as the run reports.