### PR TITLE
fix: admit structured defaults in KRO

### DIFF
--- a/src/core/deployment/schema-cel-evaluator.ts
+++ b/src/core/deployment/schema-cel-evaluator.ts
@@ -17,22 +17,65 @@ function hasSchemaValue(fieldPath: string, spec: KroCompatibleType): boolean {
   return current !== undefined;
 }
 
+/**
+ * Apply evaluator-only rewrites to CEL source while preserving quoted data
+ * byte-for-byte. Structured defaults are embedded as CEL object literals, so
+ * function-looking text inside their string values must never be rewritten.
+ */
+function rewriteOutsideQuotedStrings(
+  expression: string,
+  rewrite: (unquotedSource: string) => string
+): string {
+  let result = '';
+  let unquotedStart = 0;
+
+  for (let index = 0; index < expression.length; index++) {
+    const quote = expression[index];
+    if (quote !== '"' && quote !== "'") continue;
+
+    result += rewrite(expression.slice(unquotedStart, index));
+
+    let end = index + 1;
+    let escaped = false;
+    for (; end < expression.length; end++) {
+      const character = expression[end];
+      if (escaped) {
+        escaped = false;
+      } else if (character === '\\') {
+        escaped = true;
+      } else if (character === quote) {
+        end++;
+        break;
+      }
+    }
+
+    result += expression.slice(index, end);
+    unquotedStart = end;
+    index = end - 1;
+  }
+
+  return result + rewrite(expression.slice(unquotedStart));
+}
+
 function prepareSchemaExpression(expression: string): string {
-  let prepared = expression;
   const schemaPath = '[a-zA-Z_$][\\w$]*(?:\\.[a-zA-Z_$][\\w$]*)*';
 
-  prepared = prepared.replace(
-    new RegExp(`\\bhas\\((?:schema\\.)?spec\\.(${schemaPath})\\)`, 'g'),
-    '__has("$1")'
-  );
-  prepared = prepared.replace(
-    new RegExp(`\\b(?:schema\\.)?spec\\.(${schemaPath})\\.orValue\\(([^()]*)\\)`, 'g'),
-    '__orValue($1, $2)'
-  );
-  prepared = prepared.replace(/\bstring\(/g, '__string(');
-  prepared = prepared.replace(/schema\.spec\.(\w+)/g, '$1');
-  prepared = prepared.replace(/\bspec\.(\w+)/g, '$1');
-  return prepared;
+  return rewriteOutsideQuotedStrings(expression, (unquotedSource) => {
+    let prepared = unquotedSource;
+    prepared = prepared.replace(
+      new RegExp(`\\bhas\\((?:schema\\.)?spec\\.(${schemaPath})\\)`, 'g'),
+      '__has("$1")'
+    );
+    prepared = prepared.replace(
+      new RegExp(`\\b(?:schema\\.)?spec\\.(${schemaPath})\\.orValue\\(`, 'g'),
+      '__orValue($1, '
+    );
+    prepared = prepared.replace(/\bstring\(/g, '__string(');
+    prepared = prepared.replace(/\bdyn\(/g, '__dyn(');
+    prepared = prepared.replace(/schema\.spec\.(\w+)/g, '$1');
+    prepared = prepared.replace(/\bspec\.(\w+)/g, '$1');
+    return prepared;
+  });
 }
 
 function createEvaluationScope(spec: KroCompatibleType): Record<string, unknown> {
@@ -41,6 +84,8 @@ function createEvaluationScope(spec: KroCompatibleType): Record<string, unknown>
       __has: (path: string) => hasSchemaValue(path, spec),
       __orValue: (value: unknown, defaultValue: unknown) => value ?? defaultValue,
       __string: (value: unknown) => String(value ?? ''),
+      // KRO uses dyn() only for static type widening; it is runtime identity.
+      __dyn: (value: unknown) => value,
       omit: () => undefined,
     })
   );

--- a/src/core/references/cel-evaluator.ts
+++ b/src/core/references/cel-evaluator.ts
@@ -31,6 +31,39 @@ import type { CelExpression, KubernetesRef } from '../types.js';
 
 export class CelEvaluator {
   /**
+   * Runtime implementations for CEL functions TypeKro emits itself.
+   *
+   * `dyn()` is a CEL type conversion used to widen expressions during KRO
+   * admission. It does not change the runtime value, so direct-mode evaluation
+   * must treat it as an identity function.
+   */
+  private evaluationFunctions(
+    context: CelEvaluationContext
+  ): Record<string, (...args: unknown[]) => unknown> {
+    return {
+      string: (value: unknown) => String(value),
+      int: (value: unknown) => parseInt(String(value), 10),
+      double: (value: unknown) => parseFloat(String(value)),
+      dyn: (value: unknown) => value,
+      size: (collection: unknown) => {
+        if (Array.isArray(collection)) return collection.length;
+        if (typeof collection === 'string') return collection.length;
+        if (collection && typeof collection === 'object') return Object.keys(collection).length;
+        return 0;
+      },
+      has: (obj: unknown, field?: unknown) => {
+        if (typeof field === 'string') {
+          return obj !== null && typeof obj === 'object' && field in obj;
+        }
+        // For expressions like has(config.debug), the field access is already resolved
+        return obj !== undefined && obj !== null;
+      },
+      concat: (...args: unknown[]) => args.join(''),
+      ...context.functions,
+    };
+  }
+
+  /**
    * Evaluate a CEL expression with the given context
    */
   async evaluate(expression: CelExpression, context: CelEvaluationContext): Promise<unknown> {
@@ -39,27 +72,7 @@ export class CelEvaluator {
       const celContext = await this.buildCelContext(expression, context);
 
       // Use cel-js to evaluate the expression with standard functions
-      const functions = {
-        // Standard CEL functions
-        string: (value: unknown) => String(value),
-        int: (value: unknown) => parseInt(String(value), 10),
-        double: (value: unknown) => parseFloat(String(value)),
-        size: (collection: unknown) => {
-          if (Array.isArray(collection)) return collection.length;
-          if (typeof collection === 'string') return collection.length;
-          if (collection && typeof collection === 'object') return Object.keys(collection).length;
-          return 0;
-        },
-        has: (obj: unknown, field?: string) => {
-          if (field) {
-            return obj && typeof obj === 'object' && field in obj;
-          }
-          // For expressions like has(config.debug), the field access is already resolved
-          return obj !== undefined && obj !== null;
-        },
-        concat: (...args: unknown[]) => args.join(''),
-        ...context.functions,
-      };
+      const functions = this.evaluationFunctions(context);
 
       const result = evaluate(expression.expression, celContext, functions);
 
@@ -84,27 +97,7 @@ export class CelEvaluator {
 
       return async (context: CelEvaluationContext) => {
         const celContext = await this.buildCelContext(expression, context);
-        const functions = {
-          // Standard CEL functions
-          string: (value: unknown) => String(value),
-          int: (value: unknown) => parseInt(String(value), 10),
-          double: (value: unknown) => parseFloat(String(value)),
-          size: (collection: unknown) => {
-            if (Array.isArray(collection)) return collection.length;
-            if (typeof collection === 'string') return collection.length;
-            if (collection && typeof collection === 'object') return Object.keys(collection).length;
-            return 0;
-          },
-          has: (obj: unknown, field?: string) => {
-            if (field) {
-              return obj && typeof obj === 'object' && field in obj;
-            }
-            // For expressions like has(config.debug), the field access is already resolved
-            return obj !== undefined && obj !== null;
-          },
-          concat: (...args: unknown[]) => args.join(''),
-          ...context.functions,
-        };
+        const functions = this.evaluationFunctions(context);
         return evaluate(parseResult.cst, celContext, functions);
       };
     } catch (error: unknown) {

--- a/src/core/references/cel.ts
+++ b/src/core/references/cel.ts
@@ -434,7 +434,20 @@ function defaultValue(
     ? (schemaSpecHasGuard(getInnerCelPath(value)) ?? has(value).expression)
     : has(value).expression;
   const celValue = celValueForTernary(value);
-  const expression = `${guard} && ${celValue} != null ? ${celValue} : ${celValueForTernary(fallback)}`;
+  const fallbackCel = celValueForTernary(fallback);
+  // KRO gives schema object references a nominal object type while CEL object
+  // literals are inferred as maps. Although both values materialize to the same
+  // Kubernetes JSON object, CEL rejects a ternary that mixes those static types.
+  // Widen both structured branches to dyn so KRO can validate the expression
+  // without changing the runtime value or direct-mode `??` behavior.
+  const hasStructuredLiteralFallback =
+    fallback !== null &&
+    typeof fallback === 'object' &&
+    !isKubernetesRef(fallback) &&
+    !isCelExpression(fallback);
+  const selectedValue = hasStructuredLiteralFallback ? `dyn(${celValue})` : celValue;
+  const selectedFallback = hasStructuredLiteralFallback ? `dyn(${fallbackCel})` : fallbackCel;
+  const expression = `${guard} && ${celValue} != null ? ${selectedValue} : ${selectedFallback}`;
 
   return {
     [CEL_EXPRESSION_BRAND]: true,

--- a/test/core/cel-evaluator.test.ts
+++ b/test/core/cel-evaluator.test.ts
@@ -4,7 +4,8 @@
 
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { CEL_EXPRESSION_BRAND, KUBERNETES_REF_BRAND } from '../../src/core/constants/brands.js';
-import { CelEvaluator } from '../../src/core/references/index.js';
+import { Cel, CelEvaluator } from '../../src/core/references/index.js';
+import type { KubernetesRef } from '../../src/core/types/common.js';
 import { CelEvaluationError } from '../../src/index.js';
 
 describe('CelEvaluator', () => {
@@ -109,6 +110,39 @@ describe('CelEvaluator', () => {
 
       const result = await evaluator.evaluate(expression, context);
       expect(result).toBe('10.0.0.1:8080');
+    });
+
+    it('treats dyn() as identity for structured Cel.default() in evaluate and parse paths', async () => {
+      const fallback = {
+        requests: { cpu: '250m', memory: '1Gi' },
+        limits: { memory: '2Gi' },
+      };
+      const resourcesRef: KubernetesRef<typeof fallback | undefined> = {
+        [KUBERNETES_REF_BRAND]: true,
+        resourceId: 'workload',
+        fieldPath: 'spec.resources',
+      };
+      const expression = Cel.default(resourcesRef, fallback);
+
+      context.resources.set('workload', {
+        spec: {
+          resources: {
+            requests: { cpu: '500m' },
+            limits: { memory: '4Gi' },
+          },
+        },
+      });
+
+      const expected = {
+        requests: { cpu: '500m' },
+        limits: { memory: '4Gi' },
+      };
+      expect(await evaluator.evaluate(expression, context)).toEqual(expected);
+      expect(await evaluator.parse(expression)(context)).toEqual(expected);
+
+      context.resources.set('workload', { spec: {} });
+      expect(await evaluator.evaluate(expression, context)).toEqual(fallback);
+      expect(await evaluator.parse(expression)(context)).toEqual(fallback);
     });
 
     it('should evaluate complex expressions with multiple resources', async () => {

--- a/test/core/reference-resolver.test.ts
+++ b/test/core/reference-resolver.test.ts
@@ -5,7 +5,8 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 import type * as k8s from '@kubernetes/client-node';
 import { CEL_EXPRESSION_BRAND, KUBERNETES_REF_BRAND } from '../../src/core/constants/brands.js';
-import { ReferenceResolver } from '../../src/core/references/index.js';
+import { Cel, ReferenceResolver } from '../../src/core/references/index.js';
+import type { KubernetesRef } from '../../src/core/types/common.js';
 import { containsCelExpressions } from '../../src/utils/type-guards.js';
 import { createK8sError } from '../utils/mock-factories.js';
 
@@ -986,6 +987,37 @@ describe('ReferenceResolver', () => {
   });
 
   describe('resolveReferences with CEL expressions (integration)', () => {
+    it('resolves structured Cel.default() through the direct-mode pipeline', async () => {
+      const workload = {
+        id: 'workload',
+        kind: 'Deployment',
+        name: 'workload',
+        namespace: 'default',
+        manifest: { spec: {} },
+        status: 'deployed' as const,
+        deployedAt: new Date(),
+      };
+      context.deployedResources = [workload];
+      context.resourceKeyMapping = new Map([['workload', workload.manifest]]);
+
+      const fallback = {
+        requests: { cpu: '250m', memory: '1Gi' },
+        limits: { memory: '2Gi' },
+      };
+      const resourcesRef: KubernetesRef<typeof fallback | undefined> = {
+        [KUBERNETES_REF_BRAND]: true,
+        resourceId: 'workload',
+        fieldPath: 'spec.resources',
+      };
+
+      const resolved = await resolver.resolveReferences(
+        { spec: { resources: Cel.default(resourcesRef, fallback) } },
+        context
+      );
+
+      expect(resolved.spec.resources).toEqual(fallback);
+    });
+
     it('should use selective cloning when CEL expressions are present', async () => {
       const celExpr = {
         [CEL_EXPRESSION_BRAND]: true,

--- a/test/core/schema-cel-evaluator.test.ts
+++ b/test/core/schema-cel-evaluator.test.ts
@@ -40,6 +40,53 @@ describe('schema CEL evaluator', () => {
     expect(evaluateSchemaCelExpression(expression, { replicas: 2 })).toBe(3);
   });
 
+  it('treats KRO dyn() type widening as runtime identity', () => {
+    const expression: CelExpression<Record<string, unknown>> = {
+      [CEL_EXPRESSION_BRAND]: true,
+      expression:
+        'has(schema.spec.resources) && schema.spec.resources != null ? dyn(schema.spec.resources) : dyn({"requests":{"cpu":"250m"}})',
+    };
+
+    expect(evaluateSchemaCelExpression(expression, {})).toEqual({
+      requests: { cpu: '250m' },
+    });
+    expect(
+      evaluateSchemaCelExpression(expression, {
+        resources: { limits: { memory: '2Gi' } },
+      })
+    ).toEqual({ limits: { memory: '2Gi' } });
+  });
+
+  it('does not shadow a schema field named dyn with the evaluator helper', () => {
+    const expression: CelExpression<string> = {
+      [CEL_EXPRESSION_BRAND]: true,
+      expression: 'schema.spec.dyn',
+    };
+
+    expect(evaluateSchemaCelExpression(expression, { dyn: 'user-owned' })).toBe('user-owned');
+  });
+
+  it('preserves dyn( text inside a structured fallback string', () => {
+    const expression: CelExpression<Record<string, unknown>> = {
+      [CEL_EXPRESSION_BRAND]: true,
+      expression:
+        'has(schema.spec.resources) && schema.spec.resources != null ? dyn(schema.spec.resources) : dyn({"script":"dyn("})',
+    };
+
+    expect(evaluateSchemaCelExpression(expression, {})).toEqual({
+      script: 'dyn(',
+    });
+  });
+
+  it('preserves quoted schema orValue() fallbacks across lexical segments', () => {
+    const expression: CelExpression<string> = {
+      [CEL_EXPRESSION_BRAND]: true,
+      expression: 'schema.spec.optional.orValue("fallback")',
+    };
+
+    expect(evaluateSchemaCelExpression(expression, {})).toBe('fallback');
+  });
+
   it('does not evaluate escaped literal interpolation text', () => {
     const result = evaluateSchemaCelExpression(
       template('prefix-\\${schema.spec.secret}-${schema.spec.name}'),

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -248,8 +248,8 @@ describe('official Rook Ceph cluster chart platform', () => {
     const compactRgd = rgdYaml.replaceAll(' ', '');
     for (const [daemon, fallback] of Object.entries(expectedFallbacks)) {
       const path = `schema.spec.resources.${daemon}`;
-      const guard = `has(schema.spec.resources)&&has(${path})&&${path}!=null?${path}:`;
-      expect(compactRgd).toContain(`${guard}${fallback}`);
+      const guard = `has(schema.spec.resources)&&has(${path})&&${path}!=null?dyn(${path}):`;
+      expect(compactRgd).toContain(`${guard}dyn(${fallback})`);
     }
     expectCleanYaml(rgdYaml);
   });

--- a/test/unit/structured-nullish-defaults.test.ts
+++ b/test/unit/structured-nullish-defaults.test.ts
@@ -566,10 +566,10 @@ describe('structured nullish defaults', () => {
     const compact = yaml.replaceAll(' ', '');
 
     expect(compact).toContain(
-      'has(schema.spec.resources)&&has(schema.spec.resources.osd)&&schema.spec.resources.osd!=null?schema.spec.resources.osd:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+      'has(schema.spec.resources)&&has(schema.spec.resources.osd)&&schema.spec.resources.osd!=null?dyn(schema.spec.resources.osd):dyn({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
     );
     expect(compact).toContain(
-      'has(schema.spec.resources)&&has(schema.spec.resources.mon)&&schema.spec.resources.mon!=null?schema.spec.resources.mon:{"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}}'
+      'has(schema.spec.resources)&&has(schema.spec.resources.mon)&&schema.spec.resources.mon!=null?dyn(schema.spec.resources.mon):dyn({"requests":{"cpu":"100m","memory":"256Mi"},"limits":{"memory":"1Gi"}})'
     );
   });
 
@@ -680,7 +680,7 @@ describe('structured nullish defaults', () => {
 
     expect(compact).toContain('includeWhen:');
     expect(compact).toContain(
-      'has(schema.spec.resources)&&schema.spec.resources!=null?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+      'has(schema.spec.resources)&&schema.spec.resources!=null?dyn(schema.spec.resources):dyn({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
     );
     expect(compact).not.toContain('has(schema.spec.resources)?schema.spec.resources:omit()');
   });
@@ -703,7 +703,7 @@ describe('structured nullish defaults', () => {
     const compact = yaml.replaceAll(' ', '');
 
     expect(compact).toContain(
-      'has(schema.spec.resources)&&schema.spec.resources!=null?schema.spec.resources:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}'
+      'has(schema.spec.resources)&&schema.spec.resources!=null?dyn(schema.spec.resources):dyn({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
     );
     expect(compact).toContain('"replicaCount":1');
     expect(compact).not.toContain('has(schema.spec.resources)?schema.spec.resources:omit()');
@@ -794,7 +794,7 @@ describe('structured nullish defaults', () => {
     const compact = yaml.replaceAll(' ', '');
 
     expect(compact).toContain(
-      'has(schema.spec.primary)&&schema.spec.primary!=null?schema.spec.primary:(has(schema.spec.secondary)&&schema.spec.secondary!=null?schema.spec.secondary:{"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}})'
+      'has(schema.spec.primary)&&schema.spec.primary!=null?schema.spec.primary:(has(schema.spec.secondary)&&schema.spec.secondary!=null?dyn(schema.spec.secondary):dyn({"requests":{"cpu":"250m","memory":"1Gi"},"limits":{"memory":"2Gi"}}))'
     );
   });
 


### PR DESCRIPTION
## What changed

- Widen structured `Cel.default()` branches to CEL `dyn` when the fallback is a literal object.
- Preserve the existing guarded nullish-selection semantics and direct-mode JavaScript `??` behavior.
- Register KRO’s type-only `dyn()` conversion as runtime identity in both `CelEvaluator.evaluate()` and compiled `CelEvaluator.parse()` paths, using one shared function registry.
- Apply the same identity semantics in schema-only CEL evaluation without shadowing a user schema field named `dyn`: function calls are rewritten internally to `__dyn(...)`.
- Make schema-evaluator rewrites quote-aware so function-looking or schema-looking text inside structured fallback strings remains byte-for-byte data.
- Add direct-evaluator, parsed-evaluator, direct-resolver, schema-evaluator, namespace-collision, quoted-fallback, core, and Rook regression coverage.

## Why

KRO assigns schema object references a nominal object type while CEL object literals are inferred as maps. A ternary that selected between those values was semantically valid but rejected during RGD admission because the two branches had different static CEL types.

The initial KRO-side widening exposed a direct-mode parity gap: TypeKro’s local CEL evaluators did not register `dyn()`, even though `dyn()` has identity runtime semantics. This update fixes the abstraction at both evaluation entry points rather than stripping generated expressions or special-casing the resolver.

Schema-only evaluation flattens `schema.spec.*` fields into its local scope. Keeping the helper under the public name `dyn` would shadow a legitimate `schema.spec.dyn` field. A raw textual rewrite would also corrupt fallback data such as `{ "script": "dyn(" }`. Internal call rewriting now operates only on unquoted CEL source, preserving both field namespaces and literal values.

The failure surfaced while Applik8s supplied explicit Rook/Ceph daemon resource sizing through TypeKro: the generated RGD retained the correct structured defaults, but KRO rejected the expression before reconciliation.

## Impact

Object-valued defaults now admit and reconcile in KRO mode and evaluate correctly in direct mode without asking integrations to hand-author CEL. Structured fallback values are preserved exactly. Scalar, reference-based, and existing explicit-expression defaults retain their current lowering.

## Release compatibility

This branch is rebased onto current `master` (`8810530`), after v0.30.1. The intervening release changes only the Alchemy materialization requirement type channel and package metadata; post-release master changes only CI gate reporting. Neither overlaps CEL lowering, Rook composition behavior, or the affected tests.

## Verification

- Five focused evaluator/resolver/structured-default/Rook files — 118 passed
- Expanded focused set including KRO factory characterization — 253 passed
- `./scripts/run-unit-tests.sh` — 5,124 passed, 13 skipped, 1 todo, 0 failed
- Commit hook repeated the complete non-live suite — 5,124 passed, 0 failed
- `bun run build` — lint, all typechecks, library build, and examples build passed
- `git diff --check` — passed
- Live OrbStack/KRO 0.9.2: the Rook/Ceph RGD was admitted, the existing owner instance reconciled with explicit OSD/RGW resource overrides, Ceph daemons remained ready with zero restarts, and authenticated Harbor blob upload/HEAD/download completed successfully.
