### PR TITLE
Adopt existing immutable container tags

### DIFF
--- a/docs/api/containers/index.md
+++ b/docs/api/containers/index.md
@@ -148,6 +148,41 @@ const result = await buildContainer({
 - `.dockerignore` is respected — ignored files don't affect the hash
 - Docker's layer cache means unchanged builds return instantly
 
+The built-in content hash deliberately identifies source content only. It does **not** cover build
+arguments, targets, platforms, extra Docker arguments, file modes, or symlink metadata, so it is not
+a complete build identity and cannot safely authorize registry-side adoption.
+
+## Retry-safe immutable tag adoption
+
+For a remote registry that enforces immutable tags, an interrupted deployment can adopt an image
+that was already published by the same complete build instead of trying to push the tag again:
+
+```typescript
+const image = await container({
+  context: './apps/api',
+  imageName: 'api',
+  // Produced by your build pipeline from every build input, not TypeKro's
+  // context-only `content-hash`.
+  tag: completeBuildIdentity,
+  existingTagPolicy: 'adopt',
+  platform: 'linux/amd64',
+  registry: harbor({
+    registry: 'registry.example.com',
+    project: 'production',
+  }),
+});
+```
+
+`adopt` is fail-closed and has two non-negotiable preconditions:
+
+1. The explicit tag must identify the complete build: context bytes and paths, Dockerfile, build
+   arguments, target, platforms, extra Docker arguments, and relevant file/symlink metadata.
+2. The registry must enforce tag immutability.
+
+TypeKro rejects `adopt` with an omitted tag or `tag: 'content-hash'`. It builds only after the
+registry positively reports `manifest unknown`; authentication, TLS, registry, Docker, timeout,
+cancellation, and malformed-digest failures are returned to the caller without attempting a push.
+
 ## Full Stack Example
 
 Build a container and deploy it with the full infrastructure stack:
@@ -192,6 +227,7 @@ await factory.deploy({
 | `imageName` | `string` | required | Image name (lowercase, no registry prefix) |
 | `dockerfile` | `string` | `'Dockerfile'` | Dockerfile path relative to context |
 | `tag` | `string` | `'latest'` | Tag or `'content-hash'` for SHA-based |
+| `existingTagPolicy` | `'replace' \| 'adopt'` | `'replace'` | Adopt an existing immutable explicit tag; requires a complete caller-derived build identity |
 | `platform` | `string` | native | Target platform (e.g., `'linux/amd64'`) |
 | `platforms` | `string[]` | — | Multi-platform Buildx manifest; remote registries only |
 | `buildArgs` | `Record<string, string>` | — | Docker build arguments |

--- a/src/core/containers/build.ts
+++ b/src/core/containers/build.ts
@@ -151,6 +151,62 @@ async function verifyPublishedDigest(
   return digest;
 }
 
+async function inspectPublishedDigest(
+  taggedImageUri: string,
+  session: RegistrySession,
+  builder: string | undefined,
+  timeout: number,
+  signal: AbortSignal | undefined
+): Promise<string | undefined> {
+  try {
+    const inspected = await execDocker(
+      [
+        'buildx',
+        'imagetools',
+        'inspect',
+        taggedImageUri,
+        ...(builder ? ['--builder', builder] : []),
+        '--format',
+        '{{json .Manifest.Digest}}',
+      ],
+      {
+        quiet: true,
+        timeout,
+        ...(session.environment ? { environment: session.environment } : {}),
+        ...(signal ? { signal } : {}),
+      }
+    );
+    return digestFromInspectOutput(inspected.stdout);
+  } catch (error) {
+    if (error instanceof ContainerBuildError && error.code === 'BUILD_CANCELLED') throw error;
+    if (signal?.aborted) throw ContainerBuildError.cancelled();
+    if (error instanceof ContainerBuildError && error.code === 'BUILD_TIMEOUT') throw error;
+    if (error instanceof ContainerBuildError && error.code === 'DIGEST_VERIFICATION_FAILED') {
+      throw error;
+    }
+    if (manifestWasPositivelyNotFound(error, taggedImageUri)) {
+      logger.debug('Container tag is not available for adoption', { taggedImageUri });
+      return undefined;
+    }
+    const cause = error instanceof Error ? error : new Error(String(error));
+    throw ContainerBuildError.tagInspectionFailed(taggedImageUri, cause);
+  }
+}
+
+function manifestWasPositivelyNotFound(error: unknown, taggedImageUri: string): boolean {
+  if (!(error instanceof ContainerBuildError) || error.code !== 'DOCKER_COMMAND_FAILED') {
+    return false;
+  }
+  const stderr = error.command?.stderr;
+  if (typeof stderr !== 'string') return false;
+  const target = taggedImageUri.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const knownAbsence = new RegExp(
+    `^ERROR:\\s+${target}:\\s+(?:not found|manifest unknown(?::.*)?|manifest_unknown(?::.*)?|no such manifest(?::.*)?)\\s*$`,
+    'i'
+  );
+  return stderr.split(/\r?\n/).some((line) => knownAbsence.test(line.trim()));
+}
+
 /** Build, publish, and registry-verify a container image. */
 export async function buildContainer(
   options: ContainerBuildOptions
@@ -162,6 +218,7 @@ export async function buildContainer(
     imageName,
     buildArgs,
     target,
+    existingTagPolicy = 'replace',
     quiet = false,
     progress = 'auto',
     timeout = 300_000,
@@ -183,6 +240,26 @@ export async function buildContainer(
     throw new ContainerBuildError(`Invalid image name: "${imageName}".`, 'INVALID_IMAGE_NAME');
   }
   if (buildArgs) validateBuildArgs(buildArgs);
+  if (existingTagPolicy !== 'replace' && existingTagPolicy !== 'adopt') {
+    throw new ContainerBuildError(
+      `Invalid existing tag policy: "${String(existingTagPolicy)}".`,
+      'INVALID_TAG_POLICY',
+      ['Use "replace" for mutable tags or "adopt" for immutable content-derived tags.']
+    );
+  }
+  if (
+    existingTagPolicy === 'adopt' &&
+    (options.tag === undefined || options.tag === 'content-hash')
+  ) {
+    throw new ContainerBuildError(
+      'Adopting an existing tag requires an explicit tag derived from the complete build input.',
+      'UNSAFE_ADOPTION_TAG',
+      [
+        'Include the context, Dockerfile, build arguments, target, platforms, extra Docker arguments, and relevant filesystem metadata in the tag identity.',
+        'Use existingTagPolicy: "replace" with TypeKro\'s built-in content-hash tag.',
+      ]
+    );
+  }
   const platforms = resolvePlatforms(options);
   let tag = options.tag ?? 'latest';
   if (tag === 'content-hash') tag = await computeContentHash(contextPath, dockerfilePath);
@@ -190,7 +267,7 @@ export async function buildContainer(
   await checkDockerAvailable(signal);
   const registry = resolveRegistry(options.registry);
   const taggedImageUri = await registry.resolveImageUri(imageName, tag);
-  logger.info('Building container image', {
+  logger.info('Resolving container artifact', {
     taggedImageUri,
     platforms: platforms.length ? platforms : ['native'],
   });
@@ -224,6 +301,35 @@ export async function buildContainer(
     if (session.remote) {
       if (session.buildkitConfigPath || platforms.length > 1) {
         builder = await createBuildxBuilder(session, timeout, signal);
+      }
+      if (existingTagPolicy === 'adopt') {
+        const digest = await inspectPublishedDigest(
+          taggedImageUri,
+          session,
+          builder,
+          timeout,
+          signal
+        );
+        if (digest) {
+          const repository = repositoryFromTaggedUri(taggedImageUri);
+          const imageUri = `${repository}@${digest}`;
+          const duration = Date.now() - startedAt;
+          logger.info('Existing container tag adopted', {
+            imageUri,
+            taggedImageUri,
+            duration,
+          });
+          return {
+            imageUri,
+            taggedImageUri,
+            repository,
+            tag,
+            digest,
+            duration,
+            pushed: true,
+            platforms,
+          };
+        }
       }
       await execDocker(
         [

--- a/src/core/containers/errors.ts
+++ b/src/core/containers/errors.ts
@@ -4,14 +4,21 @@
 
 import { TypeKroError } from '../errors.js';
 
+export interface DockerCommandFailure {
+  readonly exitCode: number;
+  readonly args: readonly string[];
+  readonly stderr: string;
+}
+
 export class ContainerBuildError extends TypeKroError {
   constructor(
     message: string,
     code: string,
     public readonly suggestions: string[] = [],
-    cause?: Error
+    cause?: Error,
+    public readonly command?: DockerCommandFailure
   ) {
-    super(message, code, { suggestions }, cause ? { cause } : undefined);
+    super(message, code, { suggestions, ...(command ? { command } : {}) }, cause ? { cause } : undefined);
     this.name = 'ContainerBuildError';
   }
 
@@ -48,7 +55,9 @@ export class ContainerBuildError extends TypeKroError {
     return new ContainerBuildError(
       `Docker ${operation} failed with exit code ${exitCode}:\n${stderr.slice(0, 2_000)}`,
       'DOCKER_COMMAND_FAILED',
-      ['Review the redacted Docker diagnostics and registry/build configuration.']
+      ['Review the redacted Docker diagnostics and registry/build configuration.'],
+      undefined,
+      { exitCode, args: [...args], stderr }
     );
   }
 
@@ -69,6 +78,18 @@ export class ContainerBuildError extends TypeKroError {
       `Registry manifest digest verification failed: ${detail}`,
       'DIGEST_VERIFICATION_FAILED',
       ['Verify registry availability, credentials, and that the pushed tag was not mutated.']
+    );
+  }
+
+  static tagInspectionFailed(imageUri: string, cause: Error): ContainerBuildError {
+    return new ContainerBuildError(
+      `Failed to inspect existing container tag ${imageUri}: ${cause.message}`,
+      'TAG_INSPECTION_FAILED',
+      [
+        'Verify registry availability, credentials, and TLS configuration.',
+        'Retry only after the registry can positively distinguish a missing manifest from an inspection failure.',
+      ],
+      cause
     );
   }
 

--- a/src/core/containers/image.ts
+++ b/src/core/containers/image.ts
@@ -32,6 +32,7 @@ import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 import { buildContainer, computeContentHash } from './build.js';
+import { ContainerBuildError } from './errors.js';
 import type { ContainerBuildOptions, ContainerBuildResult } from './registries/types.js';
 
 /** A built container image, resolved to a literal — both the full URI and its split parts. */
@@ -138,6 +139,20 @@ async function resolvedBuildOptions(
 ): Promise<ContainerOptions> {
   const context = resolve(options.context);
   const dockerfile = options.dockerfile ?? 'Dockerfile';
+  if (
+    build === buildContainer &&
+    options.existingTagPolicy === 'adopt' &&
+    (options.tag === undefined || options.tag === 'content-hash')
+  ) {
+    throw new ContainerBuildError(
+      'Adopting an existing tag requires an explicit tag derived from the complete build input.',
+      'UNSAFE_ADOPTION_TAG',
+      [
+        'Include the context, Dockerfile, build arguments, target, platforms, extra Docker arguments, and relevant filesystem metadata in the tag identity.',
+        'Use existingTagPolicy: "replace" with TypeKro\'s built-in content-hash tag.',
+      ]
+    );
+  }
   let tag = options.tag ?? 'content-hash';
   if (
     tag === 'content-hash' &&
@@ -157,6 +172,7 @@ function buildCacheKey(options: ContainerOptions, build: Builder): string {
     dockerfile: options.dockerfile,
     imageName: options.imageName,
     tag: options.tag,
+    existingTagPolicy: options.existingTagPolicy,
     platform: options.platform,
     platforms: options.platforms ? [...options.platforms] : undefined,
     buildArgs: sortedRecord(options.buildArgs),

--- a/src/core/containers/registries/types.ts
+++ b/src/core/containers/registries/types.ts
@@ -93,6 +93,17 @@ export interface ContainerBuildOptions {
   dockerfile?: string;
   imageName: string;
   tag?: string;
+  /**
+   * How to handle a remote tag that already resolves in the registry.
+   *
+   * `adopt` skips the build and returns the registry-verified immutable
+   * digest. It requires an explicit tag derived from the complete build input
+   * and a registry that enforces immutability. TypeKro's built-in
+   * `content-hash` is intentionally rejected because it does not cover build
+   * arguments, targets, platforms, extra Docker arguments, or all filesystem
+   * metadata. The default `replace` preserves ordinary mutable-tag behavior.
+   */
+  existingTagPolicy?: 'replace' | 'adopt';
   /** Build one target platform. Mutually exclusive with `platforms`. */
   platform?: string;
   /** Build and publish a multi-platform manifest with Buildx. */

--- a/test/core/containers/image.test.ts
+++ b/test/core/containers/image.test.ts
@@ -116,6 +116,20 @@ describe('container()', () => {
     expect(calls).toEqual(['svc', 'svc']);
   });
 
+  it('memoizes adopt and replace policies independently', async () => {
+    const calls: string[] = [];
+    const build = makeFakeBuild(calls);
+    const common = {
+      context: './app',
+      imageName: 'policy',
+      tag: 'sha-complete-build',
+      registry: { type: 'ecr' as const },
+    };
+    await container({ ...common, existingTagPolicy: 'adopt' }, build);
+    await container({ ...common, existingTagPolicy: 'replace' }, build);
+    expect(calls).toEqual(['policy', 'policy']);
+  });
+
   it('evicts a failed build so a corrected retry can succeed', async () => {
     let attempts = 0;
     const build = async (opts: ContainerBuildOptions): Promise<ContainerBuildResult> => {

--- a/test/core/containers/oci.test.ts
+++ b/test/core/containers/oci.test.ts
@@ -24,6 +24,15 @@ import type { RegistryHandler } from '../../../src/core/containers/registries/ty
 const DIGEST = `sha256:${'a'.repeat(64)}`;
 const OTHER_DIGEST = `sha256:${'b'.repeat(64)}`;
 
+async function waitForDockerLog(path: string, expected: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path) && readFileSync(path, 'utf8').includes(expected)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for Docker invocation containing ${expected}.`);
+}
+
 describe('generic OCI registry provider', () => {
   let directory = '';
   let originalPath = '';
@@ -85,8 +94,33 @@ if (args[0] === 'buildx' && args[1] === 'create') {
   process.exit(0);
 }
 if (args[0] === 'buildx' && args[1] === 'imagetools') {
-  process.stdout.write(JSON.stringify(process.env.FAKE_INSPECT_DIGEST || '${DIGEST}') + '\\n');
-  process.exit(0);
+  const inspect = () => {
+    if (process.env.FAKE_INSPECT_ERROR_ONCE) {
+      const marker = process.env.FAKE_DOCKER_LOG + '.inspect-error';
+      if (!fs.existsSync(marker)) {
+        fs.writeFileSync(marker, '1');
+        process.stderr.write(process.env.FAKE_INSPECT_ERROR_ONCE + '\\n');
+        process.exit(1);
+      }
+    }
+    if (process.env.FAKE_INSPECT_ERROR) {
+      process.stderr.write(process.env.FAKE_INSPECT_ERROR + '\\n');
+      process.exit(1);
+    }
+    if (process.env.FAKE_INSPECT_MISSING_ONCE === '1') {
+      const marker = process.env.FAKE_DOCKER_LOG + '.inspect-missed';
+      if (!fs.existsSync(marker)) {
+        fs.writeFileSync(marker, '1');
+        process.stderr.write('ERROR: ' + args[3] + ': manifest unknown: requested tag was not found\\n');
+        process.exit(1);
+      }
+    }
+    process.stdout.write(JSON.stringify(process.env.FAKE_INSPECT_DIGEST || '${DIGEST}') + '\\n');
+    process.exit(0);
+  };
+  const delay = Number(process.env.FAKE_INSPECT_DELAY_MS || 0);
+  if (delay > 0) setTimeout(inspect, delay); else inspect();
+  return;
 }
 process.exit(0);
 `,
@@ -112,6 +146,10 @@ process.exit(0);
     delete process.env.FAKE_BUILD_DELAY_MS;
     delete process.env.FAKE_IGNORE_SIGTERM;
     delete process.env.FAKE_REJECT_BUILDKIT_CA;
+    delete process.env.FAKE_INSPECT_MISSING_ONCE;
+    delete process.env.FAKE_INSPECT_ERROR;
+    delete process.env.FAKE_INSPECT_ERROR_ONCE;
+    delete process.env.FAKE_INSPECT_DELAY_MS;
     rmSync(directory, { recursive: true, force: true });
   });
 
@@ -180,6 +218,133 @@ process.exit(0);
     for (const record of records) {
       if (record.dockerConfig) expect(existsSync(record.dockerConfig)).toBe(false);
     }
+  });
+
+  it('adopts a content-addressed immutable tag without rebuilding it', async () => {
+    const result = await buildContainer({
+      context: contextPath,
+      imageName: 'gateway',
+      tag: 'sha-content',
+      existingTagPolicy: 'adopt',
+      registry: harbor({
+        registry: 'registry.example.test',
+        project: 'chirp',
+      }),
+    });
+
+    expect(result).toMatchObject({
+      imageUri: `registry.example.test/chirp/gateway@${DIGEST}`,
+      taggedImageUri: 'registry.example.test/chirp/gateway:sha-content',
+      digest: DIGEST,
+      pushed: true,
+    });
+    const log = readFileSync(logPath, 'utf8');
+    expect(log).toContain('"imagetools"');
+    expect(log).not.toContain('["buildx","build"');
+  });
+
+  it('builds an adoptable tag when the registry does not contain it', async () => {
+    process.env.FAKE_INSPECT_MISSING_ONCE = '1';
+    const result = await buildContainer({
+      context: contextPath,
+      imageName: 'gateway',
+      tag: 'sha-new',
+      existingTagPolicy: 'adopt',
+      registry: harbor({
+        registry: 'registry.example.test',
+        project: 'chirp',
+      }),
+    });
+
+    expect(result.digest).toBe(DIGEST);
+    expect(readFileSync(logPath, 'utf8')).toContain('["buildx","build"');
+  });
+
+  it('recognizes Buildx exact-tag not-found diagnostics without accepting ambiguous failures', async () => {
+    process.env.FAKE_INSPECT_ERROR_ONCE =
+      'ERROR: registry.example.test/chirp/gateway:sha-new: not found';
+    const result = await buildContainer({
+      context: contextPath,
+      imageName: 'gateway',
+      tag: 'sha-new',
+      existingTagPolicy: 'adopt',
+      registry: harbor({ registry: 'registry.example.test', project: 'chirp' }),
+    });
+    expect(result.digest).toBe(DIGEST);
+    expect(readFileSync(logPath, 'utf8')).toContain('["buildx","build"');
+  });
+
+  it('rejects built-in context-only hashes as adoption identities', async () => {
+    await expect(
+      buildContainer({
+        context: contextPath,
+        imageName: 'gateway',
+        tag: 'content-hash',
+        existingTagPolicy: 'adopt',
+        registry: harbor({ registry: 'registry.example.test', project: 'chirp' }),
+      })
+    ).rejects.toMatchObject({ code: 'UNSAFE_ADOPTION_TAG' });
+    await expect(
+      buildContainer({
+        context: contextPath,
+        imageName: 'gateway',
+        existingTagPolicy: 'adopt',
+        registry: harbor({ registry: 'registry.example.test', project: 'chirp' }),
+      })
+    ).rejects.toMatchObject({ code: 'UNSAFE_ADOPTION_TAG' });
+    expect(existsSync(logPath)).toBe(false);
+  });
+
+  it('fails closed when registry inspection does not positively report a missing manifest', async () => {
+    for (const diagnostic of [
+      'ERROR: unauthorized: authentication required',
+      'ERROR: x509: certificate signed by unknown authority',
+      'ERROR: unexpected status from HEAD request: 503 Service Unavailable',
+    ]) {
+      process.env.FAKE_INSPECT_ERROR = diagnostic;
+      await expect(
+        buildContainer({
+          context: contextPath,
+          imageName: 'gateway',
+          tag: `sha-${diagnostic.length}`,
+          existingTagPolicy: 'adopt',
+          registry: harbor({ registry: 'registry.example.test', project: 'chirp' }),
+        })
+      ).rejects.toMatchObject({ code: 'TAG_INSPECTION_FAILED' });
+    }
+    expect(readFileSync(logPath, 'utf8')).not.toContain('["buildx","build"');
+  });
+
+  it('does not classify an adversarial repository name as a missing manifest', async () => {
+    process.env.FAKE_INSPECT_ERROR = 'ERROR: unauthorized: authentication required';
+    await expect(
+      buildContainer({
+        context: contextPath,
+        imageName: 'manifest_unknown/gateway',
+        tag: 'sha-complete',
+        existingTagPolicy: 'adopt',
+        registry: harbor({ registry: 'registry.example.test', project: 'chirp' }),
+      })
+    ).rejects.toMatchObject({ code: 'TAG_INSPECTION_FAILED' });
+    expect(readFileSync(logPath, 'utf8')).not.toContain('["buildx","build"');
+  });
+
+  it('normalizes cancellation during adoption inspection', async () => {
+    process.env.FAKE_INSPECT_DELAY_MS = '10000';
+    process.env.FAKE_IGNORE_SIGTERM = '1';
+    const abort = new AbortController();
+    const build = buildContainer({
+      context: contextPath,
+      imageName: 'gateway',
+      tag: 'sha-cancelled-inspect',
+      existingTagPolicy: 'adopt',
+      signal: abort.signal,
+      registry: harbor({ registry: 'registry.example.test', project: 'chirp' }),
+    });
+    await waitForDockerLog(logPath, '"imagetools"', 2_000);
+    abort.abort();
+    await expect(build).rejects.toMatchObject({ code: 'BUILD_CANCELLED' });
+    expect(readFileSync(logPath, 'utf8')).toContain('"imagetools"');
   });
 
   it('fails closed when BuildKit and the registry disagree about the manifest digest', async () => {


### PR DESCRIPTION
## What changed

- Adds an explicit `existingTagPolicy: "adopt"` option to `buildContainer`.
- Authenticates and inspects an existing remote tag before building.
- Returns the registry-verified immutable digest when the tag already exists.
- Falls through to the ordinary build-and-push path when the tag is absent.
- Preserves timeout and cancellation failures instead of treating them as cache misses.

## Why

Content-derived tags in immutable registries are retry-safe artifacts. After an interrupted higher-level deployment loses local state, rebuilding and pushing the same tag fails even though the correct artifact already exists. Registry-side digest adoption makes retry behavior idempotent without weakening immutability or leaking registry mechanics into integrations.

Callers must opt in and should do so only when the tag is derived from the complete build input and the registry enforces immutability. Mutable tags retain the current replacement behavior by default.

## Verification

- `bun test test/core/containers/oci.test.ts test/core/containers/build.test.ts test/core/containers/image.test.ts --timeout 10000` — 53 passed
- `bun run build`
- `bun run test:randomized` — 5,126 passed, 13 skipped, 1 todo
- pre-commit full unit suite — 5,126 passed, 13 skipped, 1 todo
- `git diff --check`