### PR TITLE
fix: persist top-level resource status projections

### DIFF
--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -137,7 +137,10 @@ import type {
   SchemaProxy,
   SerializationOptions,
 } from '../types/serialization.js';
-import { validateStatusCelExpressions } from '../validation/cel-validator.js';
+import {
+  createStatusResourceIdentityContext,
+  validateStatusCelExpressions,
+} from '../validation/cel-validator.js';
 import { KubernetesClientManager } from './client-provider-manager.js';
 import {
   blockerForRemainingResource,
@@ -4469,6 +4472,23 @@ export class KroResourceFactoryImpl<
           aspects: this.factoryOptions.aspects ?? [],
         });
 
+    // Semantic artifact adaptation canonicalizes graph-child keys. Preserve the
+    // authoring aliases on those reconstructed resources so status classification
+    // and emission resolve callback keys and derived nested aliases identically.
+    const authoredIdentities = createStatusResourceIdentityContext(this.resources);
+    const emittedIdentities = createStatusResourceIdentityContext(aspectResources);
+    for (const [resourceKey, resource] of Object.entries(aspectResources)) {
+      const emittedId = emittedIdentities.resourceAliases.get(resourceKey) ?? resourceKey;
+      const aliases = [...authoredIdentities.resourceAliases.entries()].flatMap(
+        ([alias, canonicalId]) => (canonicalId === emittedId && alias !== emittedId ? [alias] : [])
+      );
+      if (aliases.length > 0) {
+        setMetadataField(resource, 'resourceAliases', [
+          ...new Set([...(getMetadataField(resource, 'resourceAliases') ?? []), ...aliases]),
+        ]);
+      }
+    }
+
     // Strict CEL diagnostics gate: fail fast if the status CEL that is about
     // to be emitted references resources that are not part of this graph,
     // instead of shipping an RGD that KRO will mark Inactive on the cluster.
@@ -5406,7 +5426,8 @@ export class KroResourceFactoryImpl<
 
     // Use dynamic import to avoid circular dependencies
     const { separateStatusFields } = await import('../validation/cel-validator.js');
-    return separateStatusFields(this.statusMappings);
+    const { resourceIds } = createStatusResourceIdentityContext(this.resources);
+    return separateStatusFields(this.statusMappings, this.getNestedStatusCel(), resourceIds);
   }
 
   /**

--- a/src/core/expressions/composition/composition-analyzer.ts
+++ b/src/core/expressions/composition/composition-analyzer.ts
@@ -22,8 +22,10 @@ import { buildLexicalAliasScope } from '../analysis/alias-inliner.js';
 import {
   getForEach,
   getIncludeWhen,
+  getMetadataField,
   setForEach,
   setIncludeWhen,
+  setMetadataField,
   setTemplateOverrides,
 } from '../../metadata/index.js';
 import { extractSpecParamName } from './composition-analyzer-helpers.js';
@@ -369,5 +371,30 @@ export function applyAnalysisToResources(
     if (!resource || typeof resource !== 'object' || overrides.length === 0) continue;
 
     setTemplateOverrides(resource, overrides);
+  }
+
+  // Preserve authored local-variable identities alongside canonical resource ids.
+  // Imperative compositions are registered by resource id, so without this metadata
+  // status validation cannot distinguish a local alias from another resource that
+  // happens to own that alias as its canonical id.
+  for (const [alias, resourceId] of analysis.variableToResourceId ?? []) {
+    const resource = resources[resourceId];
+    if (!resource || typeof resource !== 'object' || alias === resourceId) continue;
+    // A variable declared in the current composition shadows same-named aliases
+    // inherited from nested compositions. Remove only alias metadata; a sibling
+    // whose canonical resource id equals the alias remains intentionally ambiguous.
+    for (const [candidateId, candidate] of Object.entries(resources)) {
+      if (candidateId === resourceId || !candidate || typeof candidate !== 'object') continue;
+      const inheritedAliases = getMetadataField(candidate, 'resourceAliases');
+      if (!inheritedAliases?.includes(alias)) continue;
+      setMetadataField(
+        candidate,
+        'resourceAliases',
+        inheritedAliases.filter((candidateAlias) => candidateAlias !== alias)
+      );
+    }
+    const aliases = new Set(getMetadataField(resource, 'resourceAliases') ?? []);
+    aliases.add(alias);
+    setMetadataField(resource, 'resourceAliases', [...aliases]);
   }
 }

--- a/src/core/planning/planner.ts
+++ b/src/core/planning/planner.ts
@@ -4,6 +4,7 @@ import {
   isMixedTemplate,
   isResourceReference,
 } from '../../utils/type-guards.js';
+import { canonicalizeCelResourceAliases } from '../../utils/cel-resource-identifiers.js';
 import { applyAspects } from '../aspects/apply.js';
 import { DependencyResolver } from '../dependencies/index.js';
 import { TypeKroError } from '../errors.js';
@@ -305,6 +306,7 @@ function canonicalizeStatusResourceReferences(
         ...value,
         expression: {
           ...value.expression,
+          expression: canonicalizeCelResourceAliases(value.expression.expression, resourceAliases),
           references: value.expression.references.map((reference) =>
             reference.source === 'resource' && reference.resourceId
               ? { ...reference, resourceId: canonicalResourceId(reference.resourceId) }
@@ -326,6 +328,10 @@ function canonicalizeStatusResourceReferences(
               ...segment,
               expression: {
                 ...segment.expression,
+                expression: canonicalizeCelResourceAliases(
+                  segment.expression.expression,
+                  resourceAliases
+                ),
                 references: segment.expression.references.map((reference) =>
                   reference.source === 'resource' && reference.resourceId
                     ? { ...reference, resourceId: canonicalResourceId(reference.resourceId) }

--- a/src/core/planning/planner.ts
+++ b/src/core/planning/planner.ts
@@ -31,6 +31,7 @@ import {
 import type { DeploymentResourceGraph } from '../types/deployment.js';
 import type { DeployableK8sResource, Enhanced, KubernetesResource } from '../types/kubernetes.js';
 import type { KroCompatibleType } from '../types/schema.js';
+import { createStatusResourceIdentityContext } from '../validation/cel-validator.js';
 
 import { createAspectManifest } from './aspects.js';
 import { canonicalDigest, canonicalStringify } from './canonical.js';
@@ -282,6 +283,211 @@ function markSensitiveSpecReferences(
   return value;
 }
 
+function canonicalizeStatusResourceReferences(
+  value: PlanValue,
+  resourceAliases: ReadonlyMap<string, string>
+): PlanValue {
+  const canonicalResourceId = (resourceId: string): string =>
+    resourceAliases.get(resourceId) ?? resourceId;
+
+  switch (value.kind) {
+    case 'sensitive-value':
+      return {
+        ...value,
+        value: canonicalizeStatusResourceReferences(value.value, resourceAliases),
+      };
+    case 'reference':
+      return value.source === 'resource' && value.resourceId
+        ? { ...value, resourceId: canonicalResourceId(value.resourceId) }
+        : value;
+    case 'expression':
+      return {
+        ...value,
+        expression: {
+          ...value.expression,
+          references: value.expression.references.map((reference) =>
+            reference.source === 'resource' && reference.resourceId
+              ? { ...reference, resourceId: canonicalResourceId(reference.resourceId) }
+              : reference
+          ),
+        },
+      };
+    case 'template':
+      return {
+        ...value,
+        segments: value.segments.map((segment) => {
+          if (segment.kind === 'reference') {
+            return segment.source === 'resource' && segment.resourceId
+              ? { ...segment, resourceId: canonicalResourceId(segment.resourceId) }
+              : segment;
+          }
+          if (segment.kind === 'expression') {
+            return {
+              ...segment,
+              expression: {
+                ...segment.expression,
+                references: segment.expression.references.map((reference) =>
+                  reference.source === 'resource' && reference.resourceId
+                    ? { ...reference, resourceId: canonicalResourceId(reference.resourceId) }
+                    : reference
+                ),
+              },
+            };
+          }
+          return segment;
+        }),
+      };
+    case 'array':
+      return {
+        ...value,
+        items: value.items.map((item) =>
+          canonicalizeStatusResourceReferences(item, resourceAliases)
+        ),
+      };
+    case 'object':
+      return {
+        ...value,
+        entries: value.entries.map((entry) => ({
+          ...entry,
+          value: canonicalizeStatusResourceReferences(entry.value, resourceAliases),
+        })),
+      };
+    default:
+      return value;
+  }
+}
+
+function resourceFieldValue(
+  desired: PlanValue,
+  fieldPath: string,
+  index = 0
+): PlanValue | undefined {
+  if (desired.kind === 'sensitive-value') return desired;
+  const segments = fieldPath
+    .split('.')
+    .filter(Boolean)
+    .map((segment) => segment.replace(/^\?/, '').replace(/\?$/, ''));
+  if (index >= segments.length) return desired;
+  const segment = segments[index];
+  if (!segment) return desired;
+
+  if (desired.kind === 'object') {
+    const entry = desired.entries.find((candidate) => candidate.key === segment);
+    return entry ? resourceFieldValue(entry.value, fieldPath, index + 1) : undefined;
+  }
+  if (desired.kind === 'array' && /^\d+$/.test(segment)) {
+    const item = desired.items[Number(segment)];
+    return item ? resourceFieldValue(item, fieldPath, index + 1) : undefined;
+  }
+  return undefined;
+}
+
+function resourceReferenceIsSensitive(
+  resourceId: string,
+  fieldPath: string,
+  resourceNodes: ReadonlyMap<string, PlanNode>,
+  capturedResources: ReadonlyMap<string, KubernetesResource>
+): boolean {
+  const resource = capturedResources.get(resourceId);
+  const topLevelField = fieldPath.split('.')[0]?.replace(/\?$/, '');
+  if (
+    resource?.kind === 'Secret' &&
+    getMetadataField(resource, 'secretMaterial') !== 'public-placeholder' &&
+    (topLevelField === 'data' || topLevelField === 'stringData')
+  ) {
+    return true;
+  }
+
+  const desired = resourceNodes.get(resourceId)?.desired;
+  if (!desired) return false;
+  const projectedValue = resourceFieldValue(desired, fieldPath);
+  return projectedValue ? summarizeValue(projectedValue).sensitive : false;
+}
+
+function markSensitiveResourceReferences(
+  value: PlanValue,
+  resourceNodes: ReadonlyMap<string, PlanNode>,
+  capturedResources: ReadonlyMap<string, KubernetesResource>
+): PlanValue {
+  if (value.kind === 'sensitive-binding' || value.kind === 'sensitive-value') return value;
+  if (
+    value.kind === 'reference' &&
+    value.source === 'resource' &&
+    value.resourceId &&
+    resourceReferenceIsSensitive(
+      value.resourceId,
+      value.fieldPath,
+      resourceNodes,
+      capturedResources
+    )
+  ) {
+    return { kind: 'sensitive-value', value };
+  }
+  if (
+    value.kind === 'expression' &&
+    value.expression.references.some(
+      (reference) =>
+        reference.source === 'resource' &&
+        reference.resourceId &&
+        resourceReferenceIsSensitive(
+          reference.resourceId,
+          reference.fieldPath,
+          resourceNodes,
+          capturedResources
+        )
+    )
+  ) {
+    return { kind: 'sensitive-value', value };
+  }
+  if (
+    value.kind === 'template' &&
+    value.segments.some((segment) => {
+      if (segment.kind === 'reference' && segment.source === 'resource' && segment.resourceId) {
+        return resourceReferenceIsSensitive(
+          segment.resourceId,
+          segment.fieldPath,
+          resourceNodes,
+          capturedResources
+        );
+      }
+      return (
+        segment.kind === 'expression' &&
+        segment.expression.references.some(
+          (reference) =>
+            reference.source === 'resource' &&
+            reference.resourceId &&
+            resourceReferenceIsSensitive(
+              reference.resourceId,
+              reference.fieldPath,
+              resourceNodes,
+              capturedResources
+            )
+        )
+      );
+    })
+  ) {
+    return { kind: 'sensitive-value', value };
+  }
+  if (value.kind === 'array') {
+    return {
+      ...value,
+      items: value.items.map((item) =>
+        markSensitiveResourceReferences(item, resourceNodes, capturedResources)
+      ),
+    };
+  }
+  if (value.kind === 'object') {
+    return {
+      ...value,
+      entries: value.entries.map((entry) => ({
+        ...entry,
+        value: markSensitiveResourceReferences(entry.value, resourceNodes, capturedResources),
+      })),
+    };
+  }
+  return value;
+}
+
 /**
  * Preserve symbolic leaves whose meaning cannot be recovered from an already
  * materialized manifest. Concrete object/array shape remains authoritative so
@@ -359,7 +565,10 @@ function statusProjections(
   diagnostics: PlanDiagnostic[],
   specSchema: SchemaIR,
   sensitiveSpecPaths: ReadonlySet<string> = new Set(),
-  resourceIds?: ReadonlySet<string>
+  resourceIds?: ReadonlySet<string>,
+  resourceAliases: ReadonlyMap<string, string> = new Map(),
+  resourceNodes: ReadonlyMap<string, PlanNode> = new Map(),
+  capturedResources: ReadonlyMap<string, KubernetesResource> = new Map()
 ): {
   readonly outputs: Readonly<Record<string, PlanValue>>;
   readonly projections: StatusProjection[];
@@ -374,7 +583,12 @@ function statusProjections(
     .filter((key) => !key.startsWith('__'))
     .sort()) {
     const lowered = lowerPlanValue(statusMappings[key], { specSchema, resourceIds });
-    const value = markSensitiveSpecReferences(lowered.value, sensitiveSpecPaths);
+    const canonicalValue = canonicalizeStatusResourceReferences(lowered.value, resourceAliases);
+    const value = markSensitiveResourceReferences(
+      markSensitiveSpecReferences(canonicalValue, sensitiveSpecPaths),
+      resourceNodes,
+      capturedResources
+    );
     outputs[key] = value;
     diagnostics.push(
       ...lowered.diagnostics.map((diagnostic) => ({
@@ -427,17 +641,18 @@ function buildStatusContract<TSpec extends KroCompatibleType>(
   diagnostics: PlanDiagnostic[],
   strict: boolean,
   specSchema: SchemaIR,
-  sensitiveSpecPaths: ReadonlySet<string> = new Set()
+  sensitiveSpecPaths: ReadonlySet<string> = new Set(),
+  resourceNodes: readonly PlanNode[] = []
 ): { readonly contract: StatusContract; readonly outputs: Readonly<Record<string, PlanValue>> } {
   const hydratedSchema = schemaToIR(capture.ir.definition.statusSchema, { strict: false });
   diagnostics.push(...hydratedSchema.diagnostics);
-  const resourceIds = new Set<string>();
+  const identityContext = createStatusResourceIdentityContext(capture.ir.resources);
+  const capturedResources = new Map<string, KubernetesResource>();
   for (const [resourceKey, resource] of Object.entries(capture.ir.resources)) {
-    resourceIds.add(resourceKey);
-    const resourceId = getResourceId(resource);
-    if (resourceId) resourceIds.add(resourceId);
-    for (const alias of getMetadataField(resource, 'resourceAliases') ?? []) {
-      resourceIds.add(alias);
+    const resourceId = getResourceId(resource) ?? resourceKey;
+    capturedResources.set(resourceId, resource);
+    for (const [alias, canonicalId] of identityContext.resourceAliases) {
+      if (canonicalId === resourceId) capturedResources.set(alias, resource);
     }
   }
   const projected = statusProjections(
@@ -445,7 +660,10 @@ function buildStatusContract<TSpec extends KroCompatibleType>(
     diagnostics,
     specSchema,
     sensitiveSpecPaths,
-    resourceIds
+    identityContext.resourceIds,
+    identityContext.resourceAliases,
+    new Map(resourceNodes.map((node) => [node.id, node])),
+    capturedResources
   );
   const persistedFields = new Set(
     projected.projections
@@ -1697,7 +1915,8 @@ function buildPlanOnce<TSpec extends KroCompatibleType>(
     diagnostics,
     false,
     specSchema,
-    resources.sensitiveSpecPaths
+    resources.sensitiveSpecPaths,
+    resources.nodes
   );
   const semanticSpec = redactSensitiveSpecValues(plannedSpec.value, resources.sensitiveSpecPaths);
   const closures = closureNodes(capture);

--- a/src/core/planning/planner.ts
+++ b/src/core/planning/planner.ts
@@ -358,7 +358,8 @@ function statusProjections(
   statusMappings: Readonly<Record<string, unknown>>,
   diagnostics: PlanDiagnostic[],
   specSchema: SchemaIR,
-  sensitiveSpecPaths: ReadonlySet<string> = new Set()
+  sensitiveSpecPaths: ReadonlySet<string> = new Set(),
+  resourceIds?: ReadonlySet<string>
 ): {
   readonly outputs: Readonly<Record<string, PlanValue>>;
   readonly projections: StatusProjection[];
@@ -372,7 +373,7 @@ function statusProjections(
   for (const key of Object.keys(statusMappings)
     .filter((key) => !key.startsWith('__'))
     .sort()) {
-    const lowered = lowerPlanValue(statusMappings[key], { specSchema });
+    const lowered = lowerPlanValue(statusMappings[key], { specSchema, resourceIds });
     const value = markSensitiveSpecReferences(lowered.value, sensitiveSpecPaths);
     outputs[key] = value;
     diagnostics.push(
@@ -430,11 +431,21 @@ function buildStatusContract<TSpec extends KroCompatibleType>(
 ): { readonly contract: StatusContract; readonly outputs: Readonly<Record<string, PlanValue>> } {
   const hydratedSchema = schemaToIR(capture.ir.definition.statusSchema, { strict: false });
   diagnostics.push(...hydratedSchema.diagnostics);
+  const resourceIds = new Set<string>();
+  for (const [resourceKey, resource] of Object.entries(capture.ir.resources)) {
+    resourceIds.add(resourceKey);
+    const resourceId = getResourceId(resource);
+    if (resourceId) resourceIds.add(resourceId);
+    for (const alias of getMetadataField(resource, 'resourceAliases') ?? []) {
+      resourceIds.add(alias);
+    }
+  }
   const projected = statusProjections(
     capture.ir.statusMappings,
     diagnostics,
     specSchema,
-    sensitiveSpecPaths
+    sensitiveSpecPaths,
+    resourceIds
   );
   const persistedFields = new Set(
     projected.projections

--- a/src/core/planning/values.ts
+++ b/src/core/planning/values.ts
@@ -207,7 +207,10 @@ function tokenImage(value: unknown): string | undefined {
     : undefined;
 }
 
-function parsedExpressionReferences(expression: string): {
+function parsedExpressionReferences(
+  expression: string,
+  resourceIds?: ReadonlySet<string>
+): {
   readonly references: ExpressionReferenceIR[];
   readonly sourceLocation?: PlanSourceLocation;
 } {
@@ -243,7 +246,10 @@ function parsedExpressionReferences(expression: string): {
           references.set(`spec:${fieldPath}`, { source: 'spec', fieldPath });
         } else if (
           root &&
-          (segments[0] === 'spec' || segments[0] === 'status' || segments[0] === 'metadata')
+          (segments[0] === 'spec' ||
+            segments[0] === 'status' ||
+            segments[0] === 'metadata' ||
+            resourceIds?.has(root))
         ) {
           const fieldPath = segments.join('.');
           references.set(`resource:${root}:${fieldPath}`, {
@@ -281,6 +287,7 @@ export function expressionIR(
     readonly language?: ExpressionIR['language'];
     readonly sensitivity?: ExpressionIR['sensitivity'];
     readonly references?: readonly ExpressionReferenceIR[];
+    readonly resourceIds?: ReadonlySet<string> | undefined;
     readonly sourceLocation?: PlanSourceLocation;
   } = {}
 ): ExpressionIR {
@@ -290,7 +297,7 @@ export function expressionIR(
   const parsed =
     options.references || options.sourceLocation
       ? undefined
-      : parsedExpressionReferences(expression);
+      : parsedExpressionReferences(expression, options.resourceIds);
   return {
     version: 1,
     language: options.language ?? 'portable-cel',
@@ -512,7 +519,10 @@ function analyzerExpressionOptions(value: object): {
   };
 }
 
-function mixedTemplatePlanValue(value: { expression: string }): PlanValue {
+function mixedTemplatePlanValue(
+  value: { expression: string },
+  resourceIds?: ReadonlySet<string>
+): PlanValue {
   const segments: PlanTemplateSegment[] = [];
   const pattern = /\$\{([^{}]+)\}/g;
   let offset = 0;
@@ -523,8 +533,16 @@ function mixedTemplatePlanValue(value: { expression: string }): PlanValue {
       segments.push({ kind: 'literal', value: value.expression.slice(offset, index) });
     }
     const expression = match[1];
-    if (!expression) return { kind: 'expression', expression: expressionIR(value.expression) };
-    segments.push({ kind: 'expression', expression: expressionIR(expression) });
+    if (!expression) {
+      return {
+        kind: 'expression',
+        expression: expressionIR(value.expression, { resourceIds }),
+      };
+    }
+    segments.push({
+      kind: 'expression',
+      expression: expressionIR(expression, { resourceIds }),
+    });
     offset = index + match[0].length;
     match = pattern.exec(value.expression);
   }
@@ -539,6 +557,7 @@ function mixedTemplatePlanValue(value: { expression: string }): PlanValue {
 
 interface MutableLoweringState {
   readonly diagnostics: PlanDiagnostic[];
+  readonly resourceIds: ReadonlySet<string> | undefined;
   readonly seen: WeakSet<object>;
   sensitive: boolean;
 }
@@ -610,13 +629,14 @@ function lowerValue(
     };
   }
   if (isMixedTemplate(value) || (isCelExpression(value) && value.__isTemplate === true)) {
-    return mixedTemplatePlanValue(value);
+    return mixedTemplatePlanValue(value, state.resourceIds);
   }
   if (isCelExpression(value)) {
     return {
       kind: 'expression',
       expression: expressionIR(value.expression, {
         language: expressionLanguage,
+        resourceIds: state.resourceIds,
         ...analyzerExpressionOptions(value),
       }),
     };
@@ -718,12 +738,14 @@ export function lowerPlanValue(
   value: unknown,
   options: {
     readonly expressionLanguage?: ExpressionIR['language'];
+    readonly resourceIds?: ReadonlySet<string> | undefined;
     readonly specSchema?: SchemaIR;
     readonly strict?: boolean;
   } = {}
 ): PlanValueLoweringResult {
   const state: MutableLoweringState = {
     diagnostics: [],
+    resourceIds: options.resourceIds,
     seen: new WeakSet<object>(),
     sensitive: false,
   };

--- a/src/core/serialization/cel-references.ts
+++ b/src/core/serialization/cel-references.ts
@@ -348,9 +348,10 @@ function collectLambdaVars(expr: string): Set<string> {
 
 /**
  * Check whether an already-resolved CEL-path string contains any
- * non-schema resource references. "Non-schema resource reference" means
- * any `<identifier>.(status|metadata|spec).<path>` where `<identifier>`
- * is neither `schema` nor a CEL macro lambda variable.
+ * non-schema resource references. The syntax-only fallback recognizes
+ * `<identifier>.(status|metadata|spec).<path>`. When graph resource IDs are
+ * available, any reference rooted at a known resource is dynamic as well,
+ * including kind-specific top-level fields such as ConfigMap `data`.
  *
  * Lambda variables (the `c` in `.exists(c, c.status == "True")`) are
  * detected via {@link collectLambdaVars} and excluded — otherwise a
@@ -366,17 +367,19 @@ function containsNoNonSchemaRefs(expr: string, resourceIds?: Iterable<string>): 
     if (id && lambdaVars.has(id)) continue;
     return false;
   }
-  // A bare reference to a known resource id (e.g. `size(workerDep)` from a
-  // forEach-collection aggregate) is also a non-schema ref even though it has
-  // no `.status`/`.spec`/`.metadata` field path. This needs the resource id
-  // set, so it only fires when callers provide it.
+  // A reference rooted at a known resource id is also non-schema even when it
+  // uses a kind-specific field such as ConfigMap `data`. Bare resource
+  // arguments (for example `size(workerDep)`) are accepted for collection
+  // aggregates. Do not match arbitrary occurrences: a resource id named
+  // `policy` must not turn the literal suffix in
+  // `string(schema.spec.name) + "-policy"` into a live-resource dependency.
   if (resourceIds) {
     for (const id of resourceIds) {
       if (lambdaVars.has(id)) continue;
       const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      // Token not preceded by `.` (so it's the resource itself, not a schema
-      // field like `schema.spec.<id>`) and not part of a longer identifier.
-      if (new RegExp(`(^|[^\\w.$])${escaped}(?![\\w$])`).test(expr)) {
+      const rootedField = new RegExp(`(^|[^\\w.$])${escaped}\\s*\\.`);
+      const bareArgument = new RegExp(`(?:\\(|,)\\s*${escaped}\\s*(?=[,)])`);
+      if (rootedField.test(expr) || bareArgument.test(expr)) {
         return false;
       }
     }
@@ -387,7 +390,7 @@ function containsNoNonSchemaRefs(expr: string, resourceIds?: Iterable<string>): 
 /**
  * Classify an expression as static (iff, after resolving all nested-
  * composition references and schema markers, it contains no references
- * to real-resource `status`/`metadata`/`spec` fields) or dynamic.
+ * to a known live resource) or dynamic.
  *
  * This is the authoritative depth-agnostic static/dynamic classifier.
  * It supersedes the local syntactic check in `validation/cel-validator.ts`

--- a/src/core/serialization/cel-references.ts
+++ b/src/core/serialization/cel-references.ts
@@ -11,6 +11,7 @@
 
 import { KUBERNETES_REF_MARKER_SOURCE } from '../../shared/brands.js';
 import { escapeCelString } from '../../utils/cel-escape.js';
+import { canonicalizeCelResourceAliases } from '../../utils/cel-resource-identifiers.js';
 import { isCelExpression, isKubernetesRef } from '../../utils/type-guards.js';
 import { isValuesMergeExpression } from '../aspects/values-merge.js';
 import { remapVariableNames } from '../composition/nested-status-cel.js';
@@ -1786,25 +1787,16 @@ export function serializeStatusMappingsToCel(
   }
 
   function normalizeLocalResourceExpr(expr: string): string {
-    let normalized = expr;
-
-    if (resourceAliases && resourceAliases.size > 0) {
-      const aliasEntries = Array.from(resourceAliases.entries())
-        .filter(([alias, resolvedId]) => alias !== resolvedId)
-        .sort((left, right) => right[0].length - left[0].length);
-
-      for (const [alias, resolvedId] of aliasEntries) {
-        normalized = normalized
-          .replace(new RegExp(`\\b${escapeRegExpLiteral(alias)}(?=\\.)`, 'g'), resolvedId)
-          .replace(
-            new RegExp(`__KUBERNETES_REF_${escapeRegExpLiteral(alias)}_`, 'g'),
-            `__KUBERNETES_REF_${resolvedId}_`
-          );
-      }
-    }
+    const normalized = resourceAliases
+      ? canonicalizeCelResourceAliases(expr, resourceAliases)
+      : expr;
+    const preserveAfterCanonicalization = new Set([
+      ...preserveVariables,
+      ...(resourceAliases?.keys() ?? []),
+    ]);
 
     return localResourceIds.length > 0
-      ? remapVariableNames(normalized, localResourceIds, preserveVariables)
+      ? remapVariableNames(normalized, localResourceIds, preserveAfterCanonicalization)
       : normalized;
   }
 

--- a/src/core/serialization/cel-references.ts
+++ b/src/core/serialization/cel-references.ts
@@ -213,7 +213,7 @@ function generateCelExpression(
       ? lookupNestedExpression(ref.resourceId, fieldName, context.nestedStatusCel, false)
       : lookupNestedExpression(ref.resourceId, fieldName, context.nestedStatusCel);
     if (innerExpr !== undefined) {
-      return finalizeCelForKro(innerExpr, context.nestedStatusCel, context);
+      return finalizeCelForKro(innerExpr, context.nestedStatusCel, context, true);
     }
   }
 
@@ -407,11 +407,18 @@ function containsNoNonSchemaRefs(expr: string, resourceIds?: Iterable<string>): 
 export function isStaticExpression(
   expr: string,
   nestedStatusCel: Record<string, string> | undefined,
-  resourceIds?: Iterable<string>
+  resourceIds?: Iterable<string>,
+  resolveKnownNestedResourceRefs = false
 ): boolean {
-  const afterNesting = resolveNestedCompositionRefs(expr, nestedStatusCel);
+  const knownResourceIds = resourceIds ? new Set(resourceIds) : undefined;
+  const afterNesting = resolveNestedCompositionRefs(
+    expr,
+    nestedStatusCel,
+    knownResourceIds,
+    resolveKnownNestedResourceRefs
+  );
   const afterMarkers = normalizeMarkerString(afterNesting);
-  return containsNoNonSchemaRefs(afterMarkers, resourceIds);
+  return containsNoNonSchemaRefs(afterMarkers, knownResourceIds);
 }
 
 // ---------------------------------------------------------------------------
@@ -576,17 +583,29 @@ export function lookupNestedExpression(
 function resolveNestedCompositionRefs(
   expr: string,
   nestedStatusCel: Record<string, string> | undefined,
-  resourceIds?: ReadonlySet<string>
+  resourceIds?: ReadonlySet<string>,
+  resolveKnownNestedResourceRefs = true
 ): string {
   if (!nestedStatusCel || Object.keys(nestedStatusCel).length === 0) {
     return expr;
   }
 
   let current = expr;
+  let allowKnownResourceSubstitution = resolveKnownNestedResourceRefs;
   for (let i = 0; i < NESTED_REF_RESOLUTION_DEPTH_LIMIT; i++) {
-    const next = substituteNestedRefsOnce(current, nestedStatusCel, resourceIds);
+    const next = substituteNestedRefsOnce(
+      current,
+      nestedStatusCel,
+      resourceIds,
+      allowKnownResourceSubstitution
+    );
     if (next === current) return current;
     current = next;
+    // Once a virtual nested-composition reference has been expanded, its
+    // analyzed expression may intentionally use a flattened child id that is
+    // also a concrete graph resource. Exact nested mappings are authoritative
+    // only inside that already-proven nested boundary.
+    allowKnownResourceSubstitution = true;
   }
   logger.warn('Nested composition resolution depth limit exceeded', {
     depthLimit: NESTED_REF_RESOLUTION_DEPTH_LIMIT,
@@ -610,7 +629,8 @@ export function inlineNestedStatusRefs(
 function substituteNestedRefsOnce(
   expr: string,
   nestedStatusCel: Record<string, string>,
-  resourceIds?: ReadonlySet<string>
+  resourceIds?: ReadonlySet<string>,
+  resolveKnownNestedResourceRefs = false
 ): string {
   const lambdaVars = collectLambdaVars(expr);
   // Match `<id>.status.<fieldPath>`. The fieldPath capture is greedy on
@@ -620,10 +640,10 @@ function substituteNestedRefsOnce(
   return expr.replace(pattern, (match, id: string, field: string) => {
     if (id === 'schema') return match;
     if (lambdaVars.has(id)) return match;
+    if (resourceIds?.has(id) && !resolveKnownNestedResourceRefs) return match;
     if (resourceIds?.has(id)) {
       const strictInnerExpr = lookupNestedExpression(id, field, nestedStatusCel, false);
-      if (strictInnerExpr !== undefined) return `(${strictInnerExpr})`;
-      return match;
+      return strictInnerExpr === undefined ? match : `(${strictInnerExpr})`;
     }
     const innerExpr = lookupNestedExpression(id, field, nestedStatusCel);
     if (innerExpr !== undefined) return `(${innerExpr})`;
@@ -705,7 +725,12 @@ function innerExprToYamlSegment(
 ): string {
   // Recursively resolve any further nested refs the inner expression itself
   // contains (multi-level nesting).
-  const resolved = resolveNestedCompositionRefs(innerExpr, nestedStatusCel, context?.resourceIds);
+  const resolved = resolveNestedCompositionRefs(
+    innerExpr,
+    nestedStatusCel,
+    context?.resourceIds,
+    true
+  );
   if (resolved.includes('__KUBERNETES_REF_')) {
     // Marker-laden — convert to mixed-template form.
     return convertKubernetesRefMarkersTocel(resolved, context);
@@ -749,10 +774,16 @@ function innerExprToYamlSegment(
 export function finalizeCelForKro(
   expr: string,
   nestedStatusCel: Record<string, string> | undefined,
-  context?: SerializationContext
+  context?: SerializationContext,
+  resolveKnownNestedResourceRefs = true
 ): string {
   const resolved = normalizeCelArrayIndexPaths(
-    resolveNestedCompositionRefs(expr, nestedStatusCel, context?.resourceIds)
+    resolveNestedCompositionRefs(
+      expr,
+      nestedStatusCel,
+      context?.resourceIds,
+      resolveKnownNestedResourceRefs
+    )
   );
   if (resolved.includes('__KUBERNETES_REF_')) {
     return convertKubernetesRefMarkersTocel(resolved, context);
@@ -1733,7 +1764,8 @@ export function serializeStatusMappingsToCel(
   statusMappings: Record<string, unknown>,
   nestedStatusCel?: Record<string, string>,
   resourceIds?: Set<string>,
-  resourceAliases?: ReadonlyMap<string, string>
+  resourceAliases?: ReadonlyMap<string, string>,
+  nestedCompositionIds: ReadonlySet<string> = new Set()
 ): Record<string, string | Record<string, unknown> | unknown[]> {
   logger.debug('Serializing status mappings to CEL', {
     fieldCount: Object.keys(statusMappings).length,
@@ -1763,10 +1795,7 @@ export function serializeStatusMappingsToCel(
 
       for (const [alias, resolvedId] of aliasEntries) {
         normalized = normalized
-          .replace(
-            new RegExp(`\\b${escapeRegExpLiteral(alias)}(?=\\.(?:status|spec|metadata)\\.)`, 'g'),
-            resolvedId
-          )
+          .replace(new RegExp(`\\b${escapeRegExpLiteral(alias)}(?=\\.)`, 'g'), resolvedId)
           .replace(
             new RegExp(`__KUBERNETES_REF_${escapeRegExpLiteral(alias)}_`, 'g'),
             `__KUBERNETES_REF_${resolvedId}_`
@@ -1809,10 +1838,21 @@ export function serializeStatusMappingsToCel(
    * Centralized here so the two branches don't drift on what "produce
    * KRO status CEL from a resolved expression" means.
    */
-  function statusFieldFromExpression(expr: string, rewriteSchemaRefs = true): string {
+  function statusFieldFromExpression(
+    expr: string,
+    rewriteSchemaRefs = true,
+    resolveKnownNestedResourceRefs = [...nestedCompositionIds].some((id) =>
+      new RegExp(`(^|[^\\w$])${escapeRegExpLiteral(id)}\\s*\\.`).test(expr)
+    )
+  ): string {
     const resolved = normalizeCelArrayIndexPaths(
       normalizeLocalResourceExpr(
-        resolveNestedCompositionRefs(normalizeLocalResourceExpr(expr), nestedStatusCel, resourceIds)
+        resolveNestedCompositionRefs(
+          normalizeLocalResourceExpr(expr),
+          nestedStatusCel,
+          resourceIds,
+          resolveKnownNestedResourceRefs
+        )
       )
     );
     if (resolved.includes('__KUBERNETES_REF_')) {
@@ -1840,7 +1880,7 @@ export function serializeStatusMappingsToCel(
         const fieldName = ref.fieldPath.replace(/^status\./, '');
         const innerExpr = lookupNestedExpression(ref.resourceId, fieldName, nestedStatusCel);
         if (innerExpr !== undefined) {
-          return statusFieldFromExpression(innerExpr);
+          return statusFieldFromExpression(innerExpr, true, true);
         }
       }
 

--- a/src/core/serialization/cel-references.ts
+++ b/src/core/serialization/cel-references.ts
@@ -1800,6 +1800,18 @@ export function serializeStatusMappingsToCel(
       : normalized;
   }
 
+  // Canonicalize the nested lookup table once at the serialization boundary. Nested resolution can
+  // expand expressions recursively; parsing each expanded intermediate causes exponential work for
+  // self-referential legacy mappings. Every substituted branch now enters resolution canonical.
+  const normalizedNestedStatusCel = nestedStatusCel
+    ? Object.fromEntries(
+        Object.entries(nestedStatusCel).map(([key, expression]) => [
+          key,
+          normalizeLocalResourceExpr(expression),
+        ])
+      )
+    : undefined;
+
   /**
    * Rewrite resolved schema refs for KRO status CEL.
    *
@@ -1838,13 +1850,11 @@ export function serializeStatusMappingsToCel(
     )
   ): string {
     const resolved = normalizeCelArrayIndexPaths(
-      normalizeLocalResourceExpr(
-        resolveNestedCompositionRefs(
-          normalizeLocalResourceExpr(expr),
-          nestedStatusCel,
-          resourceIds,
-          resolveKnownNestedResourceRefs
-        )
+      resolveNestedCompositionRefs(
+        normalizeLocalResourceExpr(expr),
+        normalizedNestedStatusCel,
+        resourceIds,
+        resolveKnownNestedResourceRefs
       )
     );
     if (resolved.includes('__KUBERNETES_REF_')) {
@@ -1868,9 +1878,13 @@ export function serializeStatusMappingsToCel(
       // For nested composition status references, look up the inner
       // composition's analyzed CEL via the shared resolver and finalize
       // it for KRO status emission.
-      if (ref.__nestedComposition && nestedStatusCel) {
+      if (ref.__nestedComposition && normalizedNestedStatusCel) {
         const fieldName = ref.fieldPath.replace(/^status\./, '');
-        const innerExpr = lookupNestedExpression(ref.resourceId, fieldName, nestedStatusCel);
+        const innerExpr = lookupNestedExpression(
+          ref.resourceId,
+          fieldName,
+          normalizedNestedStatusCel
+        );
         if (innerExpr !== undefined) {
           return statusFieldFromExpression(innerExpr, true, true);
         }
@@ -1910,7 +1924,7 @@ export function serializeStatusMappingsToCel(
         // strings but handles mixed forms), then convert markers to KRO CEL.
         const resolved = resolveNestedRefMarkers(
           normalizeLocalResourceExpr(value),
-          nestedStatusCel,
+          normalizedNestedStatusCel,
           resourceIds
         );
         return rewriteSchemaRefsForKroStatus(convertKubernetesRefMarkersTocel(resolved));

--- a/src/core/serialization/core.ts
+++ b/src/core/serialization/core.ts
@@ -30,7 +30,12 @@ import {
 import { remapResourceStatusReferences } from '../expressions/composition/composition-analyzer-helpers.js';
 import { StatusBuilderAnalyzer } from '../expressions/factory/status-builder-analyzer.js';
 import { getComponentLogger } from '../logging/index.js';
-import { getMetadataField, setResourceId } from '../metadata/index.js';
+import {
+  getMetadataField,
+  getResourceId,
+  setMetadataField,
+  setResourceId,
+} from '../metadata/index.js';
 import {
   inspectCapturedComposition,
   lowerPlanValue,
@@ -134,6 +139,12 @@ function separateResourcesAndClosures<
       closures[key] = value as DeploymentClosure;
     } else if (value && typeof value === 'object' && 'kind' in value && 'apiVersion' in value) {
       // This is an Enhanced<> resource
+      const resourceId = getResourceId(value);
+      if (resourceId && resourceId !== key) {
+        const aliases = new Set(getMetadataField(value, 'resourceAliases') ?? []);
+        aliases.add(key);
+        setMetadataField(value, 'resourceAliases', [...aliases]);
+      }
       resources[key] = value as Enhanced<unknown, unknown>;
     } else {
       // Unknown type, treat as resource for backward compatibility
@@ -2583,8 +2594,7 @@ function createTypedResourceGraph<
     plan: (spec, planOptions = {}) => planCapturedComposition(capture, spec, planOptions),
     planTemplate: (planOptions = {}) =>
       planCapturedTemplate(capture, schema.spec as TSpec, planOptions),
-    planSymbolic: (spec, planOptions = {}) =>
-      planCapturedTemplate(capture, spec, planOptions),
+    planSymbolic: (spec, planOptions = {}) => planCapturedTemplate(capture, spec, planOptions),
     planMaterialized: (spec, materializedGraph, planOptions = {}) =>
       planMaterializedComposition(capture, spec, materializedGraph, planOptions),
   };

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -16,7 +16,6 @@ import { getCompositionAnalysisMetadata } from '../composition/analysis-metadata
 import { createCompositionContext, runWithCompositionContext } from '../composition/context.js';
 import { TypeKroError } from '../errors.js';
 import { getComponentLogger } from '../logging/index.js';
-import { getMetadataField, getResourceId } from '../metadata/index.js';
 import { createSchemaProxy } from '../references/index.js';
 import type {
   KroSimpleSchemaWithMetadata,
@@ -24,22 +23,15 @@ import type {
   TernaryConditional,
 } from '../types/serialization.js';
 import type { KroCompatibleType, KroSimpleSchema, KubernetesResource } from '../types.js';
-import { separateStatusFields } from '../validation/cel-validator.js';
+import {
+  createStatusResourceIdentityContext,
+  getNestedCompositionIds,
+  separateStatusFields,
+} from '../validation/cel-validator.js';
 import { celLiteralForValueTree, serializeStatusMappingsToCel } from './cel-references.js';
 
 const logger = getComponentLogger('schema-defaults');
 const SCHEMA_MARKER_PATTERN_SOURCE = KUBERNETES_REF_SCHEMA_MARKER_SOURCE;
-
-function deriveResourceIdAliases(resourceId: string): string[] {
-  const aliases: string[] = [];
-  for (const match of resourceId.matchAll(/\d+/g)) {
-    const suffix = resourceId.slice((match.index ?? 0) + match[0].length);
-    if (suffix && /^[A-Z]/.test(suffix)) {
-      aliases.push(suffix.charAt(0).toLowerCase() + suffix.slice(1));
-    }
-  }
-  return aliases;
-}
 
 // ---------------------------------------------------------------------------
 // Arktype JSON AST → Kro type helpers (private)
@@ -940,12 +932,7 @@ function probeAmbiguousStructuredFallbacks(
     // SimpleSchema cannot represent explicit null.
     const optionalPath = matchingAncestorPath(field, optionalFieldPaths);
     if (optionalPath === undefined) continue;
-    const probedResource = runProbe(
-      compositionFn,
-      specJson,
-      new Set([optionalPath]),
-      resourceId
-    );
+    const probedResource = runProbe(compositionFn, specJson, new Set([optionalPath]), resourceId);
 
     for (const candidate of candidates) {
       const probeRead = readProbeValueAtPath(proxyResource, probedResource, candidate);
@@ -1653,8 +1640,8 @@ export function arktypeToKroSchema(
   nestedStatusCel?: Record<string, string>,
   schemaFieldValidations?: Readonly<Record<string, string>>
 ): KroSimpleSchemaWithMetadata {
-  const nullableField = collectSchemaFieldPaths(schemaDefinition.spec.json).nullable
-    .values()
+  const nullableField = collectSchemaFieldPaths(schemaDefinition.spec.json)
+    .nullable.values()
     .next().value;
   if (nullableField !== undefined) {
     throw new TypeKroError(
@@ -1820,39 +1807,31 @@ export function arktypeToKroSchema(
   // Static = references only schema.spec.* or literal values → TypeKro runtime hydration
   // Classification is transitive through nestedStatusCel: a nested composition
   // reference whose inner analyzed value is schema-only/literal is treated as static.
-  const resourceIds = resources ? new Set<string>() : undefined;
-  const resourceAliases = resources ? new Map<string, string>() : undefined;
+  const resourceIdentityContext = resources
+    ? createStatusResourceIdentityContext(resources)
+    : undefined;
+  const resourceIds = resourceIdentityContext?.resourceIds;
+  const resourceAliases = resourceIdentityContext?.resourceAliases;
+  const nestedCompositionIds = statusMappings
+    ? getNestedCompositionIds(statusMappings)
+    : new Set<string>();
 
-  if (resources && resourceIds && resourceAliases) {
-    for (const [resourceKey, resource] of Object.entries(resources)) {
-      const resourceId = getResourceId(resource) ?? resourceKey;
-      resourceIds.add(resourceKey);
-      resourceIds.add(resourceId);
-      resourceAliases.set(resourceKey, resourceId);
-      resourceAliases.set(resourceId, resourceId);
-      for (const alias of new Set([
-        ...deriveResourceIdAliases(resourceKey),
-        ...deriveResourceIdAliases(resourceId),
-      ])) {
-        if (!resourceAliases.has(alias)) {
-          resourceAliases.set(alias, resourceId);
-        }
-      }
-
-      const aliases = getMetadataField(resource, 'resourceAliases') as string[] | undefined;
-      if (aliases) {
-        for (const alias of aliases) {
-          resourceAliases.set(alias, resourceId);
-        }
-      }
-    }
-  }
-
-  const { dynamicFields } = separateStatusFields(userStatusMappings, nestedStatusCel, resourceIds);
+  const { dynamicFields } = separateStatusFields(
+    userStatusMappings,
+    nestedStatusCel,
+    resourceIds,
+    nestedCompositionIds
+  );
 
   const statusCelExpressions =
     Object.keys(dynamicFields).length > 0
-      ? serializeStatusMappingsToCel(dynamicFields, nestedStatusCel, resourceIds, resourceAliases)
+      ? serializeStatusMappingsToCel(
+          dynamicFields,
+          nestedStatusCel,
+          resourceIds ? new Set(resourceIds) : undefined,
+          resourceAliases,
+          nestedCompositionIds
+        )
       : {};
 
   // Extract just the version part for the schema (Kro expects v1alpha1, not kro.run/v1alpha1)

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -16,7 +16,7 @@ import { getCompositionAnalysisMetadata } from '../composition/analysis-metadata
 import { createCompositionContext, runWithCompositionContext } from '../composition/context.js';
 import { TypeKroError } from '../errors.js';
 import { getComponentLogger } from '../logging/index.js';
-import { getMetadataField } from '../metadata/index.js';
+import { getMetadataField, getResourceId } from '../metadata/index.js';
 import { createSchemaProxy } from '../references/index.js';
 import type {
   KroSimpleSchemaWithMetadata,
@@ -1820,13 +1820,20 @@ export function arktypeToKroSchema(
   // Static = references only schema.spec.* or literal values → TypeKro runtime hydration
   // Classification is transitive through nestedStatusCel: a nested composition
   // reference whose inner analyzed value is schema-only/literal is treated as static.
-  const resourceIds = resources ? new Set(Object.keys(resources)) : undefined;
+  const resourceIds = resources ? new Set<string>() : undefined;
   const resourceAliases = resources ? new Map<string, string>() : undefined;
 
-  if (resources && resourceAliases) {
-    for (const [resourceId, resource] of Object.entries(resources)) {
+  if (resources && resourceIds && resourceAliases) {
+    for (const [resourceKey, resource] of Object.entries(resources)) {
+      const resourceId = getResourceId(resource) ?? resourceKey;
+      resourceIds.add(resourceKey);
+      resourceIds.add(resourceId);
+      resourceAliases.set(resourceKey, resourceId);
       resourceAliases.set(resourceId, resourceId);
-      for (const alias of deriveResourceIdAliases(resourceId)) {
+      for (const alias of new Set([
+        ...deriveResourceIdAliases(resourceKey),
+        ...deriveResourceIdAliases(resourceId),
+      ])) {
         if (!resourceAliases.has(alias)) {
           resourceAliases.set(alias, resourceId);
         }

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -1831,6 +1831,18 @@ export function arktypeToKroSchema(
         { errors: sensitiveErrors }
       );
     }
+    const ambiguousErrors = statusValidation.errors.filter(
+      (error) => error.code === 'ambiguous-resource'
+    );
+    if (ambiguousErrors.length > 0) {
+      throw new TypeKroError(
+        `KRO status cannot resolve ambiguous resource identities: ${ambiguousErrors
+          .map((error) => `${error.field}: ${error.error}`)
+          .join('; ')}`,
+        'KRO_AMBIGUOUS_STATUS_RESOURCE',
+        { errors: ambiguousErrors }
+      );
+    }
   }
 
   const { dynamicFields } = separateStatusFields(

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -27,6 +27,7 @@ import {
   createStatusResourceIdentityContext,
   getNestedCompositionIds,
   separateStatusFields,
+  validateStatusCelExpressions,
 } from '../validation/cel-validator.js';
 import { celLiteralForValueTree, serializeStatusMappingsToCel } from './cel-references.js';
 
@@ -1815,6 +1816,22 @@ export function arktypeToKroSchema(
   const nestedCompositionIds = statusMappings
     ? getNestedCompositionIds(statusMappings)
     : new Set<string>();
+
+  if (resources && Object.keys(userStatusMappings).length > 0) {
+    const statusValidation = validateStatusCelExpressions(userStatusMappings, resources);
+    const sensitiveErrors = statusValidation.errors.filter(
+      (error) => error.code === 'sensitive-status'
+    );
+    if (sensitiveErrors.length > 0) {
+      throw new TypeKroError(
+        `KRO status cannot expose sensitive resource data: ${sensitiveErrors
+          .map((error) => `${error.field}: ${error.error}`)
+          .join('; ')}`,
+        'KRO_SENSITIVE_STATUS_PROJECTION',
+        { errors: sensitiveErrors }
+      );
+    }
+  }
 
   const { dynamicFields } = separateStatusFields(
     userStatusMappings,

--- a/src/core/validation/cel-validator.ts
+++ b/src/core/validation/cel-validator.ts
@@ -9,8 +9,68 @@
 
 import { isCelExpression, isKubernetesRef } from '../../utils/type-guards.js';
 import { remapVariableNames } from '../composition/nested-status-cel.js';
+import { getMetadataField, getResourceId } from '../metadata/index.js';
 import { isStaticExpression, lookupNestedExpression } from '../serialization/cel-references.js';
 import type { KubernetesResource } from '../types.js';
+
+export interface StatusResourceIdentityContext {
+  readonly resourceIds: ReadonlySet<string>;
+  readonly resourceAliases: ReadonlyMap<string, string>;
+}
+
+export function getNestedCompositionIds(
+  statusMappings: Readonly<Record<string, unknown>>
+): ReadonlySet<string> {
+  const descriptor = Object.getOwnPropertyDescriptor(statusMappings, '__nestedCompositionFns');
+  return descriptor?.value instanceof Map
+    ? new Set(
+        [...descriptor.value.keys()].filter((value): value is string => typeof value === 'string')
+      )
+    : new Set();
+}
+
+function deriveResourceIdAliases(resourceId: string): string[] {
+  const aliases: string[] = [];
+  for (const match of resourceId.matchAll(/\d+/g)) {
+    const suffix = resourceId.slice((match.index ?? 0) + match[0].length);
+    if (suffix && /^[A-Z]/.test(suffix)) {
+      aliases.push(suffix.charAt(0).toLowerCase() + suffix.slice(1));
+    }
+  }
+  return aliases;
+}
+
+/**
+ * Build the canonical resource identity set used by status planning,
+ * serialization, and client-side hydration.
+ */
+export function createStatusResourceIdentityContext(
+  resources: Readonly<Record<string, KubernetesResource>>
+): StatusResourceIdentityContext {
+  const resourceIds = new Set<string>();
+  const resourceAliases = new Map<string, string>();
+
+  for (const [resourceKey, resource] of Object.entries(resources)) {
+    const resourceId = getResourceId(resource) ?? resourceKey;
+    resourceIds.add(resourceKey);
+    resourceIds.add(resourceId);
+    resourceAliases.set(resourceKey, resourceId);
+    resourceAliases.set(resourceId, resourceId);
+
+    for (const alias of new Set([
+      ...deriveResourceIdAliases(resourceKey),
+      ...deriveResourceIdAliases(resourceId),
+      ...(getMetadataField(resource, 'resourceAliases') ?? []),
+    ])) {
+      resourceIds.add(alias);
+      if (!resourceAliases.has(alias)) {
+        resourceAliases.set(alias, resourceId);
+      }
+    }
+  }
+
+  return { resourceIds, resourceAliases };
+}
 
 export interface CelValidationError {
   field: string;
@@ -93,7 +153,8 @@ export function validateResourceId(id: string): { isValid: boolean; error?: stri
 function requiresKroResolution(
   value: unknown,
   nestedStatusCel?: Record<string, string>,
-  resourceIds?: ReadonlySet<string>
+  resourceIds?: ReadonlySet<string>,
+  nestedCompositionIds: ReadonlySet<string> = new Set()
 ): boolean {
   const localResourceIds = resourceIds ? Array.from(resourceIds) : [];
   const preserveVariables = new Set<string>();
@@ -125,7 +186,7 @@ function requiresKroResolution(
         ? lookupNestedExpression(value.resourceId, fieldName, nestedStatusCel, false)
         : lookupNestedExpression(value.resourceId, fieldName, nestedStatusCel);
       if (innerExpr !== undefined) {
-        return !isStaticExpression(innerExpr, nestedStatusCel, resourceIds);
+        return !isStaticExpression(innerExpr, nestedStatusCel, resourceIds, true);
       }
       // Nested ref with no entry in the table is conservatively dynamic. Do not
       // log during classification: later analysis may still recover an alias.
@@ -155,7 +216,17 @@ function requiresKroResolution(
       localResourceIds.length > 0
         ? remapVariableNames(value.expression, localResourceIds, preserveVariables)
         : value.expression;
-    return !isStaticExpression(normalizedExpression, nestedStatusCel, resourceIds);
+    const referencesNestedComposition = [...nestedCompositionIds].some((id) =>
+      new RegExp(`(^|[^\\w$])${id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\.`).test(
+        normalizedExpression
+      )
+    );
+    return !isStaticExpression(
+      normalizedExpression,
+      nestedStatusCel,
+      resourceIds,
+      referencesNestedComposition
+    );
   }
 
   // Strings potentially containing __KUBERNETES_REF__ markers from
@@ -168,16 +239,30 @@ function requiresKroResolution(
       localResourceIds.length > 0
         ? remapVariableNames(value, localResourceIds, preserveVariables)
         : value;
-    return !isStaticExpression(normalizedValue, nestedStatusCel, resourceIds);
+    const referencesNestedComposition = [...nestedCompositionIds].some(
+      (id) =>
+        normalizedValue.includes(`__KUBERNETES_REF_${id}_`) ||
+        new RegExp(`(^|[^\\w$])${id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\.`).test(
+          normalizedValue
+        )
+    );
+    return !isStaticExpression(
+      normalizedValue,
+      nestedStatusCel,
+      resourceIds,
+      referencesNestedComposition
+    );
   }
 
   if (Array.isArray(value)) {
-    return value.some((v) => requiresKroResolution(v, nestedStatusCel, resourceIds));
+    return value.some((v) =>
+      requiresKroResolution(v, nestedStatusCel, resourceIds, nestedCompositionIds)
+    );
   }
 
   if (typeof value === 'object' && value !== null) {
     return Object.values(value as Record<string, unknown>).some((v) =>
-      requiresKroResolution(v, nestedStatusCel, resourceIds)
+      requiresKroResolution(v, nestedStatusCel, resourceIds, nestedCompositionIds)
     );
   }
 
@@ -193,7 +278,8 @@ function requiresKroResolution(
 function separateNestedObject(
   obj: Record<string, unknown>,
   nestedStatusCel?: Record<string, string>,
-  resourceIds?: ReadonlySet<string>
+  resourceIds?: ReadonlySet<string>,
+  nestedCompositionIds: ReadonlySet<string> = new Set()
 ): {
   staticPart: Record<string, unknown>;
   dynamicPart: Record<string, unknown>;
@@ -214,7 +300,8 @@ function separateNestedObject(
       const nested = separateNestedObject(
         value as Record<string, unknown>,
         nestedStatusCel,
-        resourceIds
+        resourceIds,
+        nestedCompositionIds
       );
 
       if (nested.hasStatic) {
@@ -223,7 +310,7 @@ function separateNestedObject(
       if (nested.hasDynamic) {
         dynamicPart[key] = nested.dynamicPart;
       }
-    } else if (requiresKroResolution(value, nestedStatusCel, resourceIds)) {
+    } else if (requiresKroResolution(value, nestedStatusCel, resourceIds, nestedCompositionIds)) {
       dynamicPart[key] = value;
     } else {
       staticPart[key] = value;
@@ -257,7 +344,8 @@ function separateNestedObject(
 export function separateStatusFields(
   statusMappings: Record<string, unknown>,
   nestedStatusCel?: Record<string, string>,
-  resourceIds?: ReadonlySet<string>
+  resourceIds?: ReadonlySet<string>,
+  nestedCompositionIds: ReadonlySet<string> = getNestedCompositionIds(statusMappings)
 ): {
   staticFields: Record<string, unknown>;
   dynamicFields: Record<string, unknown>;
@@ -295,7 +383,8 @@ export function separateStatusFields(
       const { staticPart, dynamicPart, hasStatic, hasDynamic } = separateNestedObject(
         fieldValue as Record<string, unknown>,
         nestedStatusCel,
-        resourceIds
+        resourceIds,
+        nestedCompositionIds
       );
 
       if (hasStatic) {
@@ -304,7 +393,9 @@ export function separateStatusFields(
       if (hasDynamic) {
         dynamicFields[fieldName] = dynamicPart;
       }
-    } else if (requiresKroResolution(fieldValue, nestedStatusCel, resourceIds)) {
+    } else if (
+      requiresKroResolution(fieldValue, nestedStatusCel, resourceIds, nestedCompositionIds)
+    ) {
       dynamicFields[fieldName] = fieldValue;
     } else {
       staticFields[fieldName] = fieldValue;

--- a/src/core/validation/cel-validator.ts
+++ b/src/core/validation/cel-validator.ts
@@ -8,7 +8,11 @@
  */
 
 import { isCelExpression, isKubernetesRef } from '../../utils/type-guards.js';
-import { celRootReferences } from '../../utils/cel-resource-identifiers.js';
+import {
+  celRootReferences,
+  kubernetesMarkerReferences,
+  type CelRootReference,
+} from '../../utils/cel-resource-identifiers.js';
 import { remapVariableNames } from '../composition/nested-status-cel.js';
 import { getMetadataField, getResourceId } from '../metadata/index.js';
 import { isStaticExpression, lookupNestedExpression } from '../serialization/cel-references.js';
@@ -17,6 +21,7 @@ import type { KubernetesResource } from '../types.js';
 export interface StatusResourceIdentityContext {
   readonly resourceIds: ReadonlySet<string>;
   readonly resourceAliases: ReadonlyMap<string, string>;
+  readonly ambiguousResourceAliases: ReadonlyMap<string, readonly string[]>;
 }
 
 export function getNestedCompositionIds(
@@ -50,27 +55,53 @@ export function createStatusResourceIdentityContext(
 ): StatusResourceIdentityContext {
   const resourceIds = new Set<string>();
   const resourceAliases = new Map<string, string>();
+  const identityOwners = new Map<string, { canonicalId: string; resourceKey: string }>();
+  const ambiguousResourceAliases = new Map<string, Set<string>>();
+
+  const registerIdentity = (
+    identity: string,
+    canonicalId: string,
+    resourceKey: string
+  ): void => {
+    const ambiguousOwners = ambiguousResourceAliases.get(identity);
+    if (ambiguousOwners) {
+      ambiguousOwners.add(canonicalId);
+      resourceIds.add(identity);
+      return;
+    }
+    const existing = identityOwners.get(identity);
+    if (existing && existing.canonicalId !== canonicalId) {
+      ambiguousResourceAliases.set(identity, new Set([existing.canonicalId, canonicalId]));
+      resourceAliases.delete(identity);
+      resourceIds.add(identity);
+      return;
+    }
+    identityOwners.set(identity, { canonicalId, resourceKey });
+    resourceIds.add(identity);
+    resourceAliases.set(identity, canonicalId);
+  };
 
   for (const [resourceKey, resource] of Object.entries(resources)) {
     const resourceId = getResourceId(resource) ?? resourceKey;
-    resourceIds.add(resourceKey);
-    resourceIds.add(resourceId);
-    resourceAliases.set(resourceKey, resourceId);
-    resourceAliases.set(resourceId, resourceId);
+    registerIdentity(resourceKey, resourceId, resourceKey);
+    registerIdentity(resourceId, resourceId, resourceKey);
 
     for (const alias of new Set([
       ...deriveResourceIdAliases(resourceKey),
       ...deriveResourceIdAliases(resourceId),
       ...(getMetadataField(resource, 'resourceAliases') ?? []),
     ])) {
-      resourceIds.add(alias);
-      if (!resourceAliases.has(alias)) {
-        resourceAliases.set(alias, resourceId);
-      }
+      registerIdentity(alias, resourceId, resourceKey);
     }
   }
 
-  return { resourceIds, resourceAliases };
+  return {
+    resourceIds,
+    resourceAliases,
+    ambiguousResourceAliases: new Map(
+      [...ambiguousResourceAliases].map(([identity, owners]) => [identity, [...owners]])
+    ),
+  };
 }
 
 export interface CelValidationError {
@@ -79,7 +110,7 @@ export interface CelValidationError {
   error: string;
   suggestion?: string;
   /** Machine-readable finding category (used by strict CEL diagnostics). */
-  code?: 'unknown-resource' | 'sensitive-status';
+  code?: 'unknown-resource' | 'ambiguous-resource' | 'sensitive-status';
   /** The unresolved resource id, when code is 'unknown-resource'. */
   referencedResource?: string;
 }
@@ -447,8 +478,60 @@ export function validateStatusCelExpressions(
     return (
       resource?.kind === 'Secret' &&
       getMetadataField(resource, 'secretMaterial') !== 'public-placeholder' &&
-      (topLevelField === 'data' || topLevelField === 'stringData')
+      (fieldPath === '' || topLevelField === 'data' || topLevelField === 'stringData')
     );
+  }
+
+  function expressionReferences(
+    expression: string
+  ): readonly Pick<CelRootReference, 'root' | 'segments'>[] {
+    return [...kubernetesMarkerReferences(expression), ...celRootReferences(expression)];
+  }
+
+  function findSensitiveReference(expression: string): string | undefined {
+    const sensitiveReference = expressionReferences(expression).find((reference) =>
+      isSensitiveSecretField(reference.root, reference.segments.join('.'))
+    );
+    return sensitiveReference
+      ? `${sensitiveReference.root}${
+          sensitiveReference.segments.length > 0
+            ? `.${sensitiveReference.segments.join('.')}`
+            : ''
+        }`
+      : undefined;
+  }
+
+  function findAmbiguousReference(value: unknown): string | undefined {
+    if (isKubernetesRef(value)) {
+      return identityContext.ambiguousResourceAliases.has(value.resourceId)
+        ? value.resourceId
+        : undefined;
+    }
+    if (isCelExpression(value)) {
+      return expressionReferences(value.expression).find((reference) =>
+        identityContext.ambiguousResourceAliases.has(reference.root)
+      )?.root;
+    }
+    if (
+      typeof value === 'string' &&
+      (value.includes('__KUBERNETES_REF_') || value.includes('${'))
+    ) {
+      return expressionReferences(value).find((reference) =>
+        identityContext.ambiguousResourceAliases.has(reference.root)
+      )?.root;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const ambiguousReference = findAmbiguousReference(item);
+        if (ambiguousReference) return ambiguousReference;
+      }
+    } else if (value && typeof value === 'object') {
+      for (const nestedValue of Object.values(value)) {
+        const ambiguousReference = findAmbiguousReference(nestedValue);
+        if (ambiguousReference) return ambiguousReference;
+      }
+    }
+    return undefined;
   }
 
   function validateSensitivity(fieldName: string, value: unknown): void {
@@ -458,12 +541,12 @@ export function validateStatusCelExpressions(
         sensitiveExpression = `${value.resourceId}.${value.fieldPath}`;
       }
     } else if (isCelExpression(value)) {
-      const sensitiveReference = celRootReferences(value.expression).find((reference) =>
-        isSensitiveSecretField(reference.root, reference.segments.join('.'))
-      );
-      if (sensitiveReference) {
-        sensitiveExpression = `${sensitiveReference.root}.${sensitiveReference.segments.join('.')}`;
-      }
+      sensitiveExpression = findSensitiveReference(value.expression);
+    } else if (
+      typeof value === 'string' &&
+      (value.includes('__KUBERNETES_REF_') || value.includes('${'))
+    ) {
+      sensitiveExpression = findSensitiveReference(value);
     } else if (value && typeof value === 'object') {
       for (const [key, nestedValue] of Object.entries(value)) {
         validateSensitivity(`${fieldName}.${key}`, nestedValue);
@@ -489,6 +572,23 @@ export function validateStatusCelExpressions(
         validateSensitivity(fieldName, fieldValue);
       }
     }
+  }
+
+  for (const [fieldName, fieldValue] of Object.entries(statusMappings)) {
+    if (fieldName.startsWith('__')) continue;
+    const ambiguousReference = findAmbiguousReference(fieldValue);
+    if (!ambiguousReference) continue;
+    const owners = identityContext.ambiguousResourceAliases.get(ambiguousReference) ?? [];
+    errors.push({
+      field: fieldName,
+      expression: ambiguousReference,
+      error:
+        `Status resource identity '${ambiguousReference}' is ambiguous between resources ` +
+        owners.map((owner) => `'${owner}'`).join(' and '),
+      suggestion: 'Reference an unambiguous canonical resource id',
+      code: 'ambiguous-resource',
+      referencedResource: ambiguousReference,
+    });
   }
 
   // Separate static and dynamic fields using the same graph identities as serialization.

--- a/src/core/validation/cel-validator.ts
+++ b/src/core/validation/cel-validator.ts
@@ -71,8 +71,7 @@ export function validateResourceId(id: string): { isValid: boolean; error?: stri
  *
  * A value requires KRO resolution iff, after transitively resolving any
  * nested-composition references through `nestedStatusCel`, it depends on
- * at least one real-resource reference (a `status.*` or generated
- * `metadata.*` field). Schema refs and literal values — at any depth,
+ * at least one real-resource reference. Schema refs and literal values — at any depth,
  * including the far side of nested composition references — are static
  * and hydrated by the TypeKro runtime at deploy time.
  *
@@ -81,6 +80,8 @@ export function validateResourceId(id: string): { isValid: boolean; error?: stri
  *   - spec.*               — may include controller/defaulted or externalRef fields
  *   - metadata.uid         — assigned by API server
  *   - metadata.creationTimestamp / resourceVersion / generation
+ *   - explicit CEL naming a known graph resource, including kind-specific
+ *     top-level fields such as ConfigMap data or Secret stringData
  *
  * Static (TypeKro resolves at deploy time):
  *   - __schema__ refs       — resolved against the CR spec
@@ -124,7 +125,7 @@ function requiresKroResolution(
         ? lookupNestedExpression(value.resourceId, fieldName, nestedStatusCel, false)
         : lookupNestedExpression(value.resourceId, fieldName, nestedStatusCel);
       if (innerExpr !== undefined) {
-        return !isStaticExpression(innerExpr, nestedStatusCel);
+        return !isStaticExpression(innerExpr, nestedStatusCel, resourceIds);
       }
       // Nested ref with no entry in the table is conservatively dynamic. Do not
       // log during classification: later analysis may still recover an alias.
@@ -154,7 +155,7 @@ function requiresKroResolution(
       localResourceIds.length > 0
         ? remapVariableNames(value.expression, localResourceIds, preserveVariables)
         : value.expression;
-    return !isStaticExpression(normalizedExpression, nestedStatusCel);
+    return !isStaticExpression(normalizedExpression, nestedStatusCel, resourceIds);
   }
 
   // Strings potentially containing __KUBERNETES_REF__ markers from
@@ -167,7 +168,7 @@ function requiresKroResolution(
       localResourceIds.length > 0
         ? remapVariableNames(value, localResourceIds, preserveVariables)
         : value;
-    return !isStaticExpression(normalizedValue, nestedStatusCel);
+    return !isStaticExpression(normalizedValue, nestedStatusCel, resourceIds);
   }
 
   if (Array.isArray(value)) {

--- a/src/core/validation/cel-validator.ts
+++ b/src/core/validation/cel-validator.ts
@@ -8,6 +8,7 @@
  */
 
 import { isCelExpression, isKubernetesRef } from '../../utils/type-guards.js';
+import { celRootReferences } from '../../utils/cel-resource-identifiers.js';
 import { remapVariableNames } from '../composition/nested-status-cel.js';
 import { getMetadataField, getResourceId } from '../metadata/index.js';
 import { isStaticExpression, lookupNestedExpression } from '../serialization/cel-references.js';
@@ -78,7 +79,7 @@ export interface CelValidationError {
   error: string;
   suggestion?: string;
   /** Machine-readable finding category (used by strict CEL diagnostics). */
-  code?: 'unknown-resource';
+  code?: 'unknown-resource' | 'sensitive-status';
   /** The unresolved resource id, when code is 'unknown-resource'. */
   referencedResource?: string;
 }
@@ -410,18 +411,17 @@ export function separateStatusFields(
  */
 export function validateStatusCelExpressions(
   statusMappings: Record<string, unknown>,
-  resources: Record<string, KubernetesResource>
+  resources: Record<string, KubernetesResource>,
+  options: { readonly enforceSensitiveStatus?: boolean } = {}
 ): CelValidationResult {
   const errors: CelValidationError[] = [];
   const warnings: CelValidationError[] = [];
-  // Build set of valid resource identifiers - includes both resource IDs and keys
-  // This supports both `resourceId.status.field` and `variableName.status.field` patterns
-  const resourceIds = new Set([
-    ...Object.keys(resources), // Variable names (from userKeyMap in imperative pattern)
-    ...Object.values(resources)
-      .map((r) => r.id)
-      .filter(Boolean), // Resource IDs
-  ]);
+  const identityContext = createStatusResourceIdentityContext(resources);
+  const resourceIds = new Set(identityContext.resourceIds);
+  const resourcesByCanonicalId = new Map<string, KubernetesResource>();
+  for (const [resourceKey, resource] of Object.entries(resources)) {
+    resourcesByCanonicalId.set(getResourceId(resource) ?? resourceKey, resource);
+  }
   const preserveVariables = new Set<string>();
   const nestedDescriptor = Object.getOwnPropertyDescriptor(statusMappings, '__nestedStatusCel');
   const nestedStatusCelForValidation =
@@ -438,8 +438,66 @@ export function validateStatusCelExpressions(
     }
   }
 
-  // Separate static and dynamic fields
-  const { staticFields, dynamicFields } = separateStatusFields(statusMappings);
+  const nestedCompositionIds = getNestedCompositionIds(statusMappings);
+
+  function isSensitiveSecretField(resourceId: string, fieldPath: string): boolean {
+    const canonicalId = identityContext.resourceAliases.get(resourceId) ?? resourceId;
+    const resource = resourcesByCanonicalId.get(canonicalId);
+    const topLevelField = fieldPath.split('.')[0];
+    return (
+      resource?.kind === 'Secret' &&
+      getMetadataField(resource, 'secretMaterial') !== 'public-placeholder' &&
+      (topLevelField === 'data' || topLevelField === 'stringData')
+    );
+  }
+
+  function validateSensitivity(fieldName: string, value: unknown): void {
+    let sensitiveExpression: string | undefined;
+    if (isKubernetesRef(value)) {
+      if (isSensitiveSecretField(value.resourceId, value.fieldPath)) {
+        sensitiveExpression = `${value.resourceId}.${value.fieldPath}`;
+      }
+    } else if (isCelExpression(value)) {
+      const sensitiveReference = celRootReferences(value.expression).find((reference) =>
+        isSensitiveSecretField(reference.root, reference.segments.join('.'))
+      );
+      if (sensitiveReference) {
+        sensitiveExpression = `${sensitiveReference.root}.${sensitiveReference.segments.join('.')}`;
+      }
+    } else if (value && typeof value === 'object') {
+      for (const [key, nestedValue] of Object.entries(value)) {
+        validateSensitivity(`${fieldName}.${key}`, nestedValue);
+      }
+    }
+    if (sensitiveExpression) {
+      const referencedResource = sensitiveExpression.split('.')[0];
+      errors.push({
+        field: fieldName,
+        expression: sensitiveExpression,
+        error: `Status field '${fieldName}' derives from sensitive Secret data and cannot be projected`,
+        suggestion:
+          'Project a non-sensitive readiness or identity field instead of Secret data/stringData',
+        code: 'sensitive-status',
+        ...(referencedResource ? { referencedResource } : {}),
+      });
+    }
+  }
+
+  if (options.enforceSensitiveStatus !== false) {
+    for (const [fieldName, fieldValue] of Object.entries(statusMappings)) {
+      if (!fieldName.startsWith('__')) {
+        validateSensitivity(fieldName, fieldValue);
+      }
+    }
+  }
+
+  // Separate static and dynamic fields using the same graph identities as serialization.
+  const { staticFields, dynamicFields } = separateStatusFields(
+    statusMappings,
+    nestedStatusCelForValidation,
+    resourceIds,
+    nestedCompositionIds
+  );
 
   /**
    * Scan a (remapped) expression for direct resource references (`id.status.` / `id.spec.` /
@@ -640,7 +698,12 @@ export function validateResourceGraphDefinition(
 ): CelValidationResult {
   const resourceIdValidation = validateResourceIds(resources);
   const statusValidation = statusMappings
-    ? validateStatusCelExpressions(statusMappings, resources)
+    ? validateStatusCelExpressions(statusMappings, resources, {
+        // Graph construction must remain available to semantic planning, which
+        // independently taints and diagnoses sensitive projections. The legacy
+        // KRO serializer enforces this boundary immediately before YAML emission.
+        enforceSensitiveStatus: false,
+      })
     : { isValid: true, errors: [], warnings: [] };
 
   return {

--- a/src/utils/cel-resource-identifiers.ts
+++ b/src/utils/cel-resource-identifiers.ts
@@ -1,7 +1,16 @@
 import { parse } from 'cel-js';
 
+import { KUBERNETES_REF_MARKER_SOURCE } from '../shared/brands.js';
+
 const CEL_LAMBDA_MACROS = new Set(['all', 'exists', 'exists_one', 'filter', 'map']);
 const KUBERNETES_REF_MARKER_PREFIX = /__KUBERNETES_REF_([A-Za-z_$][\w$]*)_/g;
+const MAX_CEL_REFERENCE_CACHE_ENTRIES = 2_048;
+const MAX_CANONICAL_EXPRESSION_CACHE_ENTRIES = 1_024;
+const celReferenceCache = new Map<string, readonly CelRootReference[]>();
+const canonicalExpressionCaches = new WeakMap<
+  ReadonlyMap<string, string>,
+  Map<string, string>
+>();
 
 interface CelToken {
   readonly image: string;
@@ -176,7 +185,7 @@ function collectRootReferences(
  * String literals never appear as identifier nodes, so callers can safely use these offsets for
  * source-preserving rewrites without corrupting literal data.
  */
-export function celRootReferences(expression: string): readonly CelRootReference[] {
+function analyzeCelRootReferences(expression: string): readonly CelRootReference[] {
   const parsed = parse(expression);
   if (!parsed.isSuccess) {
     const references: CelRootReference[] = [];
@@ -213,17 +222,43 @@ export function celRootReferences(expression: string): readonly CelRootReference
       }
     }
     for (const match of unquoted.matchAll(
-      /\.(?:all|exists|exists_one|filter|map)\s*\(\s*([A-Za-z_$][\w$]*)\s*,/g
+      /(?:^|\.|\b)(?:all|exists|exists_one|filter|map)\s*\(\s*([A-Za-z_$][\w$]*)\s*,/g
     )) {
       if (match[1]) lambdaNames.add(match[1]);
     }
-    for (const match of unquoted.matchAll(/\b([A-Za-z_$][\w$]*)\s*(?=\??\.)/g)) {
+    const celKeywords = new Set(['true', 'false', 'null', 'in']);
+    for (const match of unquoted.matchAll(/\b([A-Za-z_$][\w$]*)\b/g)) {
       const root = match[1];
       const startOffset = match.index;
-      if (root === undefined || startOffset === undefined || lambdaNames.has(root)) continue;
+      if (
+        root === undefined ||
+        startOffset === undefined ||
+        lambdaNames.has(root) ||
+        celKeywords.has(root)
+      ) {
+        continue;
+      }
+      const before = unquoted.slice(0, startOffset).trimEnd();
+      const after = unquoted.slice(startOffset + root.length);
+      if (
+        before.endsWith('.') ||
+        before.endsWith('?.') ||
+        /^\s*\(/.test(after) ||
+        /^\s*:/.test(after)
+      ) {
+        continue;
+      }
+      const segments: string[] = [];
+      let remaining = after;
+      while (true) {
+        const segment = /^\s*\??\.\s*([A-Za-z_$][\w$]*)/.exec(remaining);
+        if (!segment?.[1]) break;
+        segments.push(segment[1]);
+        remaining = remaining.slice(segment[0].length);
+      }
       references.push({
         root,
-        segments: [],
+        segments,
         startOffset,
         endOffset: startOffset + root.length - 1,
       });
@@ -232,6 +267,42 @@ export function celRootReferences(expression: string): readonly CelRootReference
   }
   const boundRanges = collectBoundRanges(parsed.cst);
   return collectRootReferences(parsed.cst, boundRanges);
+}
+
+/**
+ * Parse CEL and return root identifier references, memoized by source text.
+ *
+ * Nested-composition resolution revisits stable expressions many times. Caching at this shared
+ * analysis boundary ensures syntax-aware consumers pay the parser cost once without coupling the
+ * cache to any particular serializer recursion strategy.
+ */
+export function celRootReferences(expression: string): readonly CelRootReference[] {
+  const cached = celReferenceCache.get(expression);
+  if (cached) return cached;
+
+  const references = analyzeCelRootReferences(expression);
+  if (celReferenceCache.size >= MAX_CEL_REFERENCE_CACHE_ENTRIES) {
+    const oldest = celReferenceCache.keys().next().value;
+    if (oldest !== undefined) celReferenceCache.delete(oldest);
+  }
+  celReferenceCache.set(expression, references);
+  return references;
+}
+
+/**
+ * Extract resource references embedded in TypeKro's string-coercion marker format.
+ */
+export function kubernetesMarkerReferences(
+  value: string
+): readonly Pick<CelRootReference, 'root' | 'segments'>[] {
+  const references: Pick<CelRootReference, 'root' | 'segments'>[] = [];
+  for (const match of value.matchAll(new RegExp(KUBERNETES_REF_MARKER_SOURCE, 'g'))) {
+    const root = match[1];
+    const fieldPath = match[2];
+    if (!root || root === '__schema__' || !fieldPath) continue;
+    references.push({ root, segments: fieldPath.split('.') });
+  }
+  return references;
 }
 
 function rewriteMarkersOutsideStrings(
@@ -287,6 +358,14 @@ export function canonicalizeCelResourceAliases(
   aliases: ReadonlyMap<string, string>
 ): string {
   if (aliases.size === 0) return expression;
+  let expressionCache = canonicalExpressionCaches.get(aliases);
+  if (!expressionCache) {
+    expressionCache = new Map();
+    canonicalExpressionCaches.set(aliases, expressionCache);
+  }
+  const cached = expressionCache.get(expression);
+  if (cached !== undefined) return cached;
+
   const withCanonicalMarkers = rewriteMarkersOutsideStrings(expression, aliases);
   const references = celRootReferences(withCanonicalMarkers);
   const replacements = references
@@ -302,5 +381,10 @@ export function canonicalizeCelResourceAliases(
       replacement.canonicalId +
       result.slice(replacement.endOffset + 1);
   }
+  if (expressionCache.size >= MAX_CANONICAL_EXPRESSION_CACHE_ENTRIES) {
+    const oldest = expressionCache.keys().next().value;
+    if (oldest !== undefined) expressionCache.delete(oldest);
+  }
+  expressionCache.set(expression, result);
   return result;
 }

--- a/src/utils/cel-resource-identifiers.ts
+++ b/src/utils/cel-resource-identifiers.ts
@@ -1,0 +1,306 @@
+import { parse } from 'cel-js';
+
+const CEL_LAMBDA_MACROS = new Set(['all', 'exists', 'exists_one', 'filter', 'map']);
+const KUBERNETES_REF_MARKER_PREFIX = /__KUBERNETES_REF_([A-Za-z_$][\w$]*)_/g;
+
+interface CelToken {
+  readonly image: string;
+  readonly startOffset: number;
+  readonly endOffset: number;
+}
+
+interface BoundRange {
+  readonly name: string;
+  readonly startOffset: number;
+  readonly endOffset: number;
+}
+
+export interface CelRootReference {
+  readonly root: string;
+  readonly segments: readonly string[];
+  readonly startOffset: number;
+  readonly endOffset: number;
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : undefined;
+}
+
+function children(value: unknown): Record<string, unknown> | undefined {
+  return record(record(value)?.children);
+}
+
+function array(value: unknown): readonly unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function token(value: unknown): CelToken | undefined {
+  const candidate = record(value);
+  return candidate &&
+    typeof candidate.image === 'string' &&
+    typeof candidate.startOffset === 'number' &&
+    typeof candidate.endOffset === 'number'
+    ? {
+        image: candidate.image,
+        startOffset: candidate.startOffset,
+        endOffset: candidate.endOffset,
+      }
+    : undefined;
+}
+
+function directIdentifier(value: unknown): CelToken | undefined {
+  const identifierTokens = array(children(value)?.Identifier);
+  return token(identifierTokens[0]);
+}
+
+function firstIdentifier(value: unknown): CelToken | undefined {
+  const current = record(value);
+  if (!current) return undefined;
+  if (current.name === 'identifierExpression') {
+    return directIdentifier(current);
+  }
+  for (const child of Object.values(current)) {
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        const found = firstIdentifier(item);
+        if (found) return found;
+      }
+    } else {
+      const found = firstIdentifier(child);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+function nodeRange(value: unknown): { startOffset: number; endOffset: number } | undefined {
+  let startOffset = Number.POSITIVE_INFINITY;
+  let endOffset = Number.NEGATIVE_INFINITY;
+  const visit = (current: unknown): void => {
+    const currentToken = token(current);
+    if (currentToken) {
+      startOffset = Math.min(startOffset, currentToken.startOffset);
+      endOffset = Math.max(endOffset, currentToken.endOffset);
+      return;
+    }
+    const currentRecord = record(current);
+    if (!currentRecord) return;
+    for (const child of Object.values(currentRecord)) {
+      if (Array.isArray(child)) child.forEach(visit);
+      else visit(child);
+    }
+  };
+  visit(value);
+  return Number.isFinite(startOffset) && Number.isFinite(endOffset)
+    ? { startOffset, endOffset }
+    : undefined;
+}
+
+function collectBoundRanges(cst: unknown): BoundRange[] {
+  const ranges: BoundRange[] = [];
+  const visit = (value: unknown): void => {
+    const current = record(value);
+    if (!current) return;
+    if (current.name === 'identifierDotExpression' || current.name === 'macrosExpression') {
+      const currentChildren = children(current);
+      const macro = token(array(currentChildren?.Identifier)[0])?.image;
+      if (macro && CEL_LAMBDA_MACROS.has(macro)) {
+        const bindingExpression = array(currentChildren?.arg)[0];
+        const binding = firstIdentifier(bindingExpression);
+        if (binding) {
+          ranges.push({
+            name: binding.image,
+            startOffset: binding.startOffset,
+            endOffset: binding.endOffset,
+          });
+          for (const body of array(currentChildren?.args)) {
+            const range = nodeRange(body);
+            if (range) ranges.push({ name: binding.image, ...range });
+          }
+        }
+      }
+    }
+    for (const child of Object.values(current)) {
+      if (Array.isArray(child)) child.forEach(visit);
+      else visit(child);
+    }
+  };
+  visit(cst);
+  return ranges;
+}
+
+function collectRootReferences(
+  cst: unknown,
+  boundRanges: readonly BoundRange[]
+): CelRootReference[] {
+  const references: CelRootReference[] = [];
+  const visit = (value: unknown): void => {
+    const current = record(value);
+    if (!current) return;
+    if (current.name === 'identifierExpression') {
+      const currentChildren = children(current);
+      const root = token(array(currentChildren?.Identifier)[0]);
+      if (
+        root &&
+        !boundRanges.some(
+          (range) =>
+            range.name === root.image &&
+            root.startOffset >= range.startOffset &&
+            root.endOffset <= range.endOffset
+        )
+      ) {
+        const segments = array(currentChildren?.identifierDotExpression).flatMap((dot) => {
+          const identifier = token(array(children(dot)?.Identifier)[0]);
+          return identifier ? [identifier.image] : [];
+        });
+        references.push({
+          root: root.image,
+          segments,
+          startOffset: root.startOffset,
+          endOffset: root.endOffset,
+        });
+      }
+    }
+    for (const child of Object.values(current)) {
+      if (Array.isArray(child)) child.forEach(visit);
+      else visit(child);
+    }
+  };
+  visit(cst);
+  return references;
+}
+
+/**
+ * Parse CEL and return root identifier references while excluding macro-local variables.
+ *
+ * String literals never appear as identifier nodes, so callers can safely use these offsets for
+ * source-preserving rewrites without corrupting literal data.
+ */
+export function celRootReferences(expression: string): readonly CelRootReference[] {
+  const parsed = parse(expression);
+  if (!parsed.isSuccess) {
+    const references: CelRootReference[] = [];
+    for (const match of expression.matchAll(/\$\{([^{}]+)\}/g)) {
+      const inner = match[1];
+      const matchStart = match.index;
+      if (inner === undefined || matchStart === undefined) continue;
+      const innerOffset = matchStart + 2;
+      references.push(
+        ...celRootReferences(inner).map((reference) => ({
+          ...reference,
+          startOffset: reference.startOffset + innerOffset,
+          endOffset: reference.endOffset + innerOffset,
+        }))
+      );
+    }
+    if (references.length > 0) return references;
+
+    const lambdaNames = new Set<string>();
+    let unquoted = '';
+    let quote: '"' | "'" | null = null;
+    let escaped = false;
+    for (const char of expression) {
+      if (quote) {
+        unquoted += ' ';
+        if (escaped) escaped = false;
+        else if (char === '\\') escaped = true;
+        else if (char === quote) quote = null;
+      } else if (char === '"' || char === "'") {
+        quote = char;
+        unquoted += ' ';
+      } else {
+        unquoted += char;
+      }
+    }
+    for (const match of unquoted.matchAll(
+      /\.(?:all|exists|exists_one|filter|map)\s*\(\s*([A-Za-z_$][\w$]*)\s*,/g
+    )) {
+      if (match[1]) lambdaNames.add(match[1]);
+    }
+    for (const match of unquoted.matchAll(/\b([A-Za-z_$][\w$]*)\s*(?=\??\.)/g)) {
+      const root = match[1];
+      const startOffset = match.index;
+      if (root === undefined || startOffset === undefined || lambdaNames.has(root)) continue;
+      references.push({
+        root,
+        segments: [],
+        startOffset,
+        endOffset: startOffset + root.length - 1,
+      });
+    }
+    return references;
+  }
+  const boundRanges = collectBoundRanges(parsed.cst);
+  return collectRootReferences(parsed.cst, boundRanges);
+}
+
+function rewriteMarkersOutsideStrings(
+  expression: string,
+  aliases: ReadonlyMap<string, string>
+): string {
+  let result = '';
+  let chunkStart = 0;
+  let index = 0;
+  const rewriteChunk = (chunk: string): string =>
+    chunk.replace(KUBERNETES_REF_MARKER_PREFIX, (match, resourceId: string) => {
+      const canonicalId = aliases.get(resourceId);
+      return canonicalId ? `__KUBERNETES_REF_${canonicalId}_` : match;
+    });
+
+  while (index < expression.length) {
+    const quote = expression[index];
+    if (quote !== '"' && quote !== "'") {
+      index++;
+      continue;
+    }
+    result += rewriteChunk(expression.slice(chunkStart, index));
+    const quoteStart = index;
+    const triple = expression.slice(index, index + 3) === quote.repeat(3);
+    index += triple ? 3 : 1;
+    let escaped = false;
+    while (index < expression.length) {
+      if (triple && expression.slice(index, index + 3) === quote.repeat(3)) {
+        index += 3;
+        break;
+      }
+      const char = expression[index];
+      index++;
+      if (!triple && escaped) {
+        escaped = false;
+      } else if (!triple && char === '\\') {
+        escaped = true;
+      } else if (!triple && char === quote) {
+        break;
+      }
+    }
+    result += expression.slice(quoteStart, index);
+    chunkStart = index;
+  }
+  return result + rewriteChunk(expression.slice(chunkStart));
+}
+
+/**
+ * Canonicalize resource roots in executable CEL while preserving literals and lambda bindings.
+ */
+export function canonicalizeCelResourceAliases(
+  expression: string,
+  aliases: ReadonlyMap<string, string>
+): string {
+  if (aliases.size === 0) return expression;
+  const withCanonicalMarkers = rewriteMarkersOutsideStrings(expression, aliases);
+  const references = celRootReferences(withCanonicalMarkers);
+  const replacements = references
+    .flatMap((reference) => {
+      const canonicalId = aliases.get(reference.root);
+      return canonicalId && canonicalId !== reference.root ? [{ ...reference, canonicalId }] : [];
+    })
+    .sort((left, right) => right.startOffset - left.startOffset);
+  let result = withCanonicalMarkers;
+  for (const replacement of replacements) {
+    result =
+      result.slice(0, replacement.startOffset) +
+      replacement.canonicalId +
+      result.slice(replacement.endOffset + 1);
+  }
+  return result;
+}

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -1691,6 +1691,52 @@ describe('KroResourceFactory: factory creation smoke tests', () => {
 });
 
 describe('KroResourceFactory: mixed status hydration', () => {
+  it('hydrates arbitrary top-level resource projections from KRO status', async () => {
+    interface HydrationSpec {
+      name: string;
+    }
+
+    interface HydrationStatus {
+      version: string;
+    }
+
+    const contract = ConfigMap({
+      id: 'installationContract',
+      name: 'installation-contract',
+      data: { version: '1.2.3' },
+    });
+    const factory = createKroResourceFactory<HydrationSpec, HydrationStatus>(
+      'kro-top-level-resource-hydration',
+      { contractResource: contract },
+      {
+        apiVersion: 'v1alpha1',
+        kind: 'KroTopLevelResourceHydration',
+        spec: type({ name: 'string' }),
+        status: type({ version: 'string' }),
+      },
+      { version: makeCelExpr('contractResource.data.version') },
+      { namespace: 'default' }
+    );
+
+    const factoryRecord = factory as unknown as Record<string, unknown>;
+    factoryRecord.hydrateDynamicStatusFields = async (
+      _instanceName: string,
+      dynamicFields: Record<string, unknown>
+    ) => {
+      expect(dynamicFields).toHaveProperty('version');
+      return { version: '1.2.3' };
+    };
+
+    const createEnhancedProxyWithMixedHydration = getPrivateMethod(
+      factory as unknown as KroResourceFactory<TestSpec, TestStatus>,
+      'createEnhancedProxyWithMixedHydration'
+    ) as (spec: HydrationSpec, instanceName: string) => Promise<{ status: HydrationStatus }>;
+
+    const instance = await createEnhancedProxyWithMixedHydration({ name: 'demo' }, 'demo');
+
+    expect(instance.status).toEqual({ version: '1.2.3' });
+  });
+
   it('does not perform live status re-execution when hydrateStatus is false', async () => {
     interface HydrationSpec {
       name: string;

--- a/test/core/planning/composition.test.ts
+++ b/test/core/planning/composition.test.ts
@@ -23,6 +23,7 @@ import {
   SEMANTIC_PLAN_VERSION,
 } from '../../../src/experimental-planning.js';
 import {
+  Cel,
   createResource,
   externalRef,
   kubernetesComposition,
@@ -102,6 +103,54 @@ describe('captured composition planning prototype', () => {
     ]);
     expect(plan.durability).toEqual(
       expect.objectContaining({ cacheEligible: true, provenanceEligible: true })
+    );
+  });
+
+  it('plans explicit CEL over a canonical resource id and kind-specific top-level field', () => {
+    const composition = toResourceGraph(
+      {
+        name: 'planning-config-data-status',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'PlanningConfigDataStatus',
+        revision: '1',
+        spec: type({ name: 'string' }),
+        status: type({ version: 'string' }),
+      },
+      (schema) => ({
+        contractResource: simple.ConfigMap({
+          id: 'installationContract',
+          name: schema.spec.name,
+          data: { version: '1.2.3' },
+        }),
+      }),
+      () => ({
+        version: Cel.expr<string>('installationContract.data.version'),
+      })
+    );
+
+    const plan = composition.plan!({ name: 'demo' }, { strict: true });
+
+    expect(objectFields(plan.status.persistedSchema.root)).toEqual(['version']);
+    expect(plan.status.projections).toContainEqual(
+      expect.objectContaining({
+        path: 'version',
+        source: 'live-resource',
+        mode: 'native',
+      })
+    );
+    expect(plan.outputs.version).toEqual(
+      expect.objectContaining({
+        kind: 'expression',
+        expression: expect.objectContaining({
+          references: [
+            {
+              source: 'resource',
+              resourceId: 'installationContract',
+              fieldPath: 'data.version',
+            },
+          ],
+        }),
+      })
     );
   });
 

--- a/test/core/planning/composition.test.ts
+++ b/test/core/planning/composition.test.ts
@@ -154,6 +154,87 @@ describe('captured composition planning prototype', () => {
     );
   });
 
+  it('canonicalizes callback-key resource aliases in status projections', () => {
+    const composition = toResourceGraph(
+      {
+        name: 'planning-config-alias-status',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'PlanningConfigAliasStatus',
+        revision: '1',
+        spec: type({ name: 'string' }),
+        status: type({ version: 'string' }),
+      },
+      (schema) => ({
+        contractResource: simple.ConfigMap({
+          id: 'installationContract',
+          name: schema.spec.name,
+          data: { version: '1.2.3' },
+        }),
+      }),
+      () => ({
+        version: Cel.expr<string>('contractResource.data.version'),
+      })
+    );
+
+    const plan = composition.plan!({ name: 'demo' }, { strict: true });
+
+    expect(plan.outputs.version).toEqual(
+      expect.objectContaining({
+        kind: 'expression',
+        expression: expect.objectContaining({
+          references: [
+            {
+              source: 'resource',
+              resourceId: 'installationContract',
+              fieldPath: 'data.version',
+            },
+          ],
+        }),
+      })
+    );
+  });
+
+  it('rejects status projections derived through sensitive Secret resource fields', () => {
+    const composition = toResourceGraph(
+      {
+        name: 'planning-secret-resource-status',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'PlanningSecretResourceStatus',
+        revision: '1',
+        spec: type({ name: 'string', token: 'string' }),
+        status: type({ token: 'string' }),
+      },
+      (schema) => ({
+        credentials: createResource(
+          {
+            id: 'credentials',
+            apiVersion: 'v1',
+            kind: 'Secret',
+            metadata: { name: schema.spec.name },
+            data: { token: schema.spec.token },
+          },
+          { factoryName: 'secret' }
+        ),
+      }),
+      () => ({
+        token: Cel.expr<string>('credentials.data.token'),
+      })
+    );
+
+    const plan = composition.plan!({ name: 'demo', token: 'plaintext' });
+
+    expect(plan.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'PLAN_STATUS_SENSITIVE',
+        severity: 'error',
+        path: '$.status.token',
+      })
+    );
+    expect(() => composition.plan!({ name: 'demo', token: 'plaintext' }, { strict: true })).toThrow(
+      'Strict semantic planning rejected the composition'
+    );
+  });
+
   it('preserves analyzer-owned references and source locations in expression IR', () => {
     const composition = toResourceGraph(
       {

--- a/test/core/planning/composition.test.ts
+++ b/test/core/planning/composition.test.ts
@@ -142,6 +142,7 @@ describe('captured composition planning prototype', () => {
       expect.objectContaining({
         kind: 'expression',
         expression: expect.objectContaining({
+          expression: 'installationContract.data.version',
           references: [
             {
               source: 'resource',
@@ -182,6 +183,7 @@ describe('captured composition planning prototype', () => {
       expect.objectContaining({
         kind: 'expression',
         expression: expect.objectContaining({
+          expression: 'installationContract.data.version',
           references: [
             {
               source: 'resource',
@@ -192,6 +194,9 @@ describe('captured composition planning prototype', () => {
         }),
       })
     );
+    const artifact = compileKroArtifactPlan(plan);
+    expect(JSON.stringify(artifact)).toContain('installationContract.data.version');
+    expect(JSON.stringify(artifact)).not.toContain('contractResource.data.version');
   });
 
   it('rejects status projections derived through sensitive Secret resource fields', () => {

--- a/test/core/status-field-generation.test.ts
+++ b/test/core/status-field-generation.test.ts
@@ -231,6 +231,40 @@ describe('Status Field Generation', () => {
       expect(yaml).not.toContain('readyReplicas:');
       expect(yaml).not.toContain('url:');
     });
+
+    it('persists explicit status projections from ConfigMap data', () => {
+      const graph = toResourceGraph(
+        {
+          name: 'config-data-status-test',
+          apiVersion: 'v1alpha1',
+          kind: 'ConfigDataStatus',
+          spec: type({ name: 'string' }),
+          status: type({
+            version: 'string',
+            digest: 'string',
+          }),
+        },
+        (schema) => ({
+          contractResource: simple.ConfigMap({
+            name: schema.spec.name,
+            id: 'installationContract',
+            data: {
+              version: '1.2.3',
+              digest: 'sha256:abc',
+            },
+          }),
+        }),
+        () => ({
+          version: Cel.expr<string>('installationContract.data.version'),
+          digest: Cel.expr<string>('installationContract.data.digest'),
+        })
+      );
+
+      const yaml = graph.toYaml();
+
+      expect(yaml).toContain('version: ${installationContract.data.version}');
+      expect(yaml).toContain('digest: ${installationContract.data.digest}');
+    });
   });
 
   // Note: Backward compatibility test removed - automatic schema reference fallbacks

--- a/test/core/status-field-generation.test.ts
+++ b/test/core/status-field-generation.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
 
-import { Cel, createResource, simple, toResourceGraph } from '../../src/index.js';
+import { Cel, createResource, externalRef, simple, toResourceGraph } from '../../src/index.js';
 
 describe('Status Field Generation', () => {
   const WebAppSpecSchema = type({
@@ -348,6 +348,92 @@ describe('Status Field Generation', () => {
 
       expect(() => graph.toYaml()).toThrow(
         "Status field 'token' derives from sensitive Secret data and cannot be projected"
+      );
+    });
+
+    it('rejects Secret aggregates hidden behind CEL conversion functions', () => {
+      const graph = toResourceGraph(
+        {
+          name: 'secret-dyn-status-test',
+          apiVersion: 'v1alpha1',
+          kind: 'SecretDynStatus',
+          spec: type({ name: 'string' }),
+          status: type({ token: 'string' }),
+        },
+        (schema) => ({
+          credentials: externalRef({
+            id: 'credentials',
+            apiVersion: 'v1',
+            kind: 'Secret',
+            metadata: { name: schema.spec.name },
+          }),
+        }),
+        () => ({
+          token: Cel.expr<string>('dyn(credentials).data.token'),
+        })
+      );
+
+      expect(() => graph.toYaml()).toThrow(
+        "Status field 'token' derives from sensitive Secret data and cannot be projected"
+      );
+    });
+
+    it('rejects Secret data in helper-generated mixed templates', () => {
+      const secretTemplate = () =>
+        Cel.template('prefix-%s', Cel.expr<string>('string(credentials.data.token)'));
+      const graph = toResourceGraph(
+        {
+          name: 'secret-template-status-test',
+          apiVersion: 'v1alpha1',
+          kind: 'SecretTemplateStatus',
+          spec: type({ name: 'string' }),
+          status: type({ token: 'string' }),
+        },
+        (schema) => ({
+          credentials: externalRef({
+            id: 'credentials',
+            apiVersion: 'v1',
+            kind: 'Secret',
+            metadata: { name: schema.spec.name },
+          }),
+        }),
+        () => ({ token: secretTemplate() })
+      );
+
+      expect(() => graph.toYaml()).toThrow(
+        "Status field 'token' derives from sensitive Secret data and cannot be projected"
+      );
+    });
+
+    it('rejects callback aliases that collide with another canonical resource identity', () => {
+      expect(() =>
+        toResourceGraph(
+          {
+            name: 'conflicting-status-alias-test',
+            apiVersion: 'v1alpha1',
+            kind: 'ConflictingStatusAlias',
+            spec: type({ name: 'string' }),
+            status: type({ version: 'string' }),
+          },
+          (schema) => ({
+            contract: simple.ConfigMap({
+              id: 'firstConfig',
+              name: `${schema.spec.name}-first`,
+              data: { version: '1' },
+            }),
+            canonicalContract: simple.ConfigMap({
+              id: 'contract',
+              name: `${schema.spec.name}-canonical`,
+              data: { version: '2' },
+            }),
+          }),
+          () => ({
+            version: Cel.expr<string>('contract.data.version'),
+          })
+        )
+      ).toThrow(
+        "Status resource identity 'contract' is ambiguous between resources " +
+          "'firstConfig' and 'contract'"
       );
     });
   });

--- a/test/core/status-field-generation.test.ts
+++ b/test/core/status-field-generation.test.ts
@@ -265,6 +265,60 @@ describe('Status Field Generation', () => {
       expect(yaml).toContain('version: ${installationContract.data.version}');
       expect(yaml).toContain('digest: ${installationContract.data.digest}');
     });
+
+    it('canonicalizes callback keys for arbitrary top-level resource fields', () => {
+      const graph = toResourceGraph(
+        {
+          name: 'config-data-callback-alias-test',
+          apiVersion: 'v1alpha1',
+          kind: 'ConfigDataCallbackAlias',
+          spec: type({ name: 'string' }),
+          status: type({ version: 'string' }),
+        },
+        (schema) => ({
+          contractResource: simple.ConfigMap({
+            name: schema.spec.name,
+            id: 'installationContract',
+            data: { version: '1.2.3' },
+          }),
+        }),
+        () => ({
+          version: Cel.expr<string>('contractResource.data.version'),
+        })
+      );
+
+      const yaml = graph.toYaml();
+
+      expect(yaml).toContain('version: ${installationContract.data.version}');
+      expect(yaml).not.toContain('contractResource.data.version');
+    });
+
+    it('canonicalizes derived nested aliases for arbitrary top-level resource fields', () => {
+      const graph = toResourceGraph(
+        {
+          name: 'config-data-derived-alias-test',
+          apiVersion: 'v1alpha1',
+          kind: 'ConfigDataDerivedAlias',
+          spec: type({ name: 'string' }),
+          status: type({ version: 'string' }),
+        },
+        (schema) => ({
+          outer1InstallationContract: simple.ConfigMap({
+            name: schema.spec.name,
+            id: 'outer1InstallationContract',
+            data: { version: '1.2.3' },
+          }),
+        }),
+        () => ({
+          version: Cel.expr<string>('installationContract.data.version'),
+        })
+      );
+
+      const yaml = graph.toYaml();
+
+      expect(yaml).toContain('version: ${outer1InstallationContract.data.version}');
+      expect(yaml).not.toContain('version: ${installationContract.data.version}');
+    });
   });
 
   // Note: Backward compatibility test removed - automatic schema reference fallbacks

--- a/test/core/status-field-generation.test.ts
+++ b/test/core/status-field-generation.test.ts
@@ -5,7 +5,14 @@
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
 
-import { Cel, createResource, externalRef, simple, toResourceGraph } from '../../src/index.js';
+import {
+  Cel,
+  createResource,
+  externalRef,
+  kubernetesComposition,
+  simple,
+  toResourceGraph,
+} from '../../src/index.js';
 
 describe('Status Field Generation', () => {
   const WebAppSpecSchema = type({
@@ -431,6 +438,39 @@ describe('Status Field Generation', () => {
             version: Cel.expr<string>('contract.data.version'),
           })
         )
+      ).toThrow(
+        "Status resource identity 'contract' is ambiguous between resources " +
+          "'firstConfig' and 'contract'"
+      );
+    });
+
+    it('rejects ambiguous callback aliases through the imperative KRO factory', () => {
+      expect(() =>
+        kubernetesComposition(
+          {
+            name: 'imperative-conflicting-status-alias-test',
+            apiVersion: 'v1alpha1',
+            kind: 'ImperativeConflictingStatusAlias',
+            spec: type({ name: 'string' }),
+            status: type({ version: 'string' }),
+          },
+          (schema) => {
+            const contract = simple.ConfigMap({
+              id: 'firstConfig',
+              name: `${schema.name}-first`,
+              data: { value: '1' },
+            });
+            void contract;
+            simple.ConfigMap({
+              id: 'contract',
+              name: `${schema.name}-canonical`,
+              data: { value: '2' },
+            });
+            return {
+              version: Cel.expr<string>('contract.data.value'),
+            };
+          }
+        ).factory('kro').toYaml()
       ).toThrow(
         "Status resource identity 'contract' is ambiguous between resources " +
           "'firstConfig' and 'contract'"

--- a/test/core/status-field-generation.test.ts
+++ b/test/core/status-field-generation.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
 
-import { Cel, simple, toResourceGraph } from '../../src/index.js';
+import { Cel, createResource, simple, toResourceGraph } from '../../src/index.js';
 
 describe('Status Field Generation', () => {
   const WebAppSpecSchema = type({
@@ -318,6 +318,37 @@ describe('Status Field Generation', () => {
 
       expect(yaml).toContain('version: ${outer1InstallationContract.data.version}');
       expect(yaml).not.toContain('version: ${installationContract.data.version}');
+    });
+
+    it('rejects Secret data projections before legacy YAML emission', () => {
+      const graph = toResourceGraph(
+        {
+          name: 'secret-data-status-test',
+          apiVersion: 'v1alpha1',
+          kind: 'SecretDataStatus',
+          spec: type({ name: 'string', token: 'string' }),
+          status: type({ token: 'string' }),
+        },
+        (schema) => ({
+          credentials: createResource(
+            {
+              id: 'credentials',
+              apiVersion: 'v1',
+              kind: 'Secret',
+              metadata: { name: schema.spec.name },
+              data: { token: schema.spec.token },
+            },
+            { factoryName: 'secret' }
+          ),
+        }),
+        () => ({
+          token: Cel.expr<string>('credentials.data.token'),
+        })
+      );
+
+      expect(() => graph.toYaml()).toThrow(
+        "Status field 'token' derives from sensitive Secret data and cannot be projected"
+      );
     });
   });
 

--- a/test/integration/kro-top-level-status-projection.test.ts
+++ b/test/integration/kro-top-level-status-projection.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from 'bun:test';
+import type * as k8s from '@kubernetes/client-node';
+import { type } from 'arktype';
+import { kubernetesComposition } from '../../src/core/composition/imperative.js';
+import { Cel } from '../../src/core/references/cel.js';
+import type { KroResourceFactory } from '../../src/core/types/deployment.js';
+import { configMap } from '../../src/factories/kubernetes/config/config-map.js';
+import {
+  createTestNamespace,
+  deleteGeneratedCrdAndWait,
+  deleteTestFactoryInstanceAndRecoverNamespaces,
+  deleteTestNamespaceAndWait,
+  getIntegrationTestKubeConfig,
+  isClusterAvailable,
+  type TestNamespaceLease,
+} from './shared-kubeconfig.js';
+
+const clusterAvailable = await isClusterAvailable();
+const describeOrSkip = clusterAvailable ? describe : describe.skip;
+const runToken = Math.random().toString(36).slice(2, 8);
+const namespace = `typekro-status-projection-${runToken}`;
+const group = `status-projection-${runToken}.typekro.dev`;
+const kind = 'TopLevelStatusProjection';
+const instanceName = `hydration-proof-${runToken}`;
+
+setDefaultTimeout(300_000);
+
+describeOrSkip('KRO top-level resource status projection', () => {
+  let kubeConfig: k8s.KubeConfig;
+  let namespaceLease: TestNamespaceLease | undefined;
+  let factory: KroResourceFactory<{ name: string }, { version: string }> | undefined;
+  let deploymentAttempted = false;
+
+  beforeAll(async () => {
+    kubeConfig = getIntegrationTestKubeConfig();
+    namespaceLease = await createTestNamespace(namespace, kubeConfig);
+
+    const graph = kubernetesComposition(
+      {
+        name: `top-level-status-projection-${runToken}`,
+        apiVersion: `${group}/v1alpha1`,
+        kind,
+        revision: '1',
+        spec: type({ name: 'string' }),
+        status: type({ version: 'string' }),
+      },
+      () => {
+        configMap({
+          id: 'installationContract',
+          metadata: { name: 'installation-contract', namespace },
+          data: { version: '1.2.3' },
+        });
+        return { version: Cel.expr<string>('installationContract.data.version') };
+      }
+    );
+
+    factory = graph.factory('kro', {
+      namespace,
+      kubeConfig,
+      timeout: 180_000,
+      waitForReady: true,
+    });
+  });
+
+  afterAll(async () => {
+    if (!clusterAvailable) return;
+    const errors: unknown[] = [];
+
+    if (factory && deploymentAttempted) {
+      await deleteTestFactoryInstanceAndRecoverNamespaces(
+        factory,
+        instanceName,
+        [],
+        kubeConfig,
+        120_000
+      ).catch((error) => errors.push(error));
+    }
+
+    await deleteGeneratedCrdAndWait(
+      {
+        apiVersion: 'apiextensions.k8s.io/v1',
+        kind: 'CustomResourceDefinition',
+        metadata: { name: `toplevelstatusprojections.${group}` },
+      },
+      `${group}/v1alpha1`,
+      kind,
+      kubeConfig
+    ).catch((error) => errors.push(error));
+
+    if (namespaceLease) {
+      await deleteTestNamespaceAndWait(namespaceLease, kubeConfig).catch((error) =>
+        errors.push(error)
+      );
+    }
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'KRO top-level status projection cleanup failed');
+    }
+  });
+
+  it('hydrates a ConfigMap data projection into the deployed instance status', async () => {
+    if (!factory) throw new Error('KRO status projection factory was not initialized');
+    deploymentAttempted = true;
+
+    const deployed = await factory.deploy({ name: instanceName });
+
+    expect(deployed.status.version).toBe('1.2.3');
+    expect(deployed.status.version).not.toEqual({
+      expression: 'installationContract.data.version',
+    });
+  });
+});

--- a/test/unit/serialization-core-helpers.test.ts
+++ b/test/unit/serialization-core-helpers.test.ts
@@ -353,6 +353,59 @@ describe('detectAndPreserveCelExpressions', () => {
     });
   });
 
+  test('classifies explicit CEL over any known top-level resource field as dynamic', () => {
+    const version = makeCelExpr('installationContract.data.version');
+    const digest = makeCelExpr('installationContract.binaryData.digest');
+
+    const result = separateStatusFields(
+      { version, digest },
+      undefined,
+      new Set(['installationContract'])
+    );
+
+    expect(result.staticFields).toEqual({});
+    expect(result.dynamicFields).toEqual({ version, digest });
+  });
+
+  test('does not promote unknown identifiers merely because they use top-level fields', () => {
+    const localValue = makeCelExpr('applicationConfig.data.version');
+
+    const result = separateStatusFields(
+      { localValue },
+      undefined,
+      new Set(['installationContract'])
+    );
+
+    expect(result.staticFields).toEqual({ localValue });
+    expect(result.dynamicFields).toEqual({});
+  });
+
+  test('does not treat a known resource id inside a literal suffix as dynamic', () => {
+    const generatedName = makeCelExpr('string(schema.spec.name) + "-policy"');
+
+    const result = separateStatusFields(
+      { generatedName },
+      undefined,
+      new Set(['policy'])
+    );
+
+    expect(result.staticFields).toEqual({ generatedName });
+    expect(result.dynamicFields).toEqual({});
+  });
+
+  test('keeps a known resource passed as a bare aggregate argument dynamic', () => {
+    const count = makeCelExpr('size(workerDep)');
+
+    const result = separateStatusFields(
+      { count },
+      undefined,
+      new Set(['workerDep'])
+    );
+
+    expect(result.staticFields).toEqual({});
+    expect(result.dynamicFields).toEqual({ count });
+  });
+
   test('derives nested composition aliases without rewriting incidental numeric resource names', () => {
     expect(deriveNestedCompositionResourceAlias('oryIdentityStack1HydraService')).toBe('hydraService');
     expect(deriveNestedCompositionResourceAlias('s3Bucket')).toBeUndefined();

--- a/test/unit/serialization-core-helpers.test.ts
+++ b/test/unit/serialization-core-helpers.test.ts
@@ -429,6 +429,26 @@ describe('detectAndPreserveCelExpressions', () => {
     expect(result.phases).toEqual(['${deployment.status.phase}', '${"static"}']);
   });
 
+  test('canonicalizes resource aliases without rewriting CEL literals or lambda variables', () => {
+    const result = serializeStatusMappingsToCel(
+      {
+        value: makeCelExpr(
+          'c.data.version == "c.data.version" && exists(c, c.type == "Ready") && contractResource.data.enabled'
+        ),
+      },
+      undefined,
+      new Set(['canonicalConfig', 'installationContract']),
+      new Map([
+        ['c', 'canonicalConfig'],
+        ['contractResource', 'installationContract'],
+      ])
+    );
+
+    expect(result.value).toBe(
+      '${canonicalConfig.data.version == "c.data.version" && exists(c, c.type == "Ready") && installationContract.data.enabled}'
+    );
+  });
+
   test('detects multiple CEL expressions', () => {
     const cel1 = makeCelExpr('expr1');
     const cel2 = makeCelExpr('expr2');

--- a/test/unit/serialization-core-helpers.test.ts
+++ b/test/unit/serialization-core-helpers.test.ts
@@ -21,7 +21,11 @@ import '../../src/factories/kubernetes/config/secret.js';
 // HelmRelease is auto-registered when createResource() is called with kind: HelmRelease.
 // For test isolation, register it explicitly.
 import { registerFactory, getKindInfo } from '../../src/core/resources/factory-registry.js';
-registerFactory({ factoryName: 'HelmRelease', kind: 'HelmRelease', apiVersion: 'helm.toolkit.fluxcd.io/v2' });
+registerFactory({
+  factoryName: 'HelmRelease',
+  kind: 'HelmRelease',
+  apiVersion: 'helm.toolkit.fluxcd.io/v2',
+});
 import {
   analyzeStatusMappingTypes,
   analyzeValueType,
@@ -383,11 +387,7 @@ describe('detectAndPreserveCelExpressions', () => {
   test('does not treat a known resource id inside a literal suffix as dynamic', () => {
     const generatedName = makeCelExpr('string(schema.spec.name) + "-policy"');
 
-    const result = separateStatusFields(
-      { generatedName },
-      undefined,
-      new Set(['policy'])
-    );
+    const result = separateStatusFields({ generatedName }, undefined, new Set(['policy']));
 
     expect(result.staticFields).toEqual({ generatedName });
     expect(result.dynamicFields).toEqual({});
@@ -396,18 +396,28 @@ describe('detectAndPreserveCelExpressions', () => {
   test('keeps a known resource passed as a bare aggregate argument dynamic', () => {
     const count = makeCelExpr('size(workerDep)');
 
-    const result = separateStatusFields(
-      { count },
-      undefined,
-      new Set(['workerDep'])
-    );
+    const result = separateStatusFields({ count }, undefined, new Set(['workerDep']));
 
     expect(result.staticFields).toEqual({});
     expect(result.dynamicFields).toEqual({ count });
   });
 
+  test('does not substitute nested mappings over a known concrete resource identity', () => {
+    const ready = makeCelExpr('foo.status.ready');
+    const nestedStatusCel = {
+      '__nestedStatus:foo:ready': 'schema.spec.enabled',
+    };
+
+    const result = separateStatusFields({ ready }, nestedStatusCel, new Set(['foo']));
+
+    expect(result.staticFields).toEqual({});
+    expect(result.dynamicFields).toEqual({ ready });
+  });
+
   test('derives nested composition aliases without rewriting incidental numeric resource names', () => {
-    expect(deriveNestedCompositionResourceAlias('oryIdentityStack1HydraService')).toBe('hydraService');
+    expect(deriveNestedCompositionResourceAlias('oryIdentityStack1HydraService')).toBe(
+      'hydraService'
+    );
     expect(deriveNestedCompositionResourceAlias('s3Bucket')).toBeUndefined();
   });
 


### PR DESCRIPTION
## What changed

- Pass known graph resource identities through legacy KRO status classification and semantic planning.
- Treat both callback keys and canonical resource IDs/aliases as the same live resource identity.
- Recognize explicit CEL rooted at kind-specific top-level Kubernetes fields, such as `ConfigMap.data`, as live resource projections.
- Preserve these references in semantic `ExpressionIR`, persisted status schemas, compiled KRO bundles, and generated RGDs.
- Keep schema-only expressions static and avoid false positives when a resource ID appears only inside a literal suffix.
- Preserve bare resource arguments such as `size(workerDep)` for collection aggregates.

## Why

TypeKro 0.31 classified explicit status CEL such as `installationContract.data.version` as static because known resource IDs were dropped at two boundaries: legacy static/dynamic classification and semantic expression lowering. Reconstructed compositions also exposed a callback-key/canonical-ID mismatch. Static fields are hydrated only in the TypeKro client and omitted from KRO's RGD status schema, which silently removed valid authoritative status fields and blocked Applik8s' generated application composition migration.

## Impact

Explicit CEL over a resource that actually belongs to the graph can now project arbitrary Kubernetes top-level fields into KRO status through both legacy and compiled-artifact deployment paths. Unknown identifiers and schema/literal-only expressions remain static.

## Verification

- Full pre-commit unit suite: 5,138 passed; 13 skipped; 1 todo; 0 failed
- Focused status/classification/planning/imperative suite: 118 passed
- Applik8s deployment adapter regression passes against this exact commit, including compiled KRO artifact status for `observedVersion` and `artifactDigest`
- `bun run typecheck`
- `bun run lint`
- `bun run build:lib`
- `git diff --check`