### PR TITLE
feat: add Hatchet durable-workflow integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "ignore": "^7.0.5",
         "js-yaml": "4.1.0",
         "pino": "^9.8.0",
+        "re2js": "2.8.6",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.1.3",
@@ -1504,6 +1505,8 @@
     "ramda": ["ramda@0.30.1", "", {}, "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "re2js": ["re2js@2.8.6", "", {}, "sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -105,6 +105,7 @@ export default withMermaid(
               { text: 'SearXNG', link: '/api/searxng/' },
               { text: 'Valkey', link: '/api/valkey/' },
               { text: 'NATS / JetStream', link: '/api/nats/' },
+              { text: 'Hatchet', link: '/api/hatchet/' },
               { text: 'Web App Compositions', link: '/api/webapp/' },
             ],
           },

--- a/docs/api/flux/index.md
+++ b/docs/api/flux/index.md
@@ -73,8 +73,7 @@ const release = helmRelease({
     kind: 'Secret',
     name: 'my-app-values',
     valuesKey: 'databaseUrl',
-    targetPath: 'config.databaseUrl',
-    literal: true
+    targetPath: 'config.databaseUrl'
   }]
 });
 ```
@@ -83,9 +82,11 @@ const release = helmRelease({
 the source value into TypeKro state. Its `name`, `valuesKey`, and `targetPath`
 fields are graph-aware, so resources created or observed in the same
 composition can provide their names through ordinary TypeKro references.
-Set `literal: true` with `targetPath` when arbitrary Secret or ConfigMap bytes
-must not be interpreted as Helm `--set` syntax. Literal values require Flux
-2.9 or newer; the managed TypeKro runtime bootstrap uses a compatible release.
+Values projected through `targetPath` use Helm `--set` parsing semantics under
+the managed Flux 2.7.5 baseline. TypeKro intentionally withholds Flux 2.9's
+`literal` field until the managed runtime and Kubernetes compatibility baseline
+can move together. Use chart-native `envFrom` or mounted files for arbitrary
+Secret bytes; do not route credentials with punctuation through `targetPath`.
 
 ## helmRepository()
 

--- a/docs/api/flux/index.md
+++ b/docs/api/flux/index.md
@@ -68,9 +68,20 @@ const release = helmRelease({
   values: {
     replicaCount: 3,
     image: { tag: 'v1.0.0' }
-  }
+  },
+  valuesFrom: [{
+    kind: 'Secret',
+    name: 'my-app-values',
+    valuesKey: 'databaseUrl',
+    targetPath: 'config.databaseUrl'
+  }]
 });
 ```
+
+`valuesFrom` exposes Flux's Secret/ConfigMap value projection without copying
+the source value into TypeKro state. Its `name`, `valuesKey`, and `targetPath`
+fields are graph-aware, so resources created or observed in the same
+composition can provide their names through ordinary TypeKro references.
 
 ## helmRepository()
 

--- a/docs/api/flux/index.md
+++ b/docs/api/flux/index.md
@@ -73,7 +73,8 @@ const release = helmRelease({
     kind: 'Secret',
     name: 'my-app-values',
     valuesKey: 'databaseUrl',
-    targetPath: 'config.databaseUrl'
+    targetPath: 'config.databaseUrl',
+    literal: true
   }]
 });
 ```
@@ -82,6 +83,9 @@ const release = helmRelease({
 the source value into TypeKro state. Its `name`, `valuesKey`, and `targetPath`
 fields are graph-aware, so resources created or observed in the same
 composition can provide their names through ordinary TypeKro references.
+Set `literal: true` with `targetPath` when arbitrary Secret or ConfigMap bytes
+must not be interpreted as Helm `--set` syntax. Literal values require Flux
+2.9 or newer; the managed TypeKro runtime bootstrap uses a compatible release.
 
 ## helmRepository()
 

--- a/docs/api/hatchet/index.md
+++ b/docs/api/hatchet/index.md
@@ -133,11 +133,12 @@ Secrets explicitly only when permanently abandoning that database and its
 workers. An owned Namespace deletes them with the installation.
 
 The same rule applies independently to `repositoryNamespaceOwnership`.
-The default HelmRepository name includes the workload Namespace as well as the
-release name, so same-named installations that share a repository Namespace
-remain independently owned. Set `repositoryName` only when an explicit
-platform naming policy is required; explicit names must be unique within the
-repository Namespace.
+The default HelmRepository name includes a length-prefixed workload Namespace
+followed by the release name. The length prefix makes the tuple encoding
+injective: `team-a`/`worker` cannot collide with `team`/`a-worker`, even when
+both installations share a repository Namespace. Set `repositoryName` only
+when an explicit platform naming policy is required; explicit names must be
+unique within the repository Namespace.
 
 Delete through the factory so TypeKro preserves dependency order:
 

--- a/docs/api/hatchet/index.md
+++ b/docs/api/hatchet/index.md
@@ -1,0 +1,188 @@
+# Hatchet
+
+TypeKro installs the official Hatchet chart as a durable-workflow platform while
+keeping database and administrator credentials outside the application CR and
+ResourceGraphDefinition.
+
+```ts
+import { hatchetInstallation } from 'typekro/hatchet';
+
+const factory = hatchetInstallation.factory('kro', {
+  namespace: 'typekro-system',
+  waitForReady: true,
+  timeout: 20 * 60_000,
+});
+
+await factory.deploy({
+  name: 'hatchet',
+  namespace: 'workflow-system',
+  database: {
+    connectionSecret: {
+      name: 'hatchet-db-app',
+      key: 'uri',
+    },
+  },
+  adminCredentialsSecret: {
+    name: 'hatchet-admin',
+    emailKey: 'adminEmail',
+    passwordKey: 'adminPassword',
+  },
+});
+```
+
+## What the composition owns
+
+`hatchetInstallation` creates:
+
+- an optional target Namespace;
+- an optional repository Namespace when it differs from the target;
+- the official Hatchet HelmRepository and `hatchet-stack` HelmRelease;
+- a non-sensitive metadata ConfigMap used for the complete public status
+  contract.
+
+It observes, but does not own:
+
+- the PostgreSQL connection Secret;
+- the administrator credential Secret;
+- the PostgreSQL database and its backup/recovery infrastructure.
+
+The database provider remains responsible for PostgreSQL availability,
+high-availability policy, backups, point-in-time recovery, monitoring, capacity,
+and deletion. For CloudNativePG, install the operator and Cluster separately,
+then reference the Cluster-generated application Secret. Hatchet requires a
+PostgreSQL database configured with UTC timezone.
+
+## Required Secrets
+
+The database Secret contains a complete PostgreSQL URI:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hatchet-db-app
+  namespace: workflow-system
+stringData:
+  uri: postgres://app:password@hatchet-db-rw:5432/hatchet?sslmode=require
+```
+
+The administrator Secret contains the bootstrap account:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hatchet-admin
+  namespace: workflow-system
+stringData:
+  adminEmail: operator@example.com
+  adminPassword: replace-me
+```
+
+Flux reads these keys through `HelmRelease.spec.valuesFrom`. Secret values never
+appear in the generated RGD or HatchetInstallation instance.
+
+The official chart creates `<name>-client-config` with
+`HATCHET_CLIENT_TOKEN` when `workerTokenJob` is enabled. The generated Secret
+name is reported as `status.workerTokenSecret`.
+
+The chart also creates `<name>-config` with Hatchet's encryption and signing
+keysets. Its name is reported as `status.configurationSecret`.
+
+## Operational defaults
+
+The composition pins:
+
+| Component | Default |
+| --- | --- |
+| Chart | `hatchet-stack` |
+| Chart version | `0.13.3` |
+| Hatchet server | `v0.94.10` |
+| Message queue | PostgreSQL |
+| Bundled PostgreSQL | disabled |
+| Bundled RabbitMQ | disabled |
+| Flux drift detection | enabled |
+| Install retries | 3 |
+| Upgrade rollback | disabled |
+
+Hatchet upgrades can commit database migrations. TypeKro therefore retries a
+failed desired revision but does not automatically roll back to an older chart.
+Review Hatchet's migration notes and verify database recovery before upgrading.
+
+User `values` are merged first. TypeKro then reapplies the external-state,
+message-queue, version, endpoint, replica, and credential-safety values so
+custom chart values cannot silently re-enable bundled state or replace the
+declared authority.
+
+## Namespace lifecycle
+
+The target Namespace is owned by default. Set `namespaceOwnership: 'external'`
+when another platform composition owns it or when database retention must
+survive Hatchet installation deletion.
+
+When the Namespace is external, the official chart leaves
+`<name>-config` and `<name>-client-config` after uninstall. The configuration
+Secret is recovery state for the retained Hatchet database, not an ordinary
+disposable chart artifact. Back up and retain it with the database. Delete both
+Secrets explicitly only when permanently abandoning that database and its
+workers. An owned Namespace deletes them with the installation.
+
+The same rule applies independently to `repositoryNamespaceOwnership`.
+
+Delete through the factory so TypeKro preserves dependency order:
+
+```ts
+await factory.deleteInstance('hatchet');
+await factory.dispose();
+```
+
+Do not delete the RGD before its instances finish finalizing.
+
+## Status
+
+The complete status contract is available in direct and KRO modes:
+
+```ts
+interface HatchetInstallationStatus {
+  ready: boolean;
+  failed: boolean;
+  phase: 'Installing' | 'Ready' | 'Failed';
+  chartVersion: string;
+  serverVersion: string;
+  endpoint: string;
+  grpcEndpoint: string;
+  configurationSecret: string;
+  workerTokenSecret: string;
+  dashboardEnabled: boolean;
+}
+```
+
+`ready` is derived from the current HelmRelease generation. External Secret
+existence is a prerequisite; successful Helm readiness is the bounded evidence
+that Hatchet integrated with those inputs.
+
+## Direct mode
+
+```ts
+const direct = hatchetInstallation.factory('direct', {
+  namespace: 'workflow-system',
+  waitForReady: true,
+  timeout: 20 * 60_000,
+});
+
+const result = await direct.deploy({
+  name: 'hatchet',
+  namespace: 'workflow-system',
+  namespaceOwnership: 'external',
+  database: {
+    connectionSecret: { name: 'hatchet-db-app' },
+  },
+  adminCredentialsSecret: { name: 'hatchet-admin' },
+  replicas: { api: 2, engine: 2, frontend: 2 },
+});
+
+console.log(result.status.endpoint);
+```
+
+Direct mode expects the observed Secrets to exist before `deploy()`. KRO mode
+records them as `externalRef` dependencies and waits for them.

--- a/docs/api/hatchet/index.md
+++ b/docs/api/hatchet/index.md
@@ -19,13 +19,10 @@ await factory.deploy({
   database: {
     connectionSecret: {
       name: 'hatchet-db-app',
-      key: 'uri',
     },
   },
   adminCredentialsSecret: {
     name: 'hatchet-admin',
-    emailKey: 'adminEmail',
-    passwordKey: 'adminPassword',
   },
 });
 ```
@@ -36,7 +33,7 @@ await factory.deploy({
 
 - an optional target Namespace;
 - an optional repository Namespace when it differs from the target;
-- one installation-scoped `<name>-hatchet` HelmRepository and the official
+- one installation-scoped `<namespace>-<name>-hatchet` HelmRepository and the official
   `hatchet-stack` HelmRelease;
 - a non-sensitive metadata ConfigMap used for the complete public status
   contract.
@@ -64,7 +61,7 @@ metadata:
   name: hatchet-db-app
   namespace: workflow-system
 stringData:
-  uri: postgres://app:password@hatchet-db-rw:5432/hatchet?sslmode=require
+  DATABASE_URL: postgres://app:password@hatchet-db-rw:5432/hatchet?sslmode=require
 ```
 
 The administrator Secret contains the bootstrap account:
@@ -76,16 +73,16 @@ metadata:
   name: hatchet-admin
   namespace: workflow-system
 stringData:
-  adminEmail: operator@example.com
-  adminPassword: replace-me
+  ADMIN_EMAIL: operator@example.com
+  ADMIN_PASSWORD: replace-me
 ```
 
-Flux reads these keys through `HelmRelease.spec.valuesFrom` with
-`literal: true`, so PostgreSQL URIs and credentials retain commas, brackets,
-dots, equals signs, and other Helm `--set` metacharacters verbatim. This
-requires Flux 2.9 or newer; the TypeKro runtime bootstrap defaults to that
-release. Secret values never appear in the generated RGD or
-HatchetInstallation instance.
+The composition appends both Secrets to the official chart's `api.envFrom` and
+`engine.envFrom` lists after the chart-generated shared configuration Secret.
+This preserves every credential byte without Helm `--set` interpretation and
+works with TypeKro's Flux 2.7.5 baseline. The fixed key names are the
+environment variables consumed by Hatchet. Secret values never appear in Helm
+values, the generated RGD, or the HatchetInstallation instance.
 
 The official chart's `hatchet-admin` command creates `hatchet-client-config`
 with `HATCHET_CLIENT_TOKEN` when `workerTokenJob` is enabled. The Secret name is
@@ -136,6 +133,11 @@ Secrets explicitly only when permanently abandoning that database and its
 workers. An owned Namespace deletes them with the installation.
 
 The same rule applies independently to `repositoryNamespaceOwnership`.
+The default HelmRepository name includes the workload Namespace as well as the
+release name, so same-named installations that share a repository Namespace
+remain independently owned. Set `repositoryName` only when an explicit
+platform naming policy is required; explicit names must be unique within the
+repository Namespace.
 
 Delete through the factory so TypeKro preserves dependency order:
 

--- a/docs/api/hatchet/index.md
+++ b/docs/api/hatchet/index.md
@@ -33,7 +33,7 @@ await factory.deploy({
 
 - an optional target Namespace;
 - an optional repository Namespace when it differs from the target;
-- one installation-scoped `<namespace>-<name>-hatchet` HelmRepository and the official
+- one installation-scoped `<length>-<namespace>-hatchet-hatchet` HelmRepository and the official
   `hatchet-stack` HelmRelease;
 - a non-sensitive metadata ConfigMap used for the complete public status
   contract.
@@ -95,11 +95,15 @@ upstream CLI defaults and are intentionally independent of the Helm release
 name.
 
 Because both recovery Secret names are fixed by the upstream Hatchet CLI,
-TypeKro admits exactly one Hatchet installation in a Namespace and requires
-the canonical release name `hatchet`. A second installation with another name
-fails schema validation before any resources are applied. Deploy independent
-Hatchet control planes into independent Namespaces; sharing these Secrets
-would couple encryption, signing, and worker credentials across releases.
+TypeKro admits exactly one Hatchet installation in a workload Namespace. The
+public `name` is the TypeKro instance identity, while the internal Helm release
+remains `hatchet`; this lets instances in separate workload Namespaces coexist
+in one KRO control Namespace without collapsing into one CR. A second instance
+targeting the same workload Namespace collides with the first instance's
+HelmRelease and recovery state and is rejected by Kubernetes/KRO ownership.
+Deploy independent Hatchet control planes into independent Namespaces; sharing
+these Secrets would couple encryption, signing, and worker credentials across
+releases.
 
 ## Operational defaults
 

--- a/docs/api/hatchet/index.md
+++ b/docs/api/hatchet/index.md
@@ -94,6 +94,13 @@ keysets. Its name is reported as `status.configurationSecret`. These are
 upstream CLI defaults and are intentionally independent of the Helm release
 name.
 
+Because both recovery Secret names are fixed by the upstream Hatchet CLI,
+TypeKro admits exactly one Hatchet installation in a Namespace and requires
+the canonical release name `hatchet`. A second installation with another name
+fails schema validation before any resources are applied. Deploy independent
+Hatchet control planes into independent Namespaces; sharing these Secrets
+would couple encryption, signing, and worker credentials across releases.
+
 ## Operational defaults
 
 The composition pins:
@@ -134,11 +141,11 @@ workers. An owned Namespace deletes them with the installation.
 
 The same rule applies independently to `repositoryNamespaceOwnership`.
 The default HelmRepository name includes a length-prefixed workload Namespace
-followed by the release name. The length prefix makes the tuple encoding
-injective: `team-a`/`worker` cannot collide with `team`/`a-worker`, even when
-both installations share a repository Namespace. Set `repositoryName` only
-when an explicit platform naming policy is required; explicit names must be
-unique within the repository Namespace.
+followed by the canonical release name. The length prefix keeps repository
+identity injective across workload Namespaces even when installations share a
+repository Namespace. Set `repositoryName` only when an explicit platform
+naming policy is required; explicit names must be unique within the repository
+Namespace.
 
 Delete through the factory so TypeKro preserves dependency order:
 

--- a/docs/api/hatchet/index.md
+++ b/docs/api/hatchet/index.md
@@ -36,7 +36,8 @@ await factory.deploy({
 
 - an optional target Namespace;
 - an optional repository Namespace when it differs from the target;
-- the official Hatchet HelmRepository and `hatchet-stack` HelmRelease;
+- one installation-scoped `<name>-hatchet` HelmRepository and the official
+  `hatchet-stack` HelmRelease;
 - a non-sensitive metadata ConfigMap used for the complete public status
   contract.
 
@@ -79,15 +80,22 @@ stringData:
   adminPassword: replace-me
 ```
 
-Flux reads these keys through `HelmRelease.spec.valuesFrom`. Secret values never
-appear in the generated RGD or HatchetInstallation instance.
+Flux reads these keys through `HelmRelease.spec.valuesFrom` with
+`literal: true`, so PostgreSQL URIs and credentials retain commas, brackets,
+dots, equals signs, and other Helm `--set` metacharacters verbatim. This
+requires Flux 2.9 or newer; the TypeKro runtime bootstrap defaults to that
+release. Secret values never appear in the generated RGD or
+HatchetInstallation instance.
 
-The official chart creates `<name>-client-config` with
-`HATCHET_CLIENT_TOKEN` when `workerTokenJob` is enabled. The generated Secret
-name is reported as `status.workerTokenSecret`.
+The official chart's `hatchet-admin` command creates `hatchet-client-config`
+with `HATCHET_CLIENT_TOKEN` when `workerTokenJob` is enabled. The Secret name is
+reported as `status.workerTokenSecret`; the field is empty when
+`workerTokenJob` is false.
 
-The chart also creates `<name>-config` with Hatchet's encryption and signing
-keysets. Its name is reported as `status.configurationSecret`.
+The chart also creates `hatchet-config` with Hatchet's encryption and signing
+keysets. Its name is reported as `status.configurationSecret`. These are
+upstream CLI defaults and are intentionally independent of the Helm release
+name.
 
 ## Operational defaults
 
@@ -121,7 +129,7 @@ when another platform composition owns it or when database retention must
 survive Hatchet installation deletion.
 
 When the Namespace is external, the official chart leaves
-`<name>-config` and `<name>-client-config` after uninstall. The configuration
+`hatchet-config` and `hatchet-client-config` after uninstall. The configuration
 Secret is recovery state for the retained Hatchet database, not an ordinary
 disposable chart artifact. Back up and retain it with the database. Delete both
 Secrets explicitly only when permanently abandoning that database and its

--- a/docs/api/kro/compositions/runtime.md
+++ b/docs/api/kro/compositions/runtime.md
@@ -42,7 +42,7 @@ The bootstrap deploys:
 ```typescript
 interface TypeKroRuntimeConfig {
   namespace?: string;     // Target namespace (default: 'flux-system')
-  fluxVersion?: string;   // Flux version (default: 'v2.7.5')
+  fluxVersion?: string;   // Flux version (default: 'v2.9.0')
   kroVersion?: string;    // Kro version (default: '0.9.2')
   rbac?: RbacMode;        // Flux controller RBAC mode (default: 'cluster-admin')
 }
@@ -65,7 +65,7 @@ TypeKro requires KRO `0.9.2+` because generated ResourceGraphDefinitions use the
 ```typescript
 const runtime = typeKroRuntimeBootstrap({
   namespace: 'flux-system',
-  fluxVersion: 'v2.7.5',
+  fluxVersion: 'v2.9.0',
   kroVersion: '0.9.2',
   rbac: 'scoped',
 });

--- a/docs/api/kro/compositions/runtime.md
+++ b/docs/api/kro/compositions/runtime.md
@@ -42,7 +42,7 @@ The bootstrap deploys:
 ```typescript
 interface TypeKroRuntimeConfig {
   namespace?: string;     // Target namespace (default: 'flux-system')
-  fluxVersion?: string;   // Flux version (default: 'v2.9.0')
+  fluxVersion?: string;   // Flux version (default: 'v2.7.5')
   kroVersion?: string;    // Kro version (default: '0.9.2')
   rbac?: RbacMode;        // Flux controller RBAC mode (default: 'cluster-admin')
 }
@@ -65,7 +65,7 @@ TypeKro requires KRO `0.9.2+` because generated ResourceGraphDefinitions use the
 ```typescript
 const runtime = typeKroRuntimeBootstrap({
   namespace: 'flux-system',
-  fluxVersion: 'v2.9.0',
+  fluxVersion: 'v2.7.5',
   kroVersion: '0.9.2',
   rbac: 'scoped',
 });

--- a/package.json
+++ b/package.json
@@ -110,6 +110,10 @@
       "import": "./dist/factories/nats/index.js",
       "types": "./dist/factories/nats/index.d.ts"
     },
+    "./hatchet": {
+      "import": "./dist/factories/hatchet/index.js",
+      "types": "./dist/factories/hatchet/index.d.ts"
+    },
     "./containers": {
       "import": "./dist/core/containers/index.js",
       "types": "./dist/core/containers/index.d.ts"

--- a/package.json
+++ b/package.json
@@ -226,7 +226,8 @@
     "estraverse": "^5.3.0",
     "ignore": "^7.0.5",
     "js-yaml": "4.1.0",
-    "pino": "^9.8.0"
+    "pino": "^9.8.0",
+    "re2js": "2.8.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.3",

--- a/src/compositions/typekro-runtime/typekro-runtime.ts
+++ b/src/compositions/typekro-runtime/typekro-runtime.ts
@@ -50,8 +50,9 @@ import {
 export function typeKroRuntimeBootstrap(config: TypeKroRuntimeConfig = {}) {
   // Use a specific stable Flux version by default to avoid schema validation issues
   // that can occur with 'latest' (e.g., 422 errors on CRD validation)
-  // v2.7.5 is the latest stable version with fixes for schema validation issues
-  const fluxVersion = config.fluxVersion || 'v2.7.5';
+  // Flux 2.9 adds literal Helm valuesFrom support, which is required to
+  // preserve arbitrary Secret bytes used by integrations such as Hatchet.
+  const fluxVersion = config.fluxVersion || 'v2.9.0';
   // KRO 0.9.2+ is REQUIRED — the TypeKro serialization pipeline emits
   // `${has(...) ? ... : omit()}` conditionals for optional spec fields
   // without defaults, and the `omit()` CEL function is gated behind the

--- a/src/compositions/typekro-runtime/typekro-runtime.ts
+++ b/src/compositions/typekro-runtime/typekro-runtime.ts
@@ -50,9 +50,7 @@ import {
 export function typeKroRuntimeBootstrap(config: TypeKroRuntimeConfig = {}) {
   // Use a specific stable Flux version by default to avoid schema validation issues
   // that can occur with 'latest' (e.g., 422 errors on CRD validation)
-  // Flux 2.9 adds literal Helm valuesFrom support, which is required to
-  // preserve arbitrary Secret bytes used by integrations such as Hatchet.
-  const fluxVersion = config.fluxVersion || 'v2.9.0';
+  const fluxVersion = config.fluxVersion || 'v2.7.5';
   // KRO 0.9.2+ is REQUIRED — the TypeKro serialization pipeline emits
   // `${has(...) ? ... : omit()}` conditionals for optional spec fields
   // without defaults, and the `omit()` CEL function is gated behind the

--- a/src/compositions/typekro-runtime/types.ts
+++ b/src/compositions/typekro-runtime/types.ts
@@ -44,6 +44,7 @@ export type RbacMode = 'cluster-admin' | 'scoped' | { clusterRoleRef: string };
 
 export interface TypeKroRuntimeConfig {
   namespace?: string;
+  /** @default 'v2.9.0' */
   fluxVersion?: string;
   kroVersion?: string;
   /**

--- a/src/compositions/typekro-runtime/types.ts
+++ b/src/compositions/typekro-runtime/types.ts
@@ -44,7 +44,7 @@ export type RbacMode = 'cluster-admin' | 'scoped' | { clusterRoleRef: string };
 
 export interface TypeKroRuntimeConfig {
   namespace?: string;
-  /** @default 'v2.9.0' */
+  /** @default 'v2.7.5' */
   fluxVersion?: string;
   kroVersion?: string;
   /**

--- a/src/core/metadata/resource-metadata.ts
+++ b/src/core/metadata/resource-metadata.ts
@@ -17,6 +17,7 @@ import type { ResourceAspectMetadata } from '../aspects/types.js';
 import type { ArtifactApplyPolicy } from '../planning/artifacts.js';
 import type { ReadinessStrategyIdentity } from '../planning/types.js';
 import type { ResourceStatus } from '../types/kubernetes.js';
+import type { RefOrValue } from '../types/references.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -49,6 +50,18 @@ export interface ResourceMetadata {
    * material remains sensitive and is redacted into bindings by the planner.
    */
   secretMaterial?: 'public-placeholder';
+  /**
+   * Unserialized authoring identity for an external reference.
+   *
+   * Enhanced resource proxy reads may render CEL expressions as `${...}`
+   * markers. Planning retains the original values here so direct execution can
+   * evaluate them against the concrete instance spec instead of treating those
+   * markers as literal Kubernetes names.
+   */
+  externalIdentity?: {
+    name: RefOrValue<string>;
+    namespace?: RefOrValue<string>;
+  };
   /** Original resource identifier for cross-resource references */
   resourceId?: string;
   /** Local resource IDs that should resolve to this emitted resource ID. */

--- a/src/core/planning/direct-runtime-adapter.ts
+++ b/src/core/planning/direct-runtime-adapter.ts
@@ -160,6 +160,42 @@ export function materializeDirectArtifactManifest(
     );
   }
   const manifest = { ...(value as KubernetesResource), id: deployedId };
+  if (artifact.role === 'external-reference' && artifact.identity) {
+    const name = materializePlanValue(
+      artifact.identity.name,
+      options,
+      `$.resources.${artifact.id}.identity.name`
+    );
+    if (typeof name !== 'string' || name.length === 0) {
+      throw new DirectArtifactRuntimeAdapterError(
+        `External reference ${artifact.id} did not materialize a Kubernetes name.`,
+        { artifactId: artifact.id }
+      );
+    }
+    const namespace = artifact.identity.namespace
+      ? materializePlanValue(
+          artifact.identity.namespace,
+          options,
+          `$.resources.${artifact.id}.identity.namespace`
+        )
+      : undefined;
+    if (namespace !== undefined && (typeof namespace !== 'string' || namespace.length === 0)) {
+      throw new DirectArtifactRuntimeAdapterError(
+        `External reference ${artifact.id} did not materialize a valid Kubernetes namespace.`,
+        { artifactId: artifact.id }
+      );
+    }
+    const metadata = {
+      ...manifest.metadata,
+      name,
+    };
+    if (namespace !== undefined) {
+      metadata.namespace = namespace;
+    } else {
+      delete metadata.namespace;
+    }
+    manifest.metadata = metadata;
+  }
   // Template overrides compensate for JavaScript branches that must remain
   // symbolic in a KRO template. Direct planning executes with a concrete spec,
   // so `desired` already contains the selected branch and is authoritative.

--- a/src/core/planning/planner.ts
+++ b/src/core/planning/planner.ts
@@ -1,10 +1,10 @@
+import { canonicalizeCelResourceAliases } from '../../utils/cel-resource-identifiers.js';
 import {
   isCelExpression,
   isKubernetesRef,
   isMixedTemplate,
   isResourceReference,
 } from '../../utils/type-guards.js';
-import { canonicalizeCelResourceAliases } from '../../utils/cel-resource-identifiers.js';
 import { applyAspects } from '../aspects/apply.js';
 import { DependencyResolver } from '../dependencies/index.js';
 import { TypeKroError } from '../errors.js';
@@ -1118,8 +1118,11 @@ function purityDiagnostics(source: string): PlanDiagnostic[] {
 }
 
 function resourceIdentity(resource: KubernetesResource, specSchema: SchemaIR): KubernetesIdentity {
-  const name = lowerPlanValue(resource.metadata?.name, { specSchema }).value;
-  const namespace = resource.metadata?.namespace;
+  const externalIdentity = getMetadataField(resource, 'externalIdentity');
+  const name = lowerPlanValue(externalIdentity?.name ?? resource.metadata?.name, {
+    specSchema,
+  }).value;
+  const namespace = externalIdentity?.namespace ?? resource.metadata?.namespace;
   const declaredScope = getResourceScope(resource);
   return {
     apiVersion: resource.apiVersion,
@@ -1535,7 +1538,14 @@ function buildResourceNodes(
     const logicalId = getResourceId(resource) ?? fallbackId;
     if (nodes.some((node) => node.id === logicalId)) return;
     referenceIdToLogical.set(logicalId, logicalId);
-    const canonicalized = canonicalizeResource(resource, diagnostics);
+    // External references are observed rather than authored desired state.
+    // Running factory canonicalizers against them is both unnecessary and
+    // ambiguous when several factories share the referenced GVK (notably
+    // Secret). Preserve their declared identity exactly.
+    const canonicalized =
+      Reflect.get(resource, '__externalRef') === true
+        ? { resource, canonicalizers: [] }
+        : canonicalizeResource(resource, diagnostics);
     representationRequirements.push(
       ...factoryRepresentationRequirements(resource, logicalId, diagnostics)
     );

--- a/src/core/references/external-refs.ts
+++ b/src/core/references/external-refs.ts
@@ -14,11 +14,11 @@
  */
 
 import { getCurrentCompositionContext } from '../composition/context.js';
-import { getResourceId } from '../metadata/index.js';
+import { getResourceId, setMetadataField } from '../metadata/index.js';
 import { createResource } from '../proxy/create-resource.js';
 import { registerFactory } from '../resources/factory-registry.js';
-import type { Enhanced, KubernetesResource } from '../types.js';
 import type { RefOrValue } from '../types/references.js';
+import type { Enhanced, KubernetesResource } from '../types.js';
 
 // Self-register so the composition analyzer recognizes `externalRef(...)` calls
 // in the AST. The kind/apiVersion are placeholders — externalRef creates resources
@@ -141,6 +141,10 @@ export function externalRef<TSpec extends object, TStatus extends object>(
   // Use existing createResource function to get Enhanced proxy
   // (createResource skips context registration for __externalRef resources)
   const enhanced = createResource<TSpec, TStatus>(resource, { scope: resolvedScope });
+  setMetadataField(enhanced, 'externalIdentity', {
+    name: resolvedName,
+    ...(resolvedNamespace !== undefined ? { namespace: resolvedNamespace } : {}),
+  });
 
   // Explicitly register with composition context so externalRef appears in Kro YAML.
   // This only happens when called directly from user code inside kubernetesComposition.

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -87,6 +87,7 @@ function getKroTypeFromJson(node: unknown): string {
         }
         const pattern = nodeObj.pattern[0];
         if (typeof pattern === 'string') {
+          assertKubernetesRegexPattern(pattern);
           markers.push(`pattern="${pattern.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`);
         }
       }
@@ -154,6 +155,82 @@ function getKroTypeFromJson(node: unknown): string {
   }
 
   return 'string';
+}
+
+/**
+ * Kubernetes validates OpenAPI patterns with RE2. ArkType accepts JavaScript
+ * regular expressions, whose grammar additionally includes constructs that
+ * the API server rejects. Fail during generation instead of emitting a CRD
+ * that can never be admitted.
+ */
+function assertKubernetesRegexPattern(pattern: string): void {
+  let inCharacterClass = false;
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    if (character === '[' && !inCharacterClass) {
+      inCharacterClass = true;
+      continue;
+    }
+    if (character === ']' && inCharacterClass) {
+      inCharacterClass = false;
+      continue;
+    }
+    if (character !== '\\') continue;
+    const escaped = pattern[index + 1];
+    if (!inCharacterClass && escaped && /[1-9]/.test(escaped)) {
+      throw unsupportedKubernetesRegex(pattern, `numeric backreference \\${escaped}`);
+    }
+    if (!inCharacterClass && escaped === 'k' && pattern[index + 2] === '<') {
+      throw unsupportedKubernetesRegex(pattern, 'named backreference \\k<...>');
+    }
+    index += 1;
+  }
+  inCharacterClass = false;
+  for (let index = 0; index < pattern.length; index += 1) {
+    const character = pattern[index];
+    if (character === '\\') {
+      index += 1;
+      continue;
+    }
+    if (character === '[' && !inCharacterClass) {
+      inCharacterClass = true;
+      continue;
+    }
+    if (character === ']' && inCharacterClass) {
+      inCharacterClass = false;
+      continue;
+    }
+    if (inCharacterClass) continue;
+    if (character === '(' && pattern[index + 1] === '?') {
+      const group = pattern.slice(index, index + 4);
+      if (!group.startsWith('(?:')) {
+        const label = group.startsWith('(?=')
+          ? 'positive lookahead'
+          : group.startsWith('(?!')
+            ? 'negative lookahead'
+            : group.startsWith('(?<=')
+              ? 'positive lookbehind'
+              : group.startsWith('(?<!')
+                ? 'negative lookbehind'
+                : group.startsWith('(?>')
+                  ? 'atomic group'
+                  : 'JavaScript-specific group';
+        throw unsupportedKubernetesRegex(pattern, label);
+      }
+    }
+    if (character === '+' && pattern[index - 1] !== '\\') {
+      const previous = pattern[index - 1];
+      if (previous === '*' || previous === '+' || previous === '?' || previous === '}') {
+        throw unsupportedKubernetesRegex(pattern, 'possessive quantifier');
+      }
+    }
+  }
+}
+
+function unsupportedKubernetesRegex(pattern: string, construct: string): Error {
+  return new Error(
+    `ArkType pattern ${JSON.stringify(pattern)} uses ${construct}, which Kubernetes RE2 validation does not support. Use an RE2-compatible pattern before generating a KRO schema.`,
+  );
 }
 
 /**

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Type } from 'arktype';
+import { RE2JS } from 're2js';
 import { KUBERNETES_REF_SCHEMA_MARKER_SOURCE } from '../../shared/brands.js';
 import { escapeCelString } from '../../utils/cel-escape.js';
 import { pascalCase } from '../../utils/string.js';
@@ -87,8 +88,15 @@ function getKroTypeFromJson(node: unknown): string {
         }
         const pattern = nodeObj.pattern[0];
         if (typeof pattern === 'string') {
-          assertKubernetesRegexPattern(pattern);
-          markers.push(`pattern="${pattern.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`);
+          markers.push(`pattern="${kubernetesRegexPattern(pattern)}"`);
+        } else if (isArkTypeFlaggedPattern(pattern)) {
+          throw new Error(
+            `ArkType pattern ${JSON.stringify(pattern.rule)} uses JavaScript flags ${JSON.stringify(pattern.flags)}, which KRO SimpleSchema cannot preserve. Use an unflagged RE2-compatible pattern before generating a KRO schema.`,
+          );
+        } else if (pattern !== undefined) {
+          throw new Error(
+            `ArkType emitted an unsupported string-pattern representation ${JSON.stringify(pattern)}. TypeKro refuses to omit the constraint while generating a KRO schema.`,
+          );
         }
       }
       return markers.length > 0 ? `string | ${markers.join(' ')}` : 'string';
@@ -163,73 +171,27 @@ function getKroTypeFromJson(node: unknown): string {
  * the API server rejects. Fail during generation instead of emitting a CRD
  * that can never be admitted.
  */
-function assertKubernetesRegexPattern(pattern: string): void {
-  let inCharacterClass = false;
-  for (let index = 0; index < pattern.length; index += 1) {
-    const character = pattern[index];
-    if (character === '[' && !inCharacterClass) {
-      inCharacterClass = true;
-      continue;
-    }
-    if (character === ']' && inCharacterClass) {
-      inCharacterClass = false;
-      continue;
-    }
-    if (character !== '\\') continue;
-    const escaped = pattern[index + 1];
-    if (!inCharacterClass && escaped && /[1-9]/.test(escaped)) {
-      throw unsupportedKubernetesRegex(pattern, `numeric backreference \\${escaped}`);
-    }
-    if (!inCharacterClass && escaped === 'k' && pattern[index + 2] === '<') {
-      throw unsupportedKubernetesRegex(pattern, 'named backreference \\k<...>');
-    }
-    index += 1;
+function kubernetesRegexPattern(pattern: string): string {
+  try {
+    RE2JS.compile(pattern);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `ArkType pattern ${JSON.stringify(pattern)} is not compatible with Kubernetes RE2 validation: ${reason}`,
+    );
   }
-  inCharacterClass = false;
-  for (let index = 0; index < pattern.length; index += 1) {
-    const character = pattern[index];
-    if (character === '\\') {
-      index += 1;
-      continue;
-    }
-    if (character === '[' && !inCharacterClass) {
-      inCharacterClass = true;
-      continue;
-    }
-    if (character === ']' && inCharacterClass) {
-      inCharacterClass = false;
-      continue;
-    }
-    if (inCharacterClass) continue;
-    if (character === '(' && pattern[index + 1] === '?') {
-      const group = pattern.slice(index, index + 4);
-      if (!group.startsWith('(?:')) {
-        const label = group.startsWith('(?=')
-          ? 'positive lookahead'
-          : group.startsWith('(?!')
-            ? 'negative lookahead'
-            : group.startsWith('(?<=')
-              ? 'positive lookbehind'
-              : group.startsWith('(?<!')
-                ? 'negative lookbehind'
-                : group.startsWith('(?>')
-                  ? 'atomic group'
-                  : 'JavaScript-specific group';
-        throw unsupportedKubernetesRegex(pattern, label);
-      }
-    }
-    if (character === '+' && pattern[index - 1] !== '\\') {
-      const previous = pattern[index - 1];
-      if (previous === '*' || previous === '+' || previous === '?' || previous === '}') {
-        throw unsupportedKubernetesRegex(pattern, 'possessive quantifier');
-      }
-    }
-  }
+  return pattern.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
 }
 
-function unsupportedKubernetesRegex(pattern: string, construct: string): Error {
-  return new Error(
-    `ArkType pattern ${JSON.stringify(pattern)} uses ${construct}, which Kubernetes RE2 validation does not support. Use an RE2-compatible pattern before generating a KRO schema.`,
+function isArkTypeFlaggedPattern(
+  value: unknown,
+): value is { readonly rule: string; readonly flags: string } {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && typeof Reflect.get(value, 'rule') === 'string'
+    && typeof Reflect.get(value, 'flags') === 'string',
   );
 }
 

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -75,6 +75,23 @@ function getKroTypeFromJson(node: unknown): string {
       if (typeof nodeObj.max === 'number') markers.push(`maximum=${nodeObj.max}`);
       return markers.length > 0 ? `${baseType} | ${markers.join(' ')}` : baseType;
     }
+    if (nodeObj.domain === 'string') {
+      const markers: string[] = [];
+      if (typeof nodeObj.minLength === 'number') markers.push(`minLength=${nodeObj.minLength}`);
+      if (typeof nodeObj.maxLength === 'number') markers.push(`maxLength=${nodeObj.maxLength}`);
+      if (Array.isArray(nodeObj.pattern)) {
+        if (nodeObj.pattern.length > 1) {
+          throw new Error(
+            'KRO SimpleSchema supports one string pattern per field; combine intersecting ArkType patterns before serialization.',
+          );
+        }
+        const pattern = nodeObj.pattern[0];
+        if (typeof pattern === 'string') {
+          markers.push(`pattern="${pattern.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`);
+        }
+      }
+      return markers.length > 0 ? `string | ${markers.join(' ')}` : 'string';
+    }
     // Map / Record types — arktype represents `Record<string, V>` as
     // `{ domain: "object", index: [{ signature: "string", value: V }] }`.
     // KRO SimpleSchema uses `map[string]<value-type>` notation for these.

--- a/src/factories/hatchet/compositions/hatchet-installation.ts
+++ b/src/factories/hatchet/compositions/hatchet-installation.ts
@@ -30,8 +30,8 @@ const HATCHET_WORKER_TOKEN_SECRET = 'hatchet-client-config';
  *
  * The composition deliberately disables the bundled PostgreSQL and RabbitMQ
  * charts. The database and admin credentials remain in external Kubernetes
- * Secrets and reach Flux through `valuesFrom`; they are never copied into the
- * KRO instance or ResourceGraphDefinition.
+ * Secrets and are mounted into Hatchet with chart-native `envFrom`; they are
+ * never copied into Helm values, the KRO instance, or ResourceGraphDefinition.
  */
 export const hatchetInstallation = kubernetesComposition(
   {
@@ -53,9 +53,10 @@ export const hatchetInstallation = kubernetesComposition(
       : spec.namespaceOwnership !== 'external';
     const repositoryName = graphMode
       ? Cel.expr<string>(
-          'has(schema.spec.repositoryName) ? schema.spec.repositoryName : string(schema.spec.name) + "-hatchet"'
+          'has(schema.spec.repositoryName) ? schema.spec.repositoryName : string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + "-" + string(schema.spec.name) + "-hatchet"'
         )
-      : (spec.repositoryName ?? `${spec.name}-${DEFAULT_HATCHET_REPOSITORY_NAME}`);
+      : (spec.repositoryName ??
+        `${targetNamespace}-${spec.name}-${DEFAULT_HATCHET_REPOSITORY_NAME}`);
     const repositoryNamespace = graphMode
       ? Cel.expr<string>(
           'has(schema.spec.repositoryNamespace) ? schema.spec.repositoryNamespace : (has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system")'
@@ -127,6 +128,14 @@ export const hatchetInstallation = kubernetesComposition(
         ? HATCHET_WORKER_TOKEN_SECRET
         : '';
     const configurationSecret = HATCHET_CONFIGURATION_SECRET;
+    const sharedConfigSecret = graphMode
+      ? Cel.expr<string>('string(schema.spec.name) + "-shared-config"')
+      : `${spec.name}-shared-config`;
+    const externalEnvironment = [
+      { secretRef: { name: sharedConfigSecret } },
+      { secretRef: { name: spec.database.connectionSecret.name } },
+      { secretRef: { name: spec.adminCredentialsSecret.name } },
+    ];
 
     namespace({
       id: 'hatchetNamespace',
@@ -216,9 +225,7 @@ export const hatchetInstallation = kubernetesComposition(
 
     const protectedValues = {
       global: {
-        sharedConfigSecretName: graphMode
-          ? Cel.expr<string>('string(schema.spec.name) + "-shared-config"')
-          : `${spec.name}-shared-config`,
+        sharedConfigSecretName: sharedConfigSecret,
       },
       sharedConfig: {
         image: { tag: serverVersion },
@@ -242,8 +249,12 @@ export const hatchetInstallation = kubernetesComposition(
       api: {
         replicaCount: apiReplicas,
         workerTokenJob: { enabled: workerTokenJob },
+        envFrom: externalEnvironment,
       },
-      engine: { replicaCount: engineReplicas },
+      engine: {
+        replicaCount: engineReplicas,
+        envFrom: externalEnvironment,
+      },
       frontend: {
         enabled: dashboardEnabled,
         replicaCount: frontendReplicas,
@@ -259,29 +270,6 @@ export const hatchetInstallation = kubernetesComposition(
       repositoryName,
       repositoryNamespace,
       repositoryUrl,
-      valuesFrom: [
-        {
-          kind: 'Secret',
-          name: spec.database.connectionSecret.name,
-          valuesKey: spec.database.connectionSecret.key ?? 'uri',
-          targetPath: 'sharedConfig.env.DATABASE_URL',
-          literal: true,
-        },
-        {
-          kind: 'Secret',
-          name: spec.adminCredentialsSecret.name,
-          valuesKey: spec.adminCredentialsSecret.emailKey ?? 'adminEmail',
-          targetPath: 'sharedConfig.defaultAdminEmail',
-          literal: true,
-        },
-        {
-          kind: 'Secret',
-          name: spec.adminCredentialsSecret.name,
-          valuesKey: spec.adminCredentialsSecret.passwordKey ?? 'adminPassword',
-          targetPath: 'sharedConfig.defaultAdminPassword',
-          literal: true,
-        },
-      ],
       values,
     });
     release.dependsOn(repository);
@@ -316,10 +304,7 @@ export const hatchetInstallation = kubernetesComposition(
   {
     schemaFieldValidations: {
       'database.connectionSecret.name': 'size(self) > 0',
-      'database.connectionSecret.key': 'size(self) > 0',
       'adminCredentialsSecret.name': 'size(self) > 0',
-      'adminCredentialsSecret.emailKey': 'size(self) > 0',
-      'adminCredentialsSecret.passwordKey': 'size(self) > 0',
     },
   }
 );
@@ -329,19 +314,9 @@ function validateSecretReferences(spec: HatchetInstallationConfig): void {
     ['database.connectionSecret.name', spec.database.connectionSecret.name],
     ['adminCredentialsSecret.name', spec.adminCredentialsSecret.name],
   ] as const;
-  const optional = [
-    ['database.connectionSecret.key', spec.database.connectionSecret.key],
-    ['adminCredentialsSecret.emailKey', spec.adminCredentialsSecret.emailKey],
-    ['adminCredentialsSecret.passwordKey', spec.adminCredentialsSecret.passwordKey],
-  ] as const;
   for (const [path, value] of required) {
     if (value.trim().length === 0) {
       throw new Error(`Hatchet ${path} must be a non-empty Secret reference.`);
-    }
-  }
-  for (const [path, value] of optional) {
-    if (value !== undefined && value.trim().length === 0) {
-      throw new Error(`Hatchet ${path} must be non-empty when supplied.`);
     }
   }
 }

--- a/src/factories/hatchet/compositions/hatchet-installation.ts
+++ b/src/factories/hatchet/compositions/hatchet-installation.ts
@@ -53,10 +53,10 @@ export const hatchetInstallation = kubernetesComposition(
       : spec.namespaceOwnership !== 'external';
     const repositoryName = graphMode
       ? Cel.expr<string>(
-          'has(schema.spec.repositoryName) ? schema.spec.repositoryName : string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + "-" + string(schema.spec.name) + "-hatchet"'
+          'has(schema.spec.repositoryName) ? schema.spec.repositoryName : string(size(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system")) + "-" + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + "-" + string(schema.spec.name) + "-hatchet"'
         )
       : (spec.repositoryName ??
-        `${targetNamespace}-${spec.name}-${DEFAULT_HATCHET_REPOSITORY_NAME}`);
+        `${targetNamespace.length}-${targetNamespace}-${spec.name}-${DEFAULT_HATCHET_REPOSITORY_NAME}`);
     const repositoryNamespace = graphMode
       ? Cel.expr<string>(
           'has(schema.spec.repositoryNamespace) ? schema.spec.repositoryNamespace : (has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system")'

--- a/src/factories/hatchet/compositions/hatchet-installation.ts
+++ b/src/factories/hatchet/compositions/hatchet-installation.ts
@@ -1,0 +1,340 @@
+import { mergeValuesExpression } from '../../../core/aspects/values-merge.js';
+import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { Cel } from '../../../core/references/cel.js';
+import { observedResource } from '../../../core/references/external-refs.js';
+import { isKubernetesRef } from '../../../utils/type-guards.js';
+import { helmReleaseConditionSummary } from '../../helm/status.js';
+import { configMap } from '../../kubernetes/config/config-map.js';
+import { namespace } from '../../kubernetes/core/namespace.js';
+import {
+  DEFAULT_HATCHET_CHART_VERSION,
+  DEFAULT_HATCHET_REPOSITORY_NAME,
+  DEFAULT_HATCHET_REPOSITORY_URL,
+  DEFAULT_HATCHET_SERVER_VERSION,
+  hatchetHelmRelease,
+  hatchetHelmRepository,
+} from '../resources/helm.js';
+import {
+  type HatchetInstallationConfig,
+  HatchetInstallationConfigSchema,
+  HatchetInstallationStatusSchema,
+} from '../types.js';
+
+const DEFAULT_HATCHET_NAMESPACE = 'hatchet-system';
+
+/**
+ * Install the official Hatchet chart against an externally authoritative
+ * PostgreSQL database.
+ *
+ * The composition deliberately disables the bundled PostgreSQL and RabbitMQ
+ * charts. The database and admin credentials remain in external Kubernetes
+ * Secrets and reach Flux through `valuesFrom`; they are never copied into the
+ * KRO instance or ResourceGraphDefinition.
+ */
+export const hatchetInstallation = kubernetesComposition(
+  {
+    name: 'hatchet-installation',
+    kind: 'HatchetInstallation',
+    spec: HatchetInstallationConfigSchema,
+    status: HatchetInstallationStatusSchema,
+  },
+  (spec: HatchetInstallationConfig) => {
+    const graphMode = isKubernetesRef(spec.name);
+    if (!graphMode) validateSecretReferences(spec);
+    const targetNamespace = graphMode
+      ? Cel.expr<string>('has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system"')
+      : (spec.namespace ?? DEFAULT_HATCHET_NAMESPACE);
+    const ownsTargetNamespace = graphMode
+      ? Cel.expr<boolean>(
+          '!has(schema.spec.namespaceOwnership) || schema.spec.namespaceOwnership == "owned"'
+        )
+      : spec.namespaceOwnership !== 'external';
+    const repositoryName = graphMode
+      ? Cel.expr<string>('has(schema.spec.repositoryName) ? schema.spec.repositoryName : "hatchet"')
+      : (spec.repositoryName ?? DEFAULT_HATCHET_REPOSITORY_NAME);
+    const repositoryNamespace = graphMode
+      ? Cel.expr<string>(
+          'has(schema.spec.repositoryNamespace) ? schema.spec.repositoryNamespace : (has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system")'
+        )
+      : (spec.repositoryNamespace ?? targetNamespace);
+    const ownsRepositoryNamespace = graphMode
+      ? Cel.expr<boolean>(
+          '!has(schema.spec.repositoryNamespaceOwnership) || schema.spec.repositoryNamespaceOwnership == "owned"'
+        )
+      : spec.repositoryNamespaceOwnership !== 'external';
+    const repositoryUrl = graphMode
+      ? Cel.expr<string>(
+          'has(schema.spec.repositoryUrl) ? schema.spec.repositoryUrl : "https://hatchet-dev.github.io/hatchet-charts"'
+        )
+      : (spec.repositoryUrl ?? DEFAULT_HATCHET_REPOSITORY_URL);
+    const chartVersion = graphMode
+      ? Cel.expr<string>('has(schema.spec.chartVersion) ? schema.spec.chartVersion : "0.13.3"')
+      : (spec.chartVersion ?? DEFAULT_HATCHET_CHART_VERSION);
+    const serverVersion = graphMode
+      ? Cel.expr<string>('has(schema.spec.serverVersion) ? schema.spec.serverVersion : "v0.94.10"')
+      : (spec.serverVersion ?? DEFAULT_HATCHET_SERVER_VERSION);
+    const apiReplicas = graphMode
+      ? Cel.expr<number>(
+          'has(schema.spec.replicas) && has(schema.spec.replicas.api) ? schema.spec.replicas.api : 1'
+        )
+      : (spec.replicas?.api ?? 1);
+    const engineReplicas = graphMode
+      ? Cel.expr<number>(
+          'has(schema.spec.replicas) && has(schema.spec.replicas.engine) ? schema.spec.replicas.engine : 1'
+        )
+      : (spec.replicas?.engine ?? 1);
+    const frontendReplicas = graphMode
+      ? Cel.expr<number>(
+          'has(schema.spec.replicas) && has(schema.spec.replicas.frontend) ? schema.spec.replicas.frontend : 1'
+        )
+      : (spec.replicas?.frontend ?? 1);
+    const dashboardEnabled = graphMode
+      ? Cel.expr<boolean>('!has(schema.spec.dashboard) || schema.spec.dashboard')
+      : (spec.dashboard ?? true);
+    const workerTokenJob = graphMode
+      ? Cel.expr<boolean>('!has(schema.spec.workerTokenJob) || schema.spec.workerTokenJob')
+      : (spec.workerTokenJob ?? true);
+    const endpoint = graphMode
+      ? Cel.expr<string>(
+          'has(schema.spec.serverUrl) ? schema.spec.serverUrl : "http://" + string(schema.spec.name) + "-api." + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + ".svc:8080"'
+        )
+      : (spec.serverUrl ?? `http://${spec.name}-api.${targetNamespace}.svc:8080`);
+    const grpcEndpoint = graphMode
+      ? Cel.expr<string>(
+          'has(schema.spec.grpcBroadcastAddress) ? schema.spec.grpcBroadcastAddress : string(schema.spec.name) + "-engine." + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + ".svc:7070"'
+        )
+      : (spec.grpcBroadcastAddress ?? `${spec.name}-engine.${targetNamespace}.svc:7070`);
+    const cookieDomain = graphMode
+      ? Cel.expr<string>(
+          'has(schema.spec.cookieDomain) ? schema.spec.cookieDomain : string(schema.spec.name) + "-api." + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + ".svc"'
+        )
+      : (spec.cookieDomain ?? `${spec.name}-api.${targetNamespace}.svc`);
+    const cookieInsecure = graphMode
+      ? Cel.expr<boolean>('!has(schema.spec.cookieInsecure) || schema.spec.cookieInsecure')
+      : (spec.cookieInsecure ?? true);
+    const grpcInsecure = graphMode
+      ? Cel.expr<boolean>('!has(schema.spec.grpcInsecure) || schema.spec.grpcInsecure')
+      : (spec.grpcInsecure ?? true);
+    const workerTokenSecret = graphMode
+      ? Cel.expr<string>('string(schema.spec.name) + "-client-config"')
+      : `${spec.name}-client-config`;
+    const configurationSecret = graphMode
+      ? Cel.expr<string>('string(schema.spec.name) + "-config"')
+      : `${spec.name}-config`;
+
+    namespace({
+      id: 'hatchetNamespace',
+      metadata: {
+        name: targetNamespace,
+        labels: {
+          'app.kubernetes.io/name': 'hatchet',
+          'app.kubernetes.io/instance': spec.name,
+          'app.kubernetes.io/managed-by': 'typekro',
+        },
+      },
+    }).withIncludeWhen(ownsTargetNamespace);
+
+    namespace({
+      id: 'hatchetRepositoryNamespace',
+      metadata: {
+        name: repositoryNamespace,
+        labels: {
+          'app.kubernetes.io/name': 'hatchet-helm-source',
+          'app.kubernetes.io/managed-by': 'typekro',
+        },
+      },
+    }).withIncludeWhen(
+      graphMode
+        ? Cel.expr<boolean>(
+            '(!has(schema.spec.repositoryNamespaceOwnership) || schema.spec.repositoryNamespaceOwnership == "owned") && has(schema.spec.repositoryNamespace) && schema.spec.repositoryNamespace != (has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system")'
+          )
+        : ownsRepositoryNamespace && repositoryNamespace !== targetNamespace
+    );
+
+    configMap({
+      id: 'hatchetMetadata',
+      metadata: {
+        name: graphMode
+          ? Cel.expr<string>('string(schema.spec.name) + "-typekro-metadata"')
+          : `${spec.name}-typekro-metadata`,
+        namespace: targetNamespace,
+        labels: {
+          'app.kubernetes.io/name': 'hatchet',
+          'app.kubernetes.io/instance': spec.name,
+          'app.kubernetes.io/managed-by': 'typekro',
+        },
+        annotations: {
+          'typekro.dev/chart-version': chartVersion,
+          'typekro.dev/server-version': serverVersion,
+          'typekro.dev/endpoint': endpoint,
+          'typekro.dev/grpc-endpoint': grpcEndpoint,
+          'typekro.dev/configuration-secret': configurationSecret,
+          'typekro.dev/worker-token-secret': workerTokenSecret,
+          'typekro.dev/dashboard-enabled': graphMode
+            ? Cel.expr<string>(dashboardEnabled, ' ? "true" : "false"')
+            : String(dashboardEnabled),
+        },
+      },
+      immutable: true,
+      data: {},
+    });
+
+    const repository = hatchetHelmRepository({
+      id: 'hatchetRepository',
+      name: repositoryName,
+      namespace: repositoryNamespace,
+      url: repositoryUrl,
+    });
+    const databaseCredentials = graphMode
+      ? observedResource<Record<string, never>, Record<string, never>>({
+          apiVersion: 'v1',
+          kind: 'Secret',
+          metadata: {
+            name: spec.database.connectionSecret.name,
+            namespace: targetNamespace,
+          },
+          id: 'hatchetDatabaseCredentials',
+        })
+      : undefined;
+    const adminCredentials = graphMode
+      ? observedResource<Record<string, never>, Record<string, never>>({
+          apiVersion: 'v1',
+          kind: 'Secret',
+          metadata: {
+            name: spec.adminCredentialsSecret.name,
+            namespace: targetNamespace,
+          },
+          id: 'hatchetAdminCredentials',
+        })
+      : undefined;
+
+    const protectedValues = {
+      global: {
+        sharedConfigSecretName: graphMode
+          ? Cel.expr<string>('string(schema.spec.name) + "-shared-config"')
+          : `${spec.name}-shared-config`,
+      },
+      sharedConfig: {
+        image: { tag: serverVersion },
+        serverUrl: endpoint,
+        serverAuthCookieDomain: cookieDomain,
+        serverAuthCookieInsecure: graphMode
+          ? Cel.expr<string>(cookieInsecure, ' ? "t" : "f"')
+          : cookieInsecure
+            ? 't'
+            : 'f',
+        grpcBroadcastAddress: grpcEndpoint,
+        grpcInsecure: graphMode
+          ? Cel.expr<string>(grpcInsecure, ' ? "t" : "f"')
+          : grpcInsecure
+            ? 't'
+            : 'f',
+        env: { SERVER_MSGQUEUE_KIND: 'postgres' },
+      },
+      postgres: { enabled: false },
+      rabbitmq: { enabled: false },
+      api: {
+        replicaCount: apiReplicas,
+        workerTokenJob: { enabled: workerTokenJob },
+      },
+      engine: { replicaCount: engineReplicas },
+      frontend: {
+        enabled: dashboardEnabled,
+        replicaCount: frontendReplicas,
+      },
+      caddy: { enabled: false },
+    };
+    const values = spec.values
+      ? mergeValuesExpression(spec.values, protectedValues)
+      : protectedValues;
+    const release = hatchetHelmRelease({
+      id: 'hatchetRelease',
+      name: spec.name,
+      namespace: targetNamespace,
+      version: chartVersion,
+      repositoryName,
+      repositoryNamespace,
+      repositoryUrl,
+      valuesFrom: [
+        {
+          kind: 'Secret',
+          name: spec.database.connectionSecret.name,
+          valuesKey: spec.database.connectionSecret.key ?? 'uri',
+          targetPath: 'sharedConfig.env.DATABASE_URL',
+        },
+        {
+          kind: 'Secret',
+          name: spec.adminCredentialsSecret.name,
+          valuesKey: spec.adminCredentialsSecret.emailKey ?? 'adminEmail',
+          targetPath: 'sharedConfig.defaultAdminEmail',
+        },
+        {
+          kind: 'Secret',
+          name: spec.adminCredentialsSecret.name,
+          valuesKey: spec.adminCredentialsSecret.passwordKey ?? 'adminPassword',
+          targetPath: 'sharedConfig.defaultAdminPassword',
+        },
+      ],
+      values,
+    });
+    release.dependsOn(repository);
+    if (databaseCredentials && adminCredentials) {
+      release.dependsOn(databaseCredentials);
+      release.dependsOn(adminCredentials);
+    }
+
+    return {
+      ...helmReleaseConditionSummary(release),
+      chartVersion: Cel.expr<string>(
+        'hatchetMetadata.metadata.annotations["typekro.dev/chart-version"]'
+      ),
+      serverVersion: Cel.expr<string>(
+        'hatchetMetadata.metadata.annotations["typekro.dev/server-version"]'
+      ),
+      endpoint: Cel.expr<string>('hatchetMetadata.metadata.annotations["typekro.dev/endpoint"]'),
+      grpcEndpoint: Cel.expr<string>(
+        'hatchetMetadata.metadata.annotations["typekro.dev/grpc-endpoint"]'
+      ),
+      configurationSecret: Cel.expr<string>(
+        'hatchetMetadata.metadata.annotations["typekro.dev/configuration-secret"]'
+      ),
+      workerTokenSecret: Cel.expr<string>(
+        'hatchetMetadata.metadata.annotations["typekro.dev/worker-token-secret"]'
+      ),
+      dashboardEnabled: Cel.expr<boolean>(
+        'hatchetMetadata.metadata.annotations["typekro.dev/dashboard-enabled"] == "true"'
+      ),
+    };
+  },
+  {
+    schemaFieldValidations: {
+      'database.connectionSecret.name': 'size(self) > 0',
+      'database.connectionSecret.key': 'size(self) > 0',
+      'adminCredentialsSecret.name': 'size(self) > 0',
+      'adminCredentialsSecret.emailKey': 'size(self) > 0',
+      'adminCredentialsSecret.passwordKey': 'size(self) > 0',
+    },
+  }
+);
+
+function validateSecretReferences(spec: HatchetInstallationConfig): void {
+  const required = [
+    ['database.connectionSecret.name', spec.database.connectionSecret.name],
+    ['adminCredentialsSecret.name', spec.adminCredentialsSecret.name],
+  ] as const;
+  const optional = [
+    ['database.connectionSecret.key', spec.database.connectionSecret.key],
+    ['adminCredentialsSecret.emailKey', spec.adminCredentialsSecret.emailKey],
+    ['adminCredentialsSecret.passwordKey', spec.adminCredentialsSecret.passwordKey],
+  ] as const;
+  for (const [path, value] of required) {
+    if (value.trim().length === 0) {
+      throw new Error(`Hatchet ${path} must be a non-empty Secret reference.`);
+    }
+  }
+  for (const [path, value] of optional) {
+    if (value !== undefined && value.trim().length === 0) {
+      throw new Error(`Hatchet ${path} must be non-empty when supplied.`);
+    }
+  }
+}

--- a/src/factories/hatchet/compositions/hatchet-installation.ts
+++ b/src/factories/hatchet/compositions/hatchet-installation.ts
@@ -21,6 +21,8 @@ import {
 } from '../types.js';
 
 const DEFAULT_HATCHET_NAMESPACE = 'hatchet-system';
+const HATCHET_CONFIGURATION_SECRET = 'hatchet-config';
+const HATCHET_WORKER_TOKEN_SECRET = 'hatchet-client-config';
 
 /**
  * Install the official Hatchet chart against an externally authoritative
@@ -50,8 +52,10 @@ export const hatchetInstallation = kubernetesComposition(
         )
       : spec.namespaceOwnership !== 'external';
     const repositoryName = graphMode
-      ? Cel.expr<string>('has(schema.spec.repositoryName) ? schema.spec.repositoryName : "hatchet"')
-      : (spec.repositoryName ?? DEFAULT_HATCHET_REPOSITORY_NAME);
+      ? Cel.expr<string>(
+          'has(schema.spec.repositoryName) ? schema.spec.repositoryName : string(schema.spec.name) + "-hatchet"'
+        )
+      : (spec.repositoryName ?? `${spec.name}-${DEFAULT_HATCHET_REPOSITORY_NAME}`);
     const repositoryNamespace = graphMode
       ? Cel.expr<string>(
           'has(schema.spec.repositoryNamespace) ? schema.spec.repositoryNamespace : (has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system")'
@@ -116,11 +120,13 @@ export const hatchetInstallation = kubernetesComposition(
       ? Cel.expr<boolean>('!has(schema.spec.grpcInsecure) || schema.spec.grpcInsecure')
       : (spec.grpcInsecure ?? true);
     const workerTokenSecret = graphMode
-      ? Cel.expr<string>('string(schema.spec.name) + "-client-config"')
-      : `${spec.name}-client-config`;
-    const configurationSecret = graphMode
-      ? Cel.expr<string>('string(schema.spec.name) + "-config"')
-      : `${spec.name}-config`;
+      ? Cel.expr<string>(
+          `(!has(schema.spec.workerTokenJob) || schema.spec.workerTokenJob) ? "${HATCHET_WORKER_TOKEN_SECRET}" : ""`
+        )
+      : workerTokenJob
+        ? HATCHET_WORKER_TOKEN_SECRET
+        : '';
+    const configurationSecret = HATCHET_CONFIGURATION_SECRET;
 
     namespace({
       id: 'hatchetNamespace',
@@ -244,9 +250,7 @@ export const hatchetInstallation = kubernetesComposition(
       },
       caddy: { enabled: false },
     };
-    const values = spec.values
-      ? mergeValuesExpression(spec.values, protectedValues)
-      : protectedValues;
+    const values = mergeHatchetValues(spec.values, protectedValues, graphMode);
     const release = hatchetHelmRelease({
       id: 'hatchetRelease',
       name: spec.name,
@@ -261,18 +265,21 @@ export const hatchetInstallation = kubernetesComposition(
           name: spec.database.connectionSecret.name,
           valuesKey: spec.database.connectionSecret.key ?? 'uri',
           targetPath: 'sharedConfig.env.DATABASE_URL',
+          literal: true,
         },
         {
           kind: 'Secret',
           name: spec.adminCredentialsSecret.name,
           valuesKey: spec.adminCredentialsSecret.emailKey ?? 'adminEmail',
           targetPath: 'sharedConfig.defaultAdminEmail',
+          literal: true,
         },
         {
           kind: 'Secret',
           name: spec.adminCredentialsSecret.name,
           valuesKey: spec.adminCredentialsSecret.passwordKey ?? 'adminPassword',
           targetPath: 'sharedConfig.defaultAdminPassword',
+          literal: true,
         },
       ],
       values,
@@ -337,4 +344,50 @@ function validateSecretReferences(spec: HatchetInstallationConfig): void {
       throw new Error(`Hatchet ${path} must be non-empty when supplied.`);
     }
   }
+}
+
+function mergeHatchetValues(
+  customValues: HatchetInstallationConfig['values'],
+  protectedValues: Record<string, unknown>,
+  graphMode: boolean
+): HatchetInstallationConfig['values'] {
+  if (!customValues) return protectedValues;
+  if (graphMode || !isPlainObject(customValues)) {
+    return mergeValuesExpression(
+      customValues,
+      protectedValues
+    ) as HatchetInstallationConfig['values'];
+  }
+  const merged = cloneValue(customValues);
+  deepMerge(merged, protectedValues);
+  return merged;
+}
+
+function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(source)) {
+    const current = target[key];
+    if (isPlainObject(current) && isPlainObject(value)) {
+      deepMerge(current, value);
+    } else {
+      target[key] = cloneValue(value);
+    }
+  }
+}
+
+function cloneValue<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneValue(item)) as T;
+  }
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [key, cloneValue(nested)])
+    ) as T;
+  }
+  return value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }

--- a/src/factories/hatchet/compositions/hatchet-installation.ts
+++ b/src/factories/hatchet/compositions/hatchet-installation.ts
@@ -21,6 +21,7 @@ import {
 } from '../types.js';
 
 const DEFAULT_HATCHET_NAMESPACE = 'hatchet-system';
+const HATCHET_RELEASE_NAME = 'hatchet';
 const HATCHET_CONFIGURATION_SECRET = 'hatchet-config';
 const HATCHET_WORKER_TOKEN_SECRET = 'hatchet-client-config';
 
@@ -53,10 +54,10 @@ export const hatchetInstallation = kubernetesComposition(
       : spec.namespaceOwnership !== 'external';
     const repositoryName = graphMode
       ? Cel.expr<string>(
-          'has(schema.spec.repositoryName) ? schema.spec.repositoryName : string(size(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system")) + "-" + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + "-" + string(schema.spec.name) + "-hatchet"'
+          `has(schema.spec.repositoryName) ? schema.spec.repositoryName : string(size(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system")) + "-" + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + "-${HATCHET_RELEASE_NAME}-hatchet"`
         )
       : (spec.repositoryName ??
-        `${targetNamespace.length}-${targetNamespace}-${spec.name}-${DEFAULT_HATCHET_REPOSITORY_NAME}`);
+        `${targetNamespace.length}-${targetNamespace}-${HATCHET_RELEASE_NAME}-${DEFAULT_HATCHET_REPOSITORY_NAME}`);
     const repositoryNamespace = graphMode
       ? Cel.expr<string>(
           'has(schema.spec.repositoryNamespace) ? schema.spec.repositoryNamespace : (has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system")'
@@ -101,19 +102,19 @@ export const hatchetInstallation = kubernetesComposition(
       : (spec.workerTokenJob ?? true);
     const endpoint = graphMode
       ? Cel.expr<string>(
-          'has(schema.spec.serverUrl) ? schema.spec.serverUrl : "http://" + string(schema.spec.name) + "-api." + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + ".svc:8080"'
+          `has(schema.spec.serverUrl) ? schema.spec.serverUrl : "http://${HATCHET_RELEASE_NAME}-api." + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + ".svc:8080"`
         )
-      : (spec.serverUrl ?? `http://${spec.name}-api.${targetNamespace}.svc:8080`);
+      : (spec.serverUrl ?? `http://${HATCHET_RELEASE_NAME}-api.${targetNamespace}.svc:8080`);
     const grpcEndpoint = graphMode
       ? Cel.expr<string>(
-          'has(schema.spec.grpcBroadcastAddress) ? schema.spec.grpcBroadcastAddress : string(schema.spec.name) + "-engine." + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + ".svc:7070"'
+          `has(schema.spec.grpcBroadcastAddress) ? schema.spec.grpcBroadcastAddress : "${HATCHET_RELEASE_NAME}-engine." + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + ".svc:7070"`
         )
-      : (spec.grpcBroadcastAddress ?? `${spec.name}-engine.${targetNamespace}.svc:7070`);
+      : (spec.grpcBroadcastAddress ?? `${HATCHET_RELEASE_NAME}-engine.${targetNamespace}.svc:7070`);
     const cookieDomain = graphMode
       ? Cel.expr<string>(
-          'has(schema.spec.cookieDomain) ? schema.spec.cookieDomain : string(schema.spec.name) + "-api." + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + ".svc"'
+          `has(schema.spec.cookieDomain) ? schema.spec.cookieDomain : "${HATCHET_RELEASE_NAME}-api." + string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + ".svc"`
         )
-      : (spec.cookieDomain ?? `${spec.name}-api.${targetNamespace}.svc`);
+      : (spec.cookieDomain ?? `${HATCHET_RELEASE_NAME}-api.${targetNamespace}.svc`);
     const cookieInsecure = graphMode
       ? Cel.expr<boolean>('!has(schema.spec.cookieInsecure) || schema.spec.cookieInsecure')
       : (spec.cookieInsecure ?? true);
@@ -128,9 +129,7 @@ export const hatchetInstallation = kubernetesComposition(
         ? HATCHET_WORKER_TOKEN_SECRET
         : '';
     const configurationSecret = HATCHET_CONFIGURATION_SECRET;
-    const sharedConfigSecret = graphMode
-      ? Cel.expr<string>('string(schema.spec.name) + "-shared-config"')
-      : `${spec.name}-shared-config`;
+    const sharedConfigSecret = `${HATCHET_RELEASE_NAME}-shared-config`;
     const externalEnvironment = [
       { secretRef: { name: sharedConfigSecret } },
       { secretRef: { name: spec.database.connectionSecret.name } },
@@ -264,7 +263,7 @@ export const hatchetInstallation = kubernetesComposition(
     const values = mergeHatchetValues(spec.values, protectedValues, graphMode);
     const release = hatchetHelmRelease({
       id: 'hatchetRelease',
-      name: spec.name,
+      name: HATCHET_RELEASE_NAME,
       namespace: targetNamespace,
       version: chartVersion,
       repositoryName,
@@ -303,6 +302,7 @@ export const hatchetInstallation = kubernetesComposition(
   },
   {
     schemaFieldValidations: {
+      name: 'size(self) > 0',
       'database.connectionSecret.name': 'size(self) > 0',
       'adminCredentialsSecret.name': 'size(self) > 0',
     },

--- a/src/factories/hatchet/compositions/index.ts
+++ b/src/factories/hatchet/compositions/index.ts
@@ -1,0 +1,1 @@
+export * from './hatchet-installation.js';

--- a/src/factories/hatchet/index.ts
+++ b/src/factories/hatchet/index.ts
@@ -1,0 +1,4 @@
+/** Official Hatchet durable-workflow platform integration for TypeKro. */
+export * from './compositions/index.js';
+export * from './resources/index.js';
+export * from './types.js';

--- a/src/factories/hatchet/resources/helm.ts
+++ b/src/factories/hatchet/resources/helm.ts
@@ -1,0 +1,69 @@
+import type { Composable, Enhanced } from '../../../core/types/index.js';
+import { helmRelease } from '../../helm/helm-release.js';
+import {
+  createHelmRepositoryReadinessEvaluator,
+  type HelmRepositorySpec,
+  type HelmRepositoryStatus,
+  helmRepository,
+} from '../../helm/helm-repository.js';
+import { createLabeledHelmReleaseEvaluator } from '../../helm/readiness-evaluators.js';
+import type { HelmReleaseSpec, HelmReleaseStatus } from '../../helm/types.js';
+import type { HatchetHelmReleaseConfig, HatchetHelmRepositoryConfig } from '../types.js';
+
+export const DEFAULT_HATCHET_REPOSITORY_URL = 'https://hatchet-dev.github.io/hatchet-charts';
+export const DEFAULT_HATCHET_REPOSITORY_NAME = 'hatchet';
+export const HATCHET_CHART_NAME = 'hatchet-stack';
+export const DEFAULT_HATCHET_CHART_VERSION = '0.13.3';
+export const DEFAULT_HATCHET_SERVER_VERSION = 'v0.94.10';
+
+export function hatchetHelmRepository(
+  config: Composable<HatchetHelmRepositoryConfig>
+): Enhanced<HelmRepositorySpec, HelmRepositoryStatus> {
+  return helmRepository({
+    name: config.name ?? DEFAULT_HATCHET_REPOSITORY_NAME,
+    namespace: config.namespace ?? 'flux-system',
+    url: config.url ?? DEFAULT_HATCHET_REPOSITORY_URL,
+    interval: config.interval ?? '5m',
+    ...(config.id && { id: config.id }),
+  }).withReadinessEvaluator(createHelmRepositoryReadinessEvaluator('Hatchet')) as Enhanced<
+    HelmRepositorySpec,
+    HelmRepositoryStatus
+  >;
+}
+
+export function hatchetHelmRelease(
+  config: Composable<HatchetHelmReleaseConfig>
+): Enhanced<HelmReleaseSpec, HelmReleaseStatus> {
+  return helmRelease({
+    name: config.name,
+    namespace: config.namespace ?? 'hatchet-system',
+    chart: {
+      repository: config.repositoryUrl ?? DEFAULT_HATCHET_REPOSITORY_URL,
+      name: HATCHET_CHART_NAME,
+      version: config.version ?? DEFAULT_HATCHET_CHART_VERSION,
+    },
+    sourceRef: {
+      name: config.repositoryName ?? DEFAULT_HATCHET_REPOSITORY_NAME,
+      namespace: config.repositoryNamespace ?? config.namespace ?? 'hatchet-system',
+      kind: 'HelmRepository',
+    },
+    driftDetection: { mode: 'enabled' },
+    install: {
+      timeout: '20m',
+      remediation: { retries: 3, remediateLastFailure: true },
+    },
+    // Hatchet upgrades may commit PostgreSQL migrations. Retry the desired
+    // revision, but never automatically roll back to an older server after a
+    // migration has succeeded.
+    upgrade: {
+      timeout: '20m',
+      remediation: { retries: 0, remediateLastFailure: false },
+    },
+    ...(config.valuesFrom && { valuesFrom: config.valuesFrom }),
+    values: config.values ?? {},
+    ...(config.id && { id: config.id }),
+  }).withReadinessEvaluator(createLabeledHelmReleaseEvaluator('Hatchet')) as Enhanced<
+    HelmReleaseSpec,
+    HelmReleaseStatus
+  >;
+}

--- a/src/factories/hatchet/resources/index.ts
+++ b/src/factories/hatchet/resources/index.ts
@@ -1,0 +1,1 @@
+export * from './helm.js';

--- a/src/factories/hatchet/types.ts
+++ b/src/factories/hatchet/types.ts
@@ -6,6 +6,15 @@ const externalSecretShape = {
 } as const;
 
 /**
+ * The value is used as both the KRO instance name and as the prefix of
+ * `<name>-typekro-metadata`. Reserving the suffix keeps every generated
+ * Kubernetes name within the DNS-1123 label limit.
+ */
+const HatchetInstanceNameSchema = type(
+  /^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$/,
+).and('string <= 46');
+
+/**
  * External PostgreSQL authority consumed by Hatchet.
  *
  * The referenced Secret must live in the Hatchet namespace and contain a
@@ -21,7 +30,7 @@ export const HatchetInstallationConfigSchema = type({
    * internal name `hatchet` because its recovery Secret names are
    * namespace-global.
    */
-  name: 'string > 0',
+  name: HatchetInstanceNameSchema,
   'namespace?': 'string',
   'namespaceOwnership?': '"owned" | "external"',
   'chartVersion?': 'string',

--- a/src/factories/hatchet/types.ts
+++ b/src/factories/hatchet/types.ts
@@ -16,7 +16,7 @@ const externalDatabaseShape = {
 } as const;
 
 export const HatchetInstallationConfigSchema = type({
-  name: 'string',
+  name: '"hatchet"',
   'namespace?': 'string',
   'namespaceOwnership?': '"owned" | "external"',
   'chartVersion?': 'string',
@@ -79,7 +79,6 @@ export interface HatchetValuesFromSource {
   name: string;
   valuesKey?: string;
   targetPath?: string;
-  literal?: boolean;
   optional?: boolean;
 }
 
@@ -96,7 +95,6 @@ export const HatchetHelmReleaseConfigSchema = type({
     name: 'string',
     'valuesKey?': 'string',
     'targetPath?': 'string',
-    'literal?': 'boolean',
     'optional?': 'boolean',
   }).array(),
   'id?': 'string',

--- a/src/factories/hatchet/types.ts
+++ b/src/factories/hatchet/types.ts
@@ -1,0 +1,115 @@
+import { type } from 'arktype';
+import type { TypeKroChartValue } from '../../core/types/common.js';
+
+const secretValueRefShape = {
+  name: 'string',
+  'key?': 'string',
+} as const;
+
+/**
+ * External PostgreSQL authority consumed by Hatchet.
+ *
+ * The referenced Secret must live in the Hatchet namespace. Its value is a
+ * complete PostgreSQL URI and remains outside the ResourceGraphDefinition.
+ */
+const externalDatabaseShape = {
+  connectionSecret: secretValueRefShape,
+} as const;
+
+const adminCredentialsShape = {
+  name: 'string',
+  'emailKey?': 'string',
+  'passwordKey?': 'string',
+} as const;
+
+export const HatchetInstallationConfigSchema = type({
+  name: 'string',
+  'namespace?': 'string',
+  'namespaceOwnership?': '"owned" | "external"',
+  'chartVersion?': 'string',
+  'serverVersion?': 'string',
+  'repositoryName?': 'string',
+  'repositoryNamespace?': 'string',
+  'repositoryNamespaceOwnership?': '"owned" | "external"',
+  'repositoryUrl?': 'string',
+  database: externalDatabaseShape,
+  adminCredentialsSecret: adminCredentialsShape,
+  'replicas?': {
+    'api?': 'number.integer >= 1',
+    'engine?': 'number.integer >= 1',
+    'frontend?': 'number.integer >= 1',
+  },
+  'dashboard?': 'boolean',
+  'serverUrl?': 'string',
+  'cookieDomain?': 'string',
+  'cookieInsecure?': 'boolean',
+  'grpcBroadcastAddress?': 'string',
+  'grpcInsecure?': 'boolean',
+  'workerTokenJob?': 'boolean',
+  'values?': 'Record<string, unknown>',
+});
+
+export type HatchetInstallationConfig = Omit<
+  typeof HatchetInstallationConfigSchema.infer,
+  'values'
+> & {
+  values?: TypeKroChartValue<Record<string, unknown>>;
+};
+
+export const HatchetInstallationStatusSchema = type({
+  ready: 'boolean',
+  failed: 'boolean',
+  phase: '"Installing" | "Ready" | "Failed"',
+  chartVersion: 'string',
+  serverVersion: 'string',
+  endpoint: 'string',
+  grpcEndpoint: 'string',
+  configurationSecret: 'string',
+  workerTokenSecret: 'string',
+  dashboardEnabled: 'boolean',
+});
+
+export type HatchetInstallationStatus = typeof HatchetInstallationStatusSchema.infer;
+
+export const HatchetHelmRepositoryConfigSchema = type({
+  'name?': 'string',
+  'namespace?': 'string',
+  'url?': 'string',
+  'interval?': 'string',
+  'id?': 'string',
+});
+
+export type HatchetHelmRepositoryConfig = typeof HatchetHelmRepositoryConfigSchema.infer;
+
+export interface HatchetValuesFromSource {
+  kind: 'Secret' | 'ConfigMap';
+  name: string;
+  valuesKey?: string;
+  targetPath?: string;
+  optional?: boolean;
+}
+
+export const HatchetHelmReleaseConfigSchema = type({
+  name: 'string',
+  'namespace?': 'string',
+  'version?': 'string',
+  'repositoryName?': 'string',
+  'repositoryNamespace?': 'string',
+  'repositoryUrl?': 'string',
+  'values?': 'Record<string, unknown>',
+  'valuesFrom?': type({
+    kind: '"Secret" | "ConfigMap"',
+    name: 'string',
+    'valuesKey?': 'string',
+    'targetPath?': 'string',
+    'optional?': 'boolean',
+  }).array(),
+  'id?': 'string',
+});
+
+export type HatchetHelmReleaseConfig = Omit<
+  typeof HatchetHelmReleaseConfigSchema.infer,
+  'values'
+> & {
+  values?: TypeKroChartValue<Record<string, unknown>>;
+};

--- a/src/factories/hatchet/types.ts
+++ b/src/factories/hatchet/types.ts
@@ -1,25 +1,18 @@
 import { type } from 'arktype';
 import type { TypeKroChartValue } from '../../core/types/common.js';
 
-const secretValueRefShape = {
+const externalSecretShape = {
   name: 'string',
-  'key?': 'string',
 } as const;
 
 /**
  * External PostgreSQL authority consumed by Hatchet.
  *
- * The referenced Secret must live in the Hatchet namespace. Its value is a
- * complete PostgreSQL URI and remains outside the ResourceGraphDefinition.
+ * The referenced Secret must live in the Hatchet namespace and contain a
+ * `DATABASE_URL` key. It remains outside the ResourceGraphDefinition.
  */
 const externalDatabaseShape = {
-  connectionSecret: secretValueRefShape,
-} as const;
-
-const adminCredentialsShape = {
-  name: 'string',
-  'emailKey?': 'string',
-  'passwordKey?': 'string',
+  connectionSecret: externalSecretShape,
 } as const;
 
 export const HatchetInstallationConfigSchema = type({
@@ -33,7 +26,7 @@ export const HatchetInstallationConfigSchema = type({
   'repositoryNamespaceOwnership?': '"owned" | "external"',
   'repositoryUrl?': 'string',
   database: externalDatabaseShape,
-  adminCredentialsSecret: adminCredentialsShape,
+  adminCredentialsSecret: externalSecretShape,
   'replicas?': {
     'api?': 'number.integer >= 1',
     'engine?': 'number.integer >= 1',

--- a/src/factories/hatchet/types.ts
+++ b/src/factories/hatchet/types.ts
@@ -16,7 +16,12 @@ const externalDatabaseShape = {
 } as const;
 
 export const HatchetInstallationConfigSchema = type({
-  name: '"hatchet"',
+  /**
+   * TypeKro instance identity. The upstream Helm release remains the fixed
+   * internal name `hatchet` because its recovery Secret names are
+   * namespace-global.
+   */
+  name: 'string > 0',
   'namespace?': 'string',
   'namespaceOwnership?': '"owned" | "external"',
   'chartVersion?': 'string',

--- a/src/factories/hatchet/types.ts
+++ b/src/factories/hatchet/types.ts
@@ -86,6 +86,7 @@ export interface HatchetValuesFromSource {
   name: string;
   valuesKey?: string;
   targetPath?: string;
+  literal?: boolean;
   optional?: boolean;
 }
 
@@ -102,6 +103,7 @@ export const HatchetHelmReleaseConfigSchema = type({
     name: 'string',
     'valuesKey?': 'string',
     'targetPath?': 'string',
+    'literal?': 'boolean',
     'optional?': 'boolean',
   }).array(),
   'id?': 'string',

--- a/src/factories/helm/helm-release.ts
+++ b/src/factories/helm/helm-release.ts
@@ -137,6 +137,17 @@ export interface HelmReleaseConfig<TValues extends object = TypeKroValueTreeObje
 export function helmRelease<TValues extends object = TypeKroValueTreeObject>(
   config: HelmReleaseConfig<TValues>
 ): Enhanced<HelmReleaseSpec<TValues>, HelmReleaseStatus> {
+  if (
+    Array.isArray(config.valuesFrom) &&
+    config.valuesFrom.some(
+      (source) => typeof source === 'object' && source !== null && Object.hasOwn(source, 'literal')
+    )
+  ) {
+    throw new Error(
+      "HelmRelease valuesFrom.literal requires Flux 2.9, but TypeKro's managed Flux baseline is 2.7.5. Remove literal or manage a compatible Flux runtime explicitly."
+    );
+  }
+
   // Determine sourceRef — use explicit config or auto-detect from repository URL
   let sourceRefName: string;
   let sourceRefNamespace: string;

--- a/src/factories/helm/helm-release.ts
+++ b/src/factories/helm/helm-release.ts
@@ -3,14 +3,22 @@ import {
   WELL_KNOWN_HELM_REPOSITORIES,
 } from '../../core/config/defaults.js';
 import { getComponentLogger } from '../../core/logging/index.js';
+import type {
+  TypeKroChartValue,
+  TypeKroValue,
+  TypeKroValueTreeObject,
+} from '../../core/types/common.js';
 import type { Enhanced } from '../../core/types/index.js';
-import type { TypeKroChartValue, TypeKroValueTreeObject } from '../../core/types/common.js';
 import { createResource } from '../shared.js';
 import { helmReleaseReadinessEvaluator } from './readiness-evaluators.js';
-import type { HelmReleaseSpec, HelmReleaseStatus } from './types.js';
+import type { HelmReleaseSpec, HelmReleaseStatus, HelmReleaseValuesFromSource } from './types.js';
 
-type HelmReleaseAuthoringSpec<TValues extends object> = Omit<HelmReleaseSpec<TValues>, 'values'> & {
+type HelmReleaseAuthoringSpec<TValues extends object> = Omit<
+  HelmReleaseSpec<TValues>,
+  'values' | 'valuesFrom'
+> & {
   values?: TypeKroChartValue<TValues>;
+  valuesFrom?: TypeKroValue<HelmReleaseValuesFromSource>[];
 };
 
 export interface HelmReleaseConfig<TValues extends object = TypeKroValueTreeObject> {
@@ -40,6 +48,11 @@ export interface HelmReleaseConfig<TValues extends object = TypeKroValueTreeObje
    * mixed-template strings, arrays, and plain objects recursively.
    */
   values?: TypeKroChartValue<TValues>;
+  /**
+   * Flux values sources. Each field remains graph-aware, so a Secret or
+   * ConfigMap created in the same composition can supply its generated name.
+   */
+  valuesFrom?: TypeKroValue<HelmReleaseValuesFromSource>[];
   /**
    * Flux install policy. The supplied fields override TypeKro's bounded retry
    * defaults; nested remediation fields are merged rather than replaced.
@@ -212,6 +225,7 @@ export function helmRelease<TValues extends object = TypeKroValueTreeObject>(
         },
       },
       ...(config.driftDetection && { driftDetection: config.driftDetection }),
+      ...(config.valuesFrom && { valuesFrom: config.valuesFrom }),
       ...(config.values && { values: config.values }),
     },
   }).withReadinessEvaluator(helmReleaseReadinessEvaluator) as Enhanced<

--- a/src/factories/helm/index.ts
+++ b/src/factories/helm/index.ts
@@ -32,4 +32,8 @@ export type { HelmReleaseConditionSummary, HelmReleasePhase } from './status.js'
 export { helmReleaseConditionSummary } from './status.js';
 
 // types.ts
-export type { HelmReleaseSpec, HelmReleaseStatus } from './types.js';
+export type {
+  HelmReleaseSpec,
+  HelmReleaseStatus,
+  HelmReleaseValuesFromSource,
+} from './types.js';

--- a/src/factories/helm/readiness-evaluators.ts
+++ b/src/factories/helm/readiness-evaluators.ts
@@ -94,15 +94,19 @@ export function createLabeledHelmReleaseEvaluator(label?: string): ReadinessEval
         typeof desiredGeneration === 'number'
           ? observedGenerations.filter((generation) => generation < desiredGeneration)
           : [];
-      if (typeof desiredGeneration === 'number' && staleGenerations.length > 0) {
+      if (
+        typeof desiredGeneration === 'number' &&
+        (observedGenerations.length === 0 || staleGenerations.length > 0)
+      ) {
         return {
           ready: false,
           reason: 'GenerationNotObserved',
           message: `${prefix}HelmRelease has not observed generation ${desiredGeneration} yet`,
           details: {
             desiredGeneration,
-            observedGeneration:
-              staleGenerations.length > 0 ? Math.max(...staleGenerations) : undefined,
+            ...(observedGenerations.length > 0
+              ? { observedGeneration: Math.max(...observedGenerations) }
+              : {}),
           },
         };
       }

--- a/src/factories/helm/types.ts
+++ b/src/factories/helm/types.ts
@@ -10,6 +10,12 @@ export interface HelmReleaseValuesFromSource {
   valuesKey?: string;
   /** Helm values path receiving the source value. */
   targetPath?: string;
+  /**
+   * Preserve the referenced bytes verbatim instead of interpreting Helm
+   * `--set` syntax. Requires Flux 2.9 or newer and has effect only with
+   * `targetPath`.
+   */
+  literal?: boolean;
   /** Allow reconciliation to continue when the source object or key is absent. */
   optional?: boolean;
 }

--- a/src/factories/helm/types.ts
+++ b/src/factories/helm/types.ts
@@ -1,5 +1,19 @@
 import type { TypeKroChartValues } from '../../core/types/common.js';
 
+/** A Flux HelmRelease values source. */
+export interface HelmReleaseValuesFromSource {
+  /** Kubernetes object kind containing the source value. */
+  kind: 'Secret' | 'ConfigMap';
+  /** Name of the source object in the HelmRelease namespace. */
+  name: string;
+  /** Source key. Defaults to `values.yaml` when `targetPath` is omitted. */
+  valuesKey?: string;
+  /** Helm values path receiving the source value. */
+  targetPath?: string;
+  /** Allow reconciliation to continue when the source object or key is absent. */
+  optional?: boolean;
+}
+
 // Helm Release Resource Types
 export interface HelmReleaseSpec<TValues extends object = Record<string, unknown>> {
   interval?: string;
@@ -20,6 +34,8 @@ export interface HelmReleaseSpec<TValues extends object = Record<string, unknown
    * mixed templates, arrays, and plain objects are serialized recursively.
    */
   values?: TypeKroChartValues<TValues>;
+  /** Values loaded from Secrets or ConfigMaps by Flux. */
+  valuesFrom?: HelmReleaseValuesFromSource[];
   targetNamespace?: string;
   install?: {
     createNamespace?: boolean;

--- a/src/factories/helm/types.ts
+++ b/src/factories/helm/types.ts
@@ -11,11 +11,10 @@ export interface HelmReleaseValuesFromSource {
   /** Helm values path receiving the source value. */
   targetPath?: string;
   /**
-   * Preserve the referenced bytes verbatim instead of interpreting Helm
-   * `--set` syntax. Requires Flux 2.9 or newer and has effect only with
-   * `targetPath`.
+   * Values projected through targetPath follow the Helm Controller baseline's
+   * `--set` parsing semantics. TypeKro does not expose Flux 2.9's `literal`
+   * field while its managed runtime remains on Flux 2.7.5.
    */
-  literal?: boolean;
   /** Allow reconciliation to continue when the source object or key is absent. */
   optional?: boolean;
 }

--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -34,12 +34,17 @@ export * from './flux/index.js';
 // HARBOR REGISTRY ECOSYSTEM
 // =============================================================================
 export * as harbor from './harbor/index.js';
+// =============================================================================
+// HATCHET DURABLE WORKFLOW ECOSYSTEM
+// =============================================================================
+export * as hatchet from './hatchet/index.js';
 export type {
   HelmReleaseConditionSummary,
   HelmReleaseConfig,
   HelmReleasePhase,
   HelmReleaseSpec,
   HelmReleaseStatus,
+  HelmReleaseValuesFromSource,
   HelmRepositoryConfig,
   HelmRepositorySpec,
   HelmRepositoryStatus,

--- a/test/core/planning/compiler.test.ts
+++ b/test/core/planning/compiler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
 import { getReadinessEvaluator, getResourceId } from '../../../src/core/metadata/index.js';
 import { resolvePortableReadinessStrategy } from '../../../src/core/readiness/index.js';
+import { Cel } from '../../../src/core/references/cel.js';
 import {
   artifactOutput,
   canonicalDigest,
@@ -255,6 +256,58 @@ describe('semantic artifact compilers', () => {
     expect(getReadinessEvaluator(manifest)?.(manifest)).toEqual({
       ready: true,
       message: 'ConfigMap is ready (configuration resource)',
+    });
+  });
+
+  it('evaluates CEL-derived external-reference namespaces in direct artifacts', () => {
+    const composition = kubernetesComposition(
+      {
+        name: 'external-reference-namespace',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'ExternalReferenceNamespace',
+        spec: type({ name: 'string', 'namespace?': 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        externalRef<Record<string, never>, Record<string, never>>({
+          apiVersion: 'v1',
+          kind: 'Secret',
+          metadata: {
+            name: spec.name,
+            namespace: Cel.expr<string>(
+              'has(schema.spec.namespace) ? schema.spec.namespace : "fallback"'
+            ),
+          },
+          id: 'credentials',
+        });
+        return { ready: true };
+      }
+    );
+    const spec = { name: 'credentials', namespace: 'workloads' };
+    const artifacts = compileDirectArtifactPlan(composition.plan!(spec, { strict: true }));
+    const graph = directArtifactPlanToResourceGraph(artifacts, {
+      instanceName: 'credentials',
+      spec,
+      resolveReadinessStrategy: resolvePortableReadinessStrategy,
+    });
+
+    expect(graph.externalReferences?.[0]?.manifest.metadata).toMatchObject({
+      name: 'credentials',
+      namespace: 'workloads',
+    });
+
+    const fallbackSpec = { name: 'credentials' };
+    const fallbackArtifacts = compileDirectArtifactPlan(
+      composition.plan!(fallbackSpec, { strict: true })
+    );
+    const fallbackGraph = directArtifactPlanToResourceGraph(fallbackArtifacts, {
+      instanceName: 'credentials',
+      spec: fallbackSpec,
+      resolveReadinessStrategy: resolvePortableReadinessStrategy,
+    });
+    expect(fallbackGraph.externalReferences?.[0]?.manifest.metadata).toMatchObject({
+      name: 'credentials',
+      namespace: 'fallback',
     });
   });
 

--- a/test/core/serialization/string-patterns.test.ts
+++ b/test/core/serialization/string-patterns.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+import { type, type Type } from 'arktype';
+
+import { kubernetesComposition, simple } from '../../../src/index.js';
+
+describe('KRO string pattern serialization', () => {
+  it('preserves compatible RE2 patterns and string length constraints', () => {
+    const schema = type(/^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$/).and(
+      'string <= 46',
+    );
+
+    expect(rgd(schema)).toContain(
+      'name: string | maxLength=46 pattern="^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$"'
+    );
+  });
+
+  it('escapes backslashes and quotes for the KRO SimpleSchema string', () => {
+    expect(rgd(type(/^[a-z]+\.example$/))).toContain(
+      'pattern="^[a-z]+\\\\.example$"'
+    );
+    expect(rgd(type(/^"quoted"$/))).toContain(
+      'pattern="^\\"quoted\\"$"'
+    );
+  });
+
+  it('fails closed for intersecting patterns that KRO cannot preserve as one marker', () => {
+    const intersection = type(/^[a-z]+$/).and(/^[^x]+$/);
+
+    expect(() => rgd(intersection)).toThrow(
+      /supports one string pattern per field/,
+    );
+  });
+
+  it('fails before emission for JavaScript lookarounds unsupported by Kubernetes RE2', () => {
+    for (const pattern of [
+      /^(?!foo)[a-z]+$/,
+      /^(?=foo)[a-z]+$/,
+      /(?<=foo)bar/,
+      /(?<!foo)bar/,
+    ]) {
+      expect(() => rgd(type(pattern))).toThrow(
+        /Kubernetes RE2 validation does not support/,
+      );
+    }
+  });
+
+  it('fails before emission for numeric and named backreferences', () => {
+    for (const pattern of [/^(a)\1$/, /^(?<value>a)\k<value>$/]) {
+      expect(() => rgd(type(pattern))).toThrow(
+        /backreference.*Kubernetes RE2 validation does not support/,
+      );
+    }
+  });
+});
+
+function rgd(nameSchema: Type<string>): string {
+  return kubernetesComposition(
+    {
+      name: 'string-pattern-test',
+      kind: 'StringPatternTest',
+      spec: type({ name: nameSchema }),
+      status: type({ ready: 'boolean' }),
+    },
+    (spec) => {
+      simple.ConfigMap({
+        id: 'metadata',
+        name: spec.name,
+        data: { name: spec.name },
+      });
+      return { ready: true };
+    },
+  ).factory('kro').toYaml();
+}

--- a/test/core/serialization/string-patterns.test.ts
+++ b/test/core/serialization/string-patterns.test.ts
@@ -39,7 +39,7 @@ describe('KRO string pattern serialization', () => {
       /(?<!foo)bar/,
     ]) {
       expect(() => rgd(type(pattern))).toThrow(
-        /Kubernetes RE2 validation does not support/,
+        /not compatible with Kubernetes RE2 validation/,
       );
     }
   });
@@ -47,9 +47,29 @@ describe('KRO string pattern serialization', () => {
   it('fails before emission for numeric and named backreferences', () => {
     for (const pattern of [/^(a)\1$/, /^(?<value>a)\k<value>$/]) {
       expect(() => rgd(type(pattern))).toThrow(
-        /backreference.*Kubernetes RE2 validation does not support/,
+        /not compatible with Kubernetes RE2 validation/,
       );
     }
+  });
+
+  it('fails before emission for JavaScript escapes rejected by Kubernetes RE2', () => {
+    expect(() => rgd(type(/^\u0061$/))).toThrow(
+      /invalid escape sequence.*\\u/,
+    );
+  });
+
+  it('fails closed for flagged ArkType patterns instead of discarding them', () => {
+    expect(() => rgd(type(/foo/i))).toThrow(
+      /uses JavaScript flags "i".*cannot preserve/,
+    );
+  });
+
+  it('preserves constraints on array elements and on the array itself', () => {
+    const schema = type({ names: 'string > 0[] > 0' });
+
+    expect(rgdObject(schema)).toContain(
+      "names: '[]string | minLength=1 | minItems=1'",
+    );
   });
 });
 
@@ -69,5 +89,17 @@ function rgd(nameSchema: Type<string>): string {
       });
       return { ready: true };
     },
+  ).factory('kro').toYaml();
+}
+
+function rgdObject(schema: Type<object>): string {
+  return kubernetesComposition(
+    {
+      name: 'string-pattern-object-test',
+      kind: 'StringPatternObjectTest',
+      spec: schema,
+      status: type({ ready: 'boolean' }),
+    },
+    () => ({ ready: true }),
   ).factory('kro').toYaml();
 }

--- a/test/factories/hatchet/factory-modes.test.ts
+++ b/test/factories/hatchet/factory-modes.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'bun:test';
+import { hatchetInstallation } from '../../../src/factories/hatchet/compositions/hatchet-installation.js';
+import {
+  DEFAULT_HATCHET_CHART_VERSION,
+  DEFAULT_HATCHET_SERVER_VERSION,
+} from '../../../src/factories/hatchet/resources/helm.js';
+
+function documents(yaml: string): string[] {
+  return yaml
+    .split(/^---$/m)
+    .map((document) => document.trim())
+    .filter(Boolean);
+}
+
+function kind(document: string): string | undefined {
+  return document.match(/^kind: (.+)$/m)?.[1];
+}
+
+const requiredConfig = {
+  name: 'hatchet',
+  namespace: 'workflow-system',
+  database: {
+    connectionSecret: { name: 'hatchet-db-app', key: 'uri' },
+  },
+  adminCredentialsSecret: {
+    name: 'hatchet-admin',
+    emailKey: 'email',
+    passwordKey: 'password',
+  },
+} as const;
+
+describe('Hatchet installation', () => {
+  it('emits the official chart with external state and Secret-backed values', () => {
+    const yaml = hatchetInstallation.factory('direct', { namespace: 'typekro-system' }).toYaml({
+      ...requiredConfig,
+      replicas: { api: 2, engine: 3, frontend: 2 },
+      values: {
+        api: { resources: { requests: { cpu: '250m' } } },
+        postgres: { enabled: true },
+        rabbitmq: { enabled: true },
+      },
+    });
+    const docs = documents(yaml);
+
+    expect(docs.map(kind)).toContain('Namespace');
+    expect(docs.map(kind)).toContain('HelmRepository');
+    expect(docs.map(kind)).toContain('HelmRelease');
+    expect(docs.map(kind)).not.toContain('Secret');
+    expect(yaml).toContain('url: https://hatchet-dev.github.io/hatchet-charts');
+    expect(yaml).toContain('chart: hatchet-stack');
+    expect(yaml).toContain(`version: ${DEFAULT_HATCHET_CHART_VERSION}`);
+    expect(yaml).toContain(`tag: ${DEFAULT_HATCHET_SERVER_VERSION}`);
+    expect(yaml).toContain('valuesFrom:');
+    expect(yaml).toContain('name: hatchet-db-app');
+    expect(yaml).toContain('valuesKey: uri');
+    expect(yaml).toContain('targetPath: sharedConfig.env.DATABASE_URL');
+    expect(yaml).toContain('name: hatchet-admin');
+    expect(yaml).toContain('valuesKey: email');
+    expect(yaml).toContain('valuesKey: password');
+    expect(yaml).toMatch(/postgres:\s*\n\s+enabled: false/);
+    expect(yaml).toMatch(/rabbitmq:\s*\n\s+enabled: false/);
+    expect(yaml).toMatch(/api:\s*\n(?:.*\n)*?\s+replicaCount: 2/);
+    expect(yaml).toMatch(/engine:\s*\n\s+replicaCount: 3/);
+    expect(yaml).toContain('cpu: 250m');
+    expect(yaml).toMatch(/workerTokenJob:\s*\n\s+enabled: true/);
+    expect(yaml).toContain('remediateLastFailure: false');
+    expect(yaml).not.toContain('rollback');
+  });
+
+  it('supports externally owned workload and repository namespaces', () => {
+    const yaml = hatchetInstallation.factory('direct', { namespace: 'typekro-system' }).toYaml({
+      ...requiredConfig,
+      namespaceOwnership: 'external',
+      repositoryNamespace: 'flux-system',
+      repositoryNamespaceOwnership: 'external',
+    });
+
+    expect(documents(yaml).map(kind)).not.toContain('Namespace');
+    expect(yaml).toContain('namespace: workflow-system');
+    expect(yaml).toContain('namespace: flux-system');
+  });
+
+  it('serializes the complete contract in KRO mode without embedding credentials', () => {
+    const factory = hatchetInstallation.factory('kro', {
+      namespace: 'typekro-system',
+    });
+    const rgd = factory.toYaml();
+
+    expect(rgd).toContain('kind: ResourceGraphDefinition');
+    expect(rgd).toContain('kind: HelmRelease');
+    expect(rgd).toContain('kind: HelmRepository');
+    expect(rgd).toContain('externalRef:');
+    expect(rgd).toContain('kind: Secret');
+    expect(rgd).toContain('${schema.spec.database.connectionSecret.name}');
+    expect(rgd).toContain('${schema.spec.adminCredentialsSecret.name}');
+    expect(rgd).toContain('valuesFrom:');
+    expect(rgd).toContain('targetPath: sharedConfig.env.DATABASE_URL');
+    expect(rgd).toContain('schema.spec.replicas.api');
+    expect(rgd).toContain('schema.spec.replicas.engine');
+    expect(rgd).toContain('postgres');
+    expect(rgd).toContain('rabbitmq');
+    expect(rgd).toContain('"enabled": false');
+    expect(rgd).toContain(
+      'chartVersion: ${hatchetMetadata.metadata.annotations["typekro.dev/chart-version"]}'
+    );
+    expect(rgd).toContain(
+      'workerTokenSecret: ${hatchetMetadata.metadata.annotations["typekro.dev/worker-token-secret"]}'
+    );
+    expect(rgd).toContain(
+      'configurationSecret: ${hatchetMetadata.metadata.annotations["typekro.dev/configuration-secret"]}'
+    );
+    expect(rgd).toContain('string(schema.spec.name) + "-config"');
+    expect(rgd).toContain('string(schema.spec.name) + "-client-config"');
+    expect(rgd).toContain('name: string | validation="size(self) > 0"');
+    expect(rgd).toContain(
+      'passwordKey: string | default="adminPassword" validation="size(self) > 0"'
+    );
+    expect(rgd).not.toContain('kind: Namespace');
+    expect(rgd).not.toContain('admin@example');
+
+    const instance = factory.toYaml(requiredConfig);
+    expect(instance).toContain('kind: HatchetInstallation');
+    expect(instance).toContain('name: hatchet');
+    expect(instance).toContain('name: hatchet-db-app');
+    expect(instance).toContain('name: hatchet-admin');
+  });
+
+  it('rejects empty direct-mode Secret references', () => {
+    const factory = hatchetInstallation.factory('direct', {
+      namespace: 'typekro-system',
+    });
+
+    expect(() =>
+      factory.toYaml({
+        ...requiredConfig,
+        database: { connectionSecret: { name: '' } },
+      })
+    ).toThrow();
+    expect(() =>
+      factory.toYaml({
+        ...requiredConfig,
+        adminCredentialsSecret: { name: '' },
+      })
+    ).toThrow();
+  });
+});

--- a/test/factories/hatchet/factory-modes.test.ts
+++ b/test/factories/hatchet/factory-modes.test.ts
@@ -108,29 +108,16 @@ describe('Hatchet installation', () => {
     expect(second).not.toContain('name: 6-team-a-hatchet-hatchet');
   });
 
-  it('length-prefixes the workload namespace so repository identity is injective', () => {
+  it('admits only the canonical release name because upstream recovery Secrets are namespace-global', () => {
     const factory = hatchetInstallation.factory('direct', {
       namespace: 'typekro-system',
     });
-    const first = factory.toYaml({
-      ...requiredConfig,
-      name: 'worker',
-      namespace: 'team-a',
-      repositoryNamespace: 'flux-system',
-      repositoryNamespaceOwnership: 'external',
-    });
-    const second = factory.toYaml({
-      ...requiredConfig,
-      name: 'a-worker',
-      namespace: 'team',
-      repositoryNamespace: 'flux-system',
-      repositoryNamespaceOwnership: 'external',
-    });
-
-    expect(first).toContain('name: 6-team-a-worker-hatchet');
-    expect(second).toContain('name: 4-team-a-worker-hatchet');
-    expect(first).not.toContain('name: 4-team-a-worker-hatchet');
-    expect(second).not.toContain('name: 6-team-a-worker-hatchet');
+    expect(() =>
+      factory.toYaml({
+        ...requiredConfig,
+        name: 'worker' as never,
+      })
+    ).toThrow();
   });
 
   it('serializes the complete contract in KRO mode without embedding credentials', () => {
@@ -171,7 +158,7 @@ describe('Hatchet installation', () => {
     );
     expect(rgd).toContain('hatchet-config');
     expect(rgd).toContain('hatchet-client-config');
-    expect(rgd).toContain('name: string | validation="size(self) > 0"');
+    expect(rgd).toContain('name: string | enum="hatchet"');
     expect(rgd).not.toContain('kind: Namespace');
     expect(rgd).not.toContain('admin@example');
 
@@ -201,29 +188,15 @@ describe('Hatchet installation', () => {
     ).toThrow();
   });
 
-  it('reports upstream fixed recovery Secret names for non-default release names', () => {
-    const yaml = hatchetInstallation.factory('direct', {
-      namespace: 'typekro-system',
-    }).toYaml({
-      ...requiredConfig,
-      name: 'workflows',
-    });
-
-    expect(yaml).toContain('typekro.dev/configuration-secret: hatchet-config');
-    expect(yaml).toContain('typekro.dev/worker-token-secret: hatchet-client-config');
-    expect(yaml).not.toContain('workflows-config');
-    expect(yaml).not.toContain('workflows-client-config');
-    expect(yaml).toContain('name: 15-workflow-system-workflows-hatchet');
-  });
-
   it('does not advertise a worker-token Secret when the chart job is disabled', () => {
-    const yaml = hatchetInstallation.factory('direct', {
-      namespace: 'typekro-system',
-    }).toYaml({
-      ...requiredConfig,
-      name: 'workflows',
-      workerTokenJob: false,
-    });
+    const yaml = hatchetInstallation
+      .factory('direct', {
+        namespace: 'typekro-system',
+      })
+      .toYaml({
+        ...requiredConfig,
+        workerTokenJob: false,
+      });
 
     expect(yaml).toMatch(/typekro\.dev\/worker-token-secret:\s*['"]?['"]?\s*$/m);
     expect(yaml).toMatch(/workerTokenJob:\s*\n\s+enabled: false/);

--- a/test/factories/hatchet/factory-modes.test.ts
+++ b/test/factories/hatchet/factory-modes.test.ts
@@ -64,7 +64,7 @@ describe('Hatchet installation', () => {
     expect(yaml).toContain('remediateLastFailure: false');
     expect(yaml).not.toContain('rollback');
     expect(yaml).not.toContain('__typekroValuesMerge');
-    expect(yaml).toContain('name: workflow-system-hatchet-hatchet');
+    expect(yaml).toContain('name: 15-workflow-system-hatchet-hatchet');
     expect(customValues).toEqual({
       api: { resources: { requests: { cpu: '250m' } } },
       postgres: { enabled: true },
@@ -102,10 +102,35 @@ describe('Hatchet installation', () => {
       repositoryNamespaceOwnership: 'external',
     });
 
-    expect(first).toContain('name: team-a-hatchet-hatchet');
-    expect(second).toContain('name: team-b-hatchet-hatchet');
-    expect(first).not.toContain('name: team-b-hatchet-hatchet');
-    expect(second).not.toContain('name: team-a-hatchet-hatchet');
+    expect(first).toContain('name: 6-team-a-hatchet-hatchet');
+    expect(second).toContain('name: 6-team-b-hatchet-hatchet');
+    expect(first).not.toContain('name: 6-team-b-hatchet-hatchet');
+    expect(second).not.toContain('name: 6-team-a-hatchet-hatchet');
+  });
+
+  it('length-prefixes the workload namespace so repository identity is injective', () => {
+    const factory = hatchetInstallation.factory('direct', {
+      namespace: 'typekro-system',
+    });
+    const first = factory.toYaml({
+      ...requiredConfig,
+      name: 'worker',
+      namespace: 'team-a',
+      repositoryNamespace: 'flux-system',
+      repositoryNamespaceOwnership: 'external',
+    });
+    const second = factory.toYaml({
+      ...requiredConfig,
+      name: 'a-worker',
+      namespace: 'team',
+      repositoryNamespace: 'flux-system',
+      repositoryNamespaceOwnership: 'external',
+    });
+
+    expect(first).toContain('name: 6-team-a-worker-hatchet');
+    expect(second).toContain('name: 4-team-a-worker-hatchet');
+    expect(first).not.toContain('name: 4-team-a-worker-hatchet');
+    expect(second).not.toContain('name: 6-team-a-worker-hatchet');
   });
 
   it('serializes the complete contract in KRO mode without embedding credentials', () => {
@@ -122,6 +147,9 @@ describe('Hatchet installation', () => {
     expect(rgd).toContain('${schema.spec.database.connectionSecret.name}');
     expect(rgd).toContain('${schema.spec.adminCredentialsSecret.name}');
     expect(rgd).toContain('envFrom');
+    expect(rgd).toContain(
+      'string(size(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system"))'
+    );
     expect(rgd).not.toContain('valuesFrom:');
     expect(rgd).not.toContain('literal: true');
     expect(rgd).toContain('schema.spec.replicas.api');
@@ -185,7 +213,7 @@ describe('Hatchet installation', () => {
     expect(yaml).toContain('typekro.dev/worker-token-secret: hatchet-client-config');
     expect(yaml).not.toContain('workflows-config');
     expect(yaml).not.toContain('workflows-client-config');
-    expect(yaml).toContain('name: workflow-system-workflows-hatchet');
+    expect(yaml).toContain('name: 15-workflow-system-workflows-hatchet');
   });
 
   it('does not advertise a worker-token Secret when the chart job is disabled', () => {

--- a/test/factories/hatchet/factory-modes.test.ts
+++ b/test/factories/hatchet/factory-modes.test.ts
@@ -31,14 +31,15 @@ const requiredConfig = {
 
 describe('Hatchet installation', () => {
   it('emits the official chart with external state and Secret-backed values', () => {
+    const customValues = {
+      api: { resources: { requests: { cpu: '250m' } } },
+      postgres: { enabled: true },
+      rabbitmq: { enabled: true },
+    };
     const yaml = hatchetInstallation.factory('direct', { namespace: 'typekro-system' }).toYaml({
       ...requiredConfig,
       replicas: { api: 2, engine: 3, frontend: 2 },
-      values: {
-        api: { resources: { requests: { cpu: '250m' } } },
-        postgres: { enabled: true },
-        rabbitmq: { enabled: true },
-      },
+      values: customValues,
     });
     const docs = documents(yaml);
 
@@ -54,6 +55,7 @@ describe('Hatchet installation', () => {
     expect(yaml).toContain('name: hatchet-db-app');
     expect(yaml).toContain('valuesKey: uri');
     expect(yaml).toContain('targetPath: sharedConfig.env.DATABASE_URL');
+    expect(yaml).toContain('literal: true');
     expect(yaml).toContain('name: hatchet-admin');
     expect(yaml).toContain('valuesKey: email');
     expect(yaml).toContain('valuesKey: password');
@@ -65,6 +67,13 @@ describe('Hatchet installation', () => {
     expect(yaml).toMatch(/workerTokenJob:\s*\n\s+enabled: true/);
     expect(yaml).toContain('remediateLastFailure: false');
     expect(yaml).not.toContain('rollback');
+    expect(yaml).not.toContain('__typekroValuesMerge');
+    expect(yaml).toContain('name: hatchet-hatchet');
+    expect(customValues).toEqual({
+      api: { resources: { requests: { cpu: '250m' } } },
+      postgres: { enabled: true },
+      rabbitmq: { enabled: true },
+    });
   });
 
   it('supports externally owned workload and repository namespaces', () => {
@@ -78,6 +87,29 @@ describe('Hatchet installation', () => {
     expect(documents(yaml).map(kind)).not.toContain('Namespace');
     expect(yaml).toContain('namespace: workflow-system');
     expect(yaml).toContain('namespace: flux-system');
+  });
+
+  it('gives every installation an isolated default repository identity', () => {
+    const factory = hatchetInstallation.factory('direct', {
+      namespace: 'typekro-system',
+    });
+    const first = factory.toYaml({
+      ...requiredConfig,
+      name: 'workflows-a',
+      repositoryNamespace: 'flux-system',
+      repositoryNamespaceOwnership: 'external',
+    });
+    const second = factory.toYaml({
+      ...requiredConfig,
+      name: 'workflows-b',
+      repositoryNamespace: 'flux-system',
+      repositoryNamespaceOwnership: 'external',
+    });
+
+    expect(first).toContain('name: workflows-a-hatchet');
+    expect(second).toContain('name: workflows-b-hatchet');
+    expect(first).not.toContain('name: workflows-b-hatchet');
+    expect(second).not.toContain('name: workflows-a-hatchet');
   });
 
   it('serializes the complete contract in KRO mode without embedding credentials', () => {
@@ -95,6 +127,7 @@ describe('Hatchet installation', () => {
     expect(rgd).toContain('${schema.spec.adminCredentialsSecret.name}');
     expect(rgd).toContain('valuesFrom:');
     expect(rgd).toContain('targetPath: sharedConfig.env.DATABASE_URL');
+    expect(rgd).toContain('literal: true');
     expect(rgd).toContain('schema.spec.replicas.api');
     expect(rgd).toContain('schema.spec.replicas.engine');
     expect(rgd).toContain('postgres');
@@ -109,8 +142,9 @@ describe('Hatchet installation', () => {
     expect(rgd).toContain(
       'configurationSecret: ${hatchetMetadata.metadata.annotations["typekro.dev/configuration-secret"]}'
     );
-    expect(rgd).toContain('string(schema.spec.name) + "-config"');
-    expect(rgd).toContain('string(schema.spec.name) + "-client-config"');
+    expect(rgd).toContain('string(schema.spec.name) + "-hatchet"');
+    expect(rgd).toContain('hatchet-config');
+    expect(rgd).toContain('hatchet-client-config');
     expect(rgd).toContain('name: string | validation="size(self) > 0"');
     expect(rgd).toContain(
       'passwordKey: string | default="adminPassword" validation="size(self) > 0"'
@@ -142,5 +176,33 @@ describe('Hatchet installation', () => {
         adminCredentialsSecret: { name: '' },
       })
     ).toThrow();
+  });
+
+  it('reports upstream fixed recovery Secret names for non-default release names', () => {
+    const yaml = hatchetInstallation.factory('direct', {
+      namespace: 'typekro-system',
+    }).toYaml({
+      ...requiredConfig,
+      name: 'workflows',
+    });
+
+    expect(yaml).toContain('typekro.dev/configuration-secret: hatchet-config');
+    expect(yaml).toContain('typekro.dev/worker-token-secret: hatchet-client-config');
+    expect(yaml).not.toContain('workflows-config');
+    expect(yaml).not.toContain('workflows-client-config');
+    expect(yaml).toContain('name: workflows-hatchet');
+  });
+
+  it('does not advertise a worker-token Secret when the chart job is disabled', () => {
+    const yaml = hatchetInstallation.factory('direct', {
+      namespace: 'typekro-system',
+    }).toYaml({
+      ...requiredConfig,
+      name: 'workflows',
+      workerTokenJob: false,
+    });
+
+    expect(yaml).toMatch(/typekro\.dev\/worker-token-secret:\s*['"]?['"]?\s*$/m);
+    expect(yaml).toMatch(/workerTokenJob:\s*\n\s+enabled: false/);
   });
 });

--- a/test/factories/hatchet/factory-modes.test.ts
+++ b/test/factories/hatchet/factory-modes.test.ts
@@ -20,12 +20,10 @@ const requiredConfig = {
   name: 'hatchet',
   namespace: 'workflow-system',
   database: {
-    connectionSecret: { name: 'hatchet-db-app', key: 'uri' },
+    connectionSecret: { name: 'hatchet-db-app' },
   },
   adminCredentialsSecret: {
     name: 'hatchet-admin',
-    emailKey: 'email',
-    passwordKey: 'password',
   },
 } as const;
 
@@ -51,24 +49,22 @@ describe('Hatchet installation', () => {
     expect(yaml).toContain('chart: hatchet-stack');
     expect(yaml).toContain(`version: ${DEFAULT_HATCHET_CHART_VERSION}`);
     expect(yaml).toContain(`tag: ${DEFAULT_HATCHET_SERVER_VERSION}`);
-    expect(yaml).toContain('valuesFrom:');
     expect(yaml).toContain('name: hatchet-db-app');
-    expect(yaml).toContain('valuesKey: uri');
-    expect(yaml).toContain('targetPath: sharedConfig.env.DATABASE_URL');
-    expect(yaml).toContain('literal: true');
     expect(yaml).toContain('name: hatchet-admin');
-    expect(yaml).toContain('valuesKey: email');
-    expect(yaml).toContain('valuesKey: password');
+    expect(yaml).toContain('envFrom:');
+    expect(yaml).toContain('name: hatchet-shared-config');
+    expect(yaml).not.toContain('valuesFrom:');
+    expect(yaml).not.toContain('literal: true');
     expect(yaml).toMatch(/postgres:\s*\n\s+enabled: false/);
     expect(yaml).toMatch(/rabbitmq:\s*\n\s+enabled: false/);
     expect(yaml).toMatch(/api:\s*\n(?:.*\n)*?\s+replicaCount: 2/);
-    expect(yaml).toMatch(/engine:\s*\n\s+replicaCount: 3/);
+    expect(yaml).toMatch(/engine:\s*\n(?:.*\n)*?\s+replicaCount: 3/);
     expect(yaml).toContain('cpu: 250m');
     expect(yaml).toMatch(/workerTokenJob:\s*\n\s+enabled: true/);
     expect(yaml).toContain('remediateLastFailure: false');
     expect(yaml).not.toContain('rollback');
     expect(yaml).not.toContain('__typekroValuesMerge');
-    expect(yaml).toContain('name: hatchet-hatchet');
+    expect(yaml).toContain('name: workflow-system-hatchet-hatchet');
     expect(customValues).toEqual({
       api: { resources: { requests: { cpu: '250m' } } },
       postgres: { enabled: true },
@@ -89,27 +85,27 @@ describe('Hatchet installation', () => {
     expect(yaml).toContain('namespace: flux-system');
   });
 
-  it('gives every installation an isolated default repository identity', () => {
+  it('gives same-named installations in different namespaces isolated repositories', () => {
     const factory = hatchetInstallation.factory('direct', {
       namespace: 'typekro-system',
     });
     const first = factory.toYaml({
       ...requiredConfig,
-      name: 'workflows-a',
+      namespace: 'team-a',
       repositoryNamespace: 'flux-system',
       repositoryNamespaceOwnership: 'external',
     });
     const second = factory.toYaml({
       ...requiredConfig,
-      name: 'workflows-b',
+      namespace: 'team-b',
       repositoryNamespace: 'flux-system',
       repositoryNamespaceOwnership: 'external',
     });
 
-    expect(first).toContain('name: workflows-a-hatchet');
-    expect(second).toContain('name: workflows-b-hatchet');
-    expect(first).not.toContain('name: workflows-b-hatchet');
-    expect(second).not.toContain('name: workflows-a-hatchet');
+    expect(first).toContain('name: team-a-hatchet-hatchet');
+    expect(second).toContain('name: team-b-hatchet-hatchet');
+    expect(first).not.toContain('name: team-b-hatchet-hatchet');
+    expect(second).not.toContain('name: team-a-hatchet-hatchet');
   });
 
   it('serializes the complete contract in KRO mode without embedding credentials', () => {
@@ -125,9 +121,9 @@ describe('Hatchet installation', () => {
     expect(rgd).toContain('kind: Secret');
     expect(rgd).toContain('${schema.spec.database.connectionSecret.name}');
     expect(rgd).toContain('${schema.spec.adminCredentialsSecret.name}');
-    expect(rgd).toContain('valuesFrom:');
-    expect(rgd).toContain('targetPath: sharedConfig.env.DATABASE_URL');
-    expect(rgd).toContain('literal: true');
+    expect(rgd).toContain('envFrom');
+    expect(rgd).not.toContain('valuesFrom:');
+    expect(rgd).not.toContain('literal: true');
     expect(rgd).toContain('schema.spec.replicas.api');
     expect(rgd).toContain('schema.spec.replicas.engine');
     expect(rgd).toContain('postgres');
@@ -142,13 +138,12 @@ describe('Hatchet installation', () => {
     expect(rgd).toContain(
       'configurationSecret: ${hatchetMetadata.metadata.annotations["typekro.dev/configuration-secret"]}'
     );
-    expect(rgd).toContain('string(schema.spec.name) + "-hatchet"');
+    expect(rgd).toContain(
+      'string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + "-" + string(schema.spec.name) + "-hatchet"'
+    );
     expect(rgd).toContain('hatchet-config');
     expect(rgd).toContain('hatchet-client-config');
     expect(rgd).toContain('name: string | validation="size(self) > 0"');
-    expect(rgd).toContain(
-      'passwordKey: string | default="adminPassword" validation="size(self) > 0"'
-    );
     expect(rgd).not.toContain('kind: Namespace');
     expect(rgd).not.toContain('admin@example');
 
@@ -190,7 +185,7 @@ describe('Hatchet installation', () => {
     expect(yaml).toContain('typekro.dev/worker-token-secret: hatchet-client-config');
     expect(yaml).not.toContain('workflows-config');
     expect(yaml).not.toContain('workflows-client-config');
-    expect(yaml).toContain('name: workflows-hatchet');
+    expect(yaml).toContain('name: workflow-system-workflows-hatchet');
   });
 
   it('does not advertise a worker-token Secret when the chart job is disabled', () => {

--- a/test/factories/hatchet/factory-modes.test.ts
+++ b/test/factories/hatchet/factory-modes.test.ts
@@ -108,16 +108,18 @@ describe('Hatchet installation', () => {
     expect(second).not.toContain('name: 6-team-a-hatchet-hatchet');
   });
 
-  it('admits only the canonical release name because upstream recovery Secrets are namespace-global', () => {
+  it('keeps the public instance identity separate from the fixed upstream release identity', () => {
     const factory = hatchetInstallation.factory('direct', {
       namespace: 'typekro-system',
     });
-    expect(() =>
-      factory.toYaml({
-        ...requiredConfig,
-        name: 'worker' as never,
-      })
-    ).toThrow();
+    const yaml = factory.toYaml({
+      ...requiredConfig,
+      name: 'team-a-control-plane',
+    });
+    expect(yaml).toContain('name: team-a-control-plane-typekro-metadata');
+    expect(yaml).toMatch(/kind: HelmRelease[\s\S]*?metadata:\s*\n\s+name: hatchet/);
+    expect(yaml).toContain('name: hatchet-shared-config');
+    expect(yaml).toContain('http://hatchet-api.workflow-system.svc:8080');
   });
 
   it('serializes the complete contract in KRO mode without embedding credentials', () => {
@@ -154,11 +156,11 @@ describe('Hatchet installation', () => {
       'configurationSecret: ${hatchetMetadata.metadata.annotations["typekro.dev/configuration-secret"]}'
     );
     expect(rgd).toContain(
-      'string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + "-" + string(schema.spec.name) + "-hatchet"'
+      'string(has(schema.spec.namespace) ? schema.spec.namespace : "hatchet-system") + "-hatchet-hatchet"'
     );
     expect(rgd).toContain('hatchet-config');
     expect(rgd).toContain('hatchet-client-config');
-    expect(rgd).toContain('name: string | enum="hatchet"');
+    expect(rgd).toContain('name: string | validation="size(self) > 0"');
     expect(rgd).not.toContain('kind: Namespace');
     expect(rgd).not.toContain('admin@example');
 
@@ -167,6 +169,35 @@ describe('Hatchet installation', () => {
     expect(instance).toContain('name: hatchet');
     expect(instance).toContain('name: hatchet-db-app');
     expect(instance).toContain('name: hatchet-admin');
+  });
+
+  it('renders independent KRO instances for separate workload namespaces', () => {
+    const factory = hatchetInstallation.factory('kro', {
+      namespace: 'typekro-system',
+    });
+    const first = factory.toYaml({
+      ...requiredConfig,
+      name: 'team-a-hatchet',
+      namespace: 'team-a',
+    });
+    const second = factory.toYaml({
+      ...requiredConfig,
+      name: 'team-b-hatchet',
+      namespace: 'team-b',
+    });
+
+    const firstInstance = documents(first).find(
+      (document) => kind(document) === 'HatchetInstallation'
+    );
+    const secondInstance = documents(second).find(
+      (document) => kind(document) === 'HatchetInstallation'
+    );
+    expect(firstInstance).toContain('name: team-a-hatchet');
+    expect(secondInstance).toContain('name: team-b-hatchet');
+    expect(first).toContain('namespace: team-a');
+    expect(second).toContain('namespace: team-b');
+    expect(first).not.toContain('name: team-b-hatchet');
+    expect(second).not.toContain('name: team-a-hatchet');
   });
 
   it('rejects empty direct-mode Secret references', () => {

--- a/test/factories/hatchet/factory-modes.test.ts
+++ b/test/factories/hatchet/factory-modes.test.ts
@@ -200,6 +200,35 @@ describe('Hatchet installation', () => {
     expect(second).not.toContain('name: team-a-hatchet');
   });
 
+  it('rejects Hatchet instance identities that cannot safely name Kubernetes resources', () => {
+    for (const name of ['Team A', 'UPPERCASE', 'a'.repeat(47)]) {
+      expect(() =>
+        hatchetInstallation.factory('direct').toYaml({
+          ...requiredConfig,
+          name,
+        })
+      ).toThrow();
+      expect(() =>
+        hatchetInstallation.factory('kro', {
+          namespace: 'typekro-system',
+        }).toYaml({
+          ...requiredConfig,
+          name,
+        })
+      ).toThrow();
+    }
+  });
+
+  it('projects the Hatchet DNS-1123 and suffix-safe bounds into the KRO schema', () => {
+    const yaml = hatchetInstallation.factory('kro', {
+      namespace: 'typekro-system',
+    }).toYaml();
+
+    expect(yaml).toContain(
+      'name: string | maxLength=46 pattern="^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$"'
+    );
+  });
+
   it('rejects empty direct-mode Secret references', () => {
     const factory = hatchetInstallation.factory('direct', {
       namespace: 'typekro-system',

--- a/test/factories/helm/helm-integration.test.ts
+++ b/test/factories/helm/helm-integration.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
 import { mergeValuesExpression } from '../../../src/core/aspects/values-merge.js';
-import { toResourceGraph } from '../../../src/core/serialization/index.js';
 import { Cel } from '../../../src/core/references/cel.js';
-import { configMap } from '../../../src/factories/kubernetes/config/config-map.js';
+import { toResourceGraph } from '../../../src/core/serialization/index.js';
 import { helmRelease, simpleHelmChart } from '../../../src/factories/helm/index.js';
+import { configMap } from '../../../src/factories/kubernetes/config/config-map.js';
 
 describe('Helm Integration with TypeKro Magic Proxy System', () => {
   const TestSpecSchema = type({
@@ -144,6 +144,54 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     expect(yaml).toContain('name: ${schema.spec.hostname}');
     expect(yaml).not.toContain('__KUBERNETES_REF_');
     expect(yaml).not.toContain('[object Object]');
+  });
+
+  it('serializes graph-aware Flux valuesFrom sources', () => {
+    const graph = toResourceGraph(
+      {
+        name: 'helm-values-from',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'TestApp',
+        spec: TestSpecSchema,
+        status: TestStatusSchema,
+      },
+      (schema) => {
+        const settings = configMap({
+          id: 'settings',
+          metadata: { name: schema.spec.hostname },
+          data: { DATABASE_URL: 'postgres://example' },
+        });
+
+        return {
+          settings,
+          app: helmRelease({
+            name: 'my-app',
+            chart: {
+              repository: 'https://charts.example.com',
+              name: 'my-chart',
+            },
+            valuesFrom: [
+              {
+                kind: 'ConfigMap',
+                name: settings.metadata.name,
+                valuesKey: 'DATABASE_URL',
+                targetPath: 'config.databaseUrl',
+              },
+            ],
+          }),
+        };
+      },
+      () => ({ ready: true })
+    );
+
+    const yaml = graph.toYaml();
+
+    expect(yaml).toContain('valuesFrom:');
+    expect(yaml).toContain('kind: ConfigMap');
+    expect(yaml).toContain('name: ${schema.spec.hostname}');
+    expect(yaml).toContain('valuesKey: DATABASE_URL');
+    expect(yaml).toContain('targetPath: config.databaseUrl');
+    expect(yaml).not.toContain('__KUBERNETES_REF_');
   });
 
   it('rejects unsupported runtime-only leaves inside Helm values with a path-specific error', () => {
@@ -301,7 +349,7 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
       .split('\n')
       .find((line) => line.includes('values: ') && line.includes('${'));
 
-    expect(valuesLine).toContain('values: \'${dyn(');
+    expect(valuesLine).toContain("values: '${dyn(");
     expect(valuesLine).toContain('schema.spec.legacyValues');
     expect(valuesLine).toContain('.merge(');
     expect(valuesLine).toContain('schema.spec.values');
@@ -445,10 +493,7 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
               host: schema.spec.hostname,
               omitted: undefined,
             },
-            env: [
-              { name: 'APP_HOST', value: schema.spec.hostname },
-              undefined,
-            ],
+            env: [{ name: 'APP_HOST', value: schema.spec.hostname }, undefined],
           },
         }),
       }),
@@ -689,8 +734,9 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     );
     // Both branches carry the same dyn-wrapped optional entry (present-branch merge + absent literal).
     expect(
-      valuesLine.match(/"celeryConfigSecretName": has\(schema\.spec\.secretName\) \? dyn\(schema\.spec\.secretName\) : omit\(\)/g)
-        ?.length
+      valuesLine.match(
+        /"celeryConfigSecretName": has\(schema\.spec\.secretName\) \? dyn\(schema\.spec\.secretName\) : omit\(\)/g
+      )?.length
     ).toBe(2);
   });
 });

--- a/test/factories/helm/helm-integration.test.ts
+++ b/test/factories/helm/helm-integration.test.ts
@@ -176,7 +176,6 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
                 name: settings.metadata.name,
                 valuesKey: 'DATABASE_URL',
                 targetPath: 'config.databaseUrl',
-                literal: true,
               },
             ],
           }),
@@ -192,8 +191,29 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     expect(yaml).toContain('name: ${schema.spec.hostname}');
     expect(yaml).toContain('valuesKey: DATABASE_URL');
     expect(yaml).toContain('targetPath: config.databaseUrl');
-    expect(yaml).toContain('literal: true');
+    expect(yaml).not.toContain('literal:');
     expect(yaml).not.toContain('__KUBERNETES_REF_');
+  });
+
+  it('rejects Flux 2.9 literal values sources while the managed baseline is Flux 2.7.5', () => {
+    expect(() =>
+      helmRelease({
+        name: 'my-app',
+        chart: {
+          repository: 'https://charts.example.com',
+          name: 'my-chart',
+        },
+        valuesFrom: [
+          {
+            kind: 'Secret',
+            name: 'credentials',
+            valuesKey: 'DATABASE_URL',
+            targetPath: 'config.databaseUrl',
+            literal: true,
+          } as never,
+        ],
+      })
+    ).toThrow(/valuesFrom\.literal requires Flux 2\.9/);
   });
 
   it('rejects unsupported runtime-only leaves inside Helm values with a path-specific error', () => {

--- a/test/factories/helm/helm-integration.test.ts
+++ b/test/factories/helm/helm-integration.test.ts
@@ -176,6 +176,7 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
                 name: settings.metadata.name,
                 valuesKey: 'DATABASE_URL',
                 targetPath: 'config.databaseUrl',
+                literal: true,
               },
             ],
           }),
@@ -191,6 +192,7 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     expect(yaml).toContain('name: ${schema.spec.hostname}');
     expect(yaml).toContain('valuesKey: DATABASE_URL');
     expect(yaml).toContain('targetPath: config.databaseUrl');
+    expect(yaml).toContain('literal: true');
     expect(yaml).not.toContain('__KUBERNETES_REF_');
   });
 

--- a/test/factories/helm/helm-readiness.test.ts
+++ b/test/factories/helm/helm-readiness.test.ts
@@ -102,6 +102,28 @@ describe('Helm Readiness Evaluators', () => {
       });
     });
 
+    it('does not accept Ready before Flux publishes any observation for the generation', () => {
+      const resource = {
+        metadata: { name: 'test', generation: 3 },
+        status: {
+          conditions: [
+            {
+              type: 'Ready',
+              status: 'True',
+              message: 'The preceding release is still reported ready',
+            },
+          ],
+        },
+      };
+
+      expect(helmReleaseReadinessEvaluator(resource)).toEqual({
+        ready: false,
+        reason: 'GenerationNotObserved',
+        message: 'HelmRelease has not observed generation 3 yet',
+        details: { desiredGeneration: 3 },
+      });
+    });
+
     it('accepts Ready only after Flux observes the current generation', () => {
       const resource = {
         metadata: { name: 'test', generation: 3 },

--- a/test/factories/opensearch/factory-modes.test.ts
+++ b/test/factories/opensearch/factory-modes.test.ts
@@ -221,7 +221,7 @@ describe('OpenSearch integration', () => {
     expect(yaml).not.toContain('__KUBERNETES_REF__');
     expect(yaml).toContain('${schema.spec.storage.size}');
     expect(yaml).toContain(
-      'adminDn: \'[]string | minItems=1 validation="size(self) > 0 && self.all(dn, size(dn) > 0)"\''
+      'adminDn: \'[]string | minLength=1 | minItems=1 validation="size(self) > 0 && self.all(dn, size(dn) > 0)"\''
     );
     expect(yaml).toContain('${cluster.status.availableNodes}');
     expect(yaml).toContain('${cluster.status.health}');

--- a/test/integration/hatchet/hatchet-installation.test.ts
+++ b/test/integration/hatchet/hatchet-installation.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Live Hatchet proof against a real cluster.
+ *
+ * bun test test/integration/hatchet/hatchet-installation.test.ts
+ *
+ * Requires Flux, KRO, CloudNativePG, and TYPEKRO_TEST_STORAGE_CLASS. The shared
+ * integration bootstrap installs those controllers. Each mode uses isolated,
+ * externally owned namespaces so the database authority survives normal
+ * Hatchet installation deletion until the harness removes the fixture.
+ */
+
+import { describe, expect, it, setDefaultTimeout } from 'bun:test';
+import type { KubernetesObject } from '@kubernetes/client-node';
+import { hatchetInstallation } from '../../../src/factories/hatchet/compositions/hatchet-installation.js';
+import {
+  DEFAULT_HATCHET_CHART_VERSION,
+  DEFAULT_HATCHET_SERVER_VERSION,
+} from '../../../src/factories/hatchet/resources/helm.js';
+import {
+  createCoreV1ApiClient,
+  createKubernetesObjectApiClient,
+  createTestNamespace,
+  deleteTestFactoryInstanceAndRecoverNamespaces,
+  deleteTestNamespaceAndWait,
+  deleteTestResourceAndWait,
+  getIntegrationTestKubeConfig,
+  isClusterAvailable,
+  isNotFoundError,
+  type ResourceIdentity,
+  requireTestStorageClass,
+  type TestNamespaceLease,
+} from '../shared-kubeconfig.js';
+
+const clusterAvailable = await isClusterAvailable();
+const describeOrSkip =
+  clusterAvailable || process.env.REQUIRE_CLUSTER_TESTS === 'true' ? describe : describe.skip;
+const runId = crypto.randomUUID().slice(0, 10);
+
+setDefaultTimeout(1_200_000);
+
+interface HatchetStatus {
+  ready: boolean;
+  failed: boolean;
+  phase: 'Installing' | 'Ready' | 'Failed';
+  chartVersion: string;
+  serverVersion: string;
+  endpoint: string;
+  grpcEndpoint: string;
+  configurationSecret: string;
+  workerTokenSecret: string;
+  dashboardEnabled: boolean;
+}
+
+async function waitForCnpgReady(namespace: string, name: string, timeoutMs: number): Promise<void> {
+  const objectApi = createKubernetesObjectApiClient(getIntegrationTestKubeConfig());
+  const startedAt = Date.now();
+  let last: KubernetesObject | undefined;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = await objectApi.read({
+      apiVersion: 'postgresql.cnpg.io/v1',
+      kind: 'Cluster',
+      metadata: { namespace, name },
+    });
+    const status = Reflect.get(last, 'status');
+    if (
+      status &&
+      typeof status === 'object' &&
+      Reflect.get(status, 'phase') === 'Cluster in healthy state'
+    ) {
+      return;
+    }
+    await Bun.sleep(2_000);
+  }
+  throw new Error(
+    `Timed out waiting for CloudNativePG Cluster ${namespace}/${name}: ${JSON.stringify(
+      Reflect.get(last ?? {}, 'status')
+    )}`
+  );
+}
+
+async function waitForSecretValue(
+  namespace: string,
+  name: string,
+  key: string,
+  timeoutMs: number
+): Promise<string> {
+  const coreApi = createCoreV1ApiClient(getIntegrationTestKubeConfig());
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const secret = await coreApi.readNamespacedSecret({ namespace, name });
+      const encoded = secret.data?.[key];
+      if (encoded) return Buffer.from(encoded, 'base64').toString('utf8');
+    } catch (error: unknown) {
+      if (!isNotFoundError(error)) throw error;
+    }
+    await Bun.sleep(1_000);
+  }
+  throw new Error(`Timed out waiting for Secret ${namespace}/${name} key ${key}`);
+}
+
+async function waitForPodCompletion(
+  namespace: string,
+  name: string,
+  timeoutMs: number
+): Promise<string> {
+  const coreApi = createCoreV1ApiClient(getIntegrationTestKubeConfig());
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    const pod = await coreApi.readNamespacedPod({ namespace, name });
+    if (pod.status?.phase === 'Succeeded') {
+      return coreApi.readNamespacedPodLog({
+        namespace,
+        name,
+        container: 'probe',
+      });
+    }
+    if (pod.status?.phase === 'Failed') {
+      const logs = await coreApi
+        .readNamespacedPodLog({ namespace, name, container: 'probe' })
+        .catch(() => '');
+      throw new Error(`Hatchet data-plane probe ${namespace}/${name} failed: ${logs}`);
+    }
+    await Bun.sleep(1_000);
+  }
+  throw new Error(`Timed out waiting for Hatchet data-plane probe ${namespace}/${name}`);
+}
+
+async function probeHatchetApi(
+  mode: 'direct' | 'kro',
+  namespace: string,
+  endpoint: string
+): Promise<void> {
+  const coreApi = createCoreV1ApiClient(getIntegrationTestKubeConfig());
+  const name = `hatchet-probe-${mode}`;
+  const pod = await coreApi.createNamespacedPod({
+    namespace,
+    body: {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name },
+      spec: {
+        restartPolicy: 'Never',
+        containers: [
+          {
+            name: 'probe',
+            image: 'curlimages/curl:8.12.1',
+            command: ['sh', '-ec', `curl --fail --silent --show-error ${endpoint}/api/ready`],
+          },
+        ],
+      },
+    },
+  });
+  const uid = pod.metadata?.uid;
+  if (!uid) {
+    throw new Error(`Created Hatchet probe ${namespace}/${name} has no UID`);
+  }
+  try {
+    const logs = await waitForPodCompletion(namespace, name, 180_000);
+    expect(logs.toLowerCase()).not.toContain('error');
+  } finally {
+    await deleteTestResourceAndWait(
+      {
+        apiVersion: 'v1',
+        kind: 'Pod',
+        metadata: { namespace, name, uid },
+      },
+      getIntegrationTestKubeConfig()
+    );
+  }
+}
+
+async function assertHatchetPodsReady(mode: 'direct' | 'kro', namespace: string): Promise<void> {
+  const pods = await createCoreV1ApiClient(getIntegrationTestKubeConfig()).listNamespacedPod({
+    namespace,
+  });
+  const workloads = pods.items.filter(
+    (pod) =>
+      !pod.metadata?.deletionTimestamp &&
+      pod.metadata?.ownerReferences?.some(
+        (owner) => owner.kind === 'ReplicaSet' || owner.kind === 'StatefulSet'
+      ) &&
+      !pod.metadata?.labels?.['cnpg.io/cluster']
+  );
+  expect(workloads.length).toBeGreaterThanOrEqual(2);
+  for (const pod of workloads) {
+    expect(pod.status?.phase).toBe('Running');
+    expect(pod.status?.containerStatuses?.length ?? 0).toBeGreaterThan(0);
+    expect(pod.status?.containerStatuses?.every((container) => container.ready)).toBe(true);
+    const restarts =
+      pod.status?.containerStatuses?.reduce(
+        (total, container) => total + container.restartCount,
+        0
+      ) ?? 0;
+    expect(restarts).toBeLessThanOrEqual(mode === 'kro' ? 10 : 2);
+  }
+}
+
+async function assertLiveHelmContract(namespace: string, dashboardEnabled: boolean): Promise<void> {
+  const release = await createKubernetesObjectApiClient(getIntegrationTestKubeConfig()).read({
+    apiVersion: 'helm.toolkit.fluxcd.io/v2',
+    kind: 'HelmRelease',
+    metadata: { namespace, name: 'hatchet' },
+  });
+  const spec = Reflect.get(release, 'spec');
+  const status = Reflect.get(release, 'status');
+  expect(spec).toMatchObject({
+    chart: {
+      spec: {
+        chart: 'hatchet-stack',
+        version: DEFAULT_HATCHET_CHART_VERSION,
+      },
+    },
+    values: {
+      postgres: { enabled: false },
+      rabbitmq: { enabled: false },
+      sharedConfig: {
+        image: { tag: DEFAULT_HATCHET_SERVER_VERSION },
+        env: { SERVER_MSGQUEUE_KIND: 'postgres' },
+      },
+      frontend: { enabled: dashboardEnabled },
+    },
+    valuesFrom: [
+      {
+        kind: 'Secret',
+        name: expect.stringContaining('hatchet-db-'),
+        valuesKey: 'uri',
+        targetPath: 'sharedConfig.env.DATABASE_URL',
+      },
+      {
+        kind: 'Secret',
+        name: expect.stringContaining('hatchet-admin-'),
+        valuesKey: 'adminEmail',
+        targetPath: 'sharedConfig.defaultAdminEmail',
+      },
+      {
+        kind: 'Secret',
+        name: expect.stringContaining('hatchet-admin-'),
+        valuesKey: 'adminPassword',
+        targetPath: 'sharedConfig.defaultAdminPassword',
+      },
+    ],
+  });
+  const generation = release.metadata?.generation;
+  const observedGeneration =
+    status && typeof status === 'object' ? Reflect.get(status, 'observedGeneration') : undefined;
+  expect(typeof generation).toBe('number');
+  expect(typeof observedGeneration).toBe('number');
+  expect(Number(observedGeneration)).toBeGreaterThanOrEqual(Number(generation));
+}
+
+async function prepareDatabase(
+  namespace: string,
+  name: string,
+  storageClass: string
+): Promise<ResourceIdentity> {
+  const objectApi = createKubernetesObjectApiClient(getIntegrationTestKubeConfig());
+  const cluster = await objectApi.create({
+    apiVersion: 'postgresql.cnpg.io/v1',
+    kind: 'Cluster',
+    metadata: { namespace, name },
+    spec: {
+      instances: 1,
+      storage: { size: '1Gi', storageClass },
+      bootstrap: { initdb: { database: 'hatchet', owner: 'app' } },
+      postgresql: { parameters: { timezone: 'UTC' } },
+    },
+  });
+  await waitForCnpgReady(namespace, name, 300_000);
+  await waitForSecretValue(namespace, `${name}-app`, 'uri', 60_000);
+  const metadata = Reflect.get(cluster, 'metadata');
+  const uid = metadata && typeof metadata === 'object' ? Reflect.get(metadata, 'uid') : undefined;
+  if (typeof uid !== 'string' || uid.length === 0) {
+    throw new Error(`Created CloudNativePG Cluster ${namespace}/${name} has no UID`);
+  }
+  return {
+    apiVersion: 'postgresql.cnpg.io/v1',
+    kind: 'Cluster',
+    metadata: { namespace, name, uid },
+  };
+}
+
+async function prepareAdminSecret(namespace: string, name: string): Promise<ResourceIdentity> {
+  const coreApi = createCoreV1ApiClient(getIntegrationTestKubeConfig());
+  const secret = await coreApi.createNamespacedSecret({
+    namespace,
+    body: {
+      metadata: { name },
+      type: 'Opaque',
+      stringData: {
+        adminEmail: `typekro-${runId}@example.test`,
+        adminPassword: `TypeKro-${runId}-Hatchet`,
+      },
+    },
+  });
+  const uid = secret.metadata?.uid;
+  if (!uid) {
+    throw new Error(`Created Secret ${namespace}/${name} has no UID`);
+  }
+  return {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: { namespace, name, uid },
+  };
+}
+
+async function readSecretIdentity(namespace: string, name: string): Promise<ResourceIdentity> {
+  const secret = await createCoreV1ApiClient(getIntegrationTestKubeConfig()).readNamespacedSecret({
+    namespace,
+    name,
+  });
+  const uid = secret.metadata?.uid;
+  if (!uid) {
+    throw new Error(`Secret ${namespace}/${name} has no UID`);
+  }
+  return {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: { namespace, name, uid },
+  };
+}
+
+async function assertResourceIdentity(identity: ResourceIdentity): Promise<void> {
+  const expectedUid = identity.metadata.uid;
+  if (!expectedUid) {
+    throw new Error(
+      `Expected retained ${identity.kind} ${identity.metadata.namespace}/${identity.metadata.name} to have a UID`
+    );
+  }
+  const resource = await createKubernetesObjectApiClient(getIntegrationTestKubeConfig()).read(
+    identity
+  );
+  expect(resource.metadata?.uid).toBe(expectedUid);
+}
+
+async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
+  const suffix = `${mode}-${runId}`;
+  const controlNamespace = `tk-hatchet-control-${suffix}`.slice(0, 63);
+  const targetNamespace = `tk-hatchet-${suffix}`.slice(0, 63);
+  const clusterName = `hatchet-db-${mode}`;
+  const adminSecret = `hatchet-admin-${mode}`;
+  const kubeConfig = getIntegrationTestKubeConfig();
+  const storageClass = await requireTestStorageClass({ kubeConfig });
+  const factory = hatchetInstallation.factory(mode, {
+    namespace: controlNamespace,
+    waitForReady: true,
+    timeout: 900_000,
+    kubeConfig,
+  });
+  let controlLease: TestNamespaceLease | undefined;
+  let targetLease: TestNamespaceLease | undefined;
+  let databaseFixture: ResourceIdentity | undefined;
+  let adminFixture: ResourceIdentity | undefined;
+  let retainedRecoveryArtifacts: ResourceIdentity[] = [];
+  let testFailure: Error | undefined;
+
+  try {
+    controlLease = await createTestNamespace(controlNamespace, kubeConfig);
+    targetLease = await createTestNamespace(targetNamespace, kubeConfig);
+    databaseFixture = await prepareDatabase(targetNamespace, clusterName, storageClass);
+    adminFixture = await prepareAdminSecret(targetNamespace, adminSecret);
+
+    const expectedEndpoint = `http://hatchet-api.${targetNamespace}.svc:8080`;
+    const expectedGrpc = `hatchet-engine.${targetNamespace}.svc:7070`;
+    const deployed = await factory.deploy({
+      name: 'hatchet',
+      namespace: targetNamespace,
+      namespaceOwnership: 'external',
+      repositoryNamespaceOwnership: 'external',
+      database: {
+        connectionSecret: { name: `${clusterName}-app`, key: 'uri' },
+      },
+      adminCredentialsSecret: { name: adminSecret },
+      dashboard: true,
+    });
+    expect(deployed.status).toMatchObject({
+      ready: true,
+      failed: false,
+      phase: 'Ready',
+      chartVersion: DEFAULT_HATCHET_CHART_VERSION,
+      serverVersion: DEFAULT_HATCHET_SERVER_VERSION,
+      endpoint: expectedEndpoint,
+      grpcEndpoint: expectedGrpc,
+      configurationSecret: 'hatchet-config',
+      workerTokenSecret: 'hatchet-client-config',
+      dashboardEnabled: true,
+    } satisfies HatchetStatus);
+
+    const token = await waitForSecretValue(
+      targetNamespace,
+      'hatchet-client-config',
+      'HATCHET_CLIENT_TOKEN',
+      180_000
+    );
+    expect(token.length).toBeGreaterThan(20);
+    retainedRecoveryArtifacts = await Promise.all([
+      readSecretIdentity(targetNamespace, 'hatchet-config'),
+      readSecretIdentity(targetNamespace, 'hatchet-client-config'),
+    ]);
+    await assertLiveHelmContract(targetNamespace, true);
+    await assertHatchetPodsReady(mode, targetNamespace);
+    await probeHatchetApi(mode, targetNamespace, expectedEndpoint);
+
+    const updated = await factory.deploy({
+      name: 'hatchet',
+      namespace: targetNamespace,
+      namespaceOwnership: 'external',
+      repositoryNamespaceOwnership: 'external',
+      database: {
+        connectionSecret: { name: `${clusterName}-app`, key: 'uri' },
+      },
+      adminCredentialsSecret: { name: adminSecret },
+      dashboard: false,
+    });
+    expect(updated.status).toMatchObject({
+      ready: true,
+      failed: false,
+      phase: 'Ready',
+      chartVersion: DEFAULT_HATCHET_CHART_VERSION,
+      serverVersion: DEFAULT_HATCHET_SERVER_VERSION,
+      endpoint: expectedEndpoint,
+      grpcEndpoint: expectedGrpc,
+      configurationSecret: 'hatchet-config',
+      workerTokenSecret: 'hatchet-client-config',
+      dashboardEnabled: false,
+    } satisfies HatchetStatus);
+    await assertLiveHelmContract(targetNamespace, false);
+    await assertHatchetPodsReady(mode, targetNamespace);
+    await probeHatchetApi(mode, targetNamespace, expectedEndpoint);
+  } catch (error: unknown) {
+    testFailure = error instanceof Error ? error : new Error(String(error));
+  }
+
+  const cleanupFailures: Error[] = [];
+  try {
+    await deleteTestFactoryInstanceAndRecoverNamespaces(
+      factory,
+      'hatchet',
+      [],
+      kubeConfig,
+      300_000
+    );
+  } catch (error: unknown) {
+    cleanupFailures.push(error instanceof Error ? error : new Error(String(error)));
+  }
+  for (const artifact of retainedRecoveryArtifacts) {
+    try {
+      await assertResourceIdentity(artifact);
+      await deleteTestResourceAndWait(artifact, kubeConfig, 60_000);
+    } catch (error: unknown) {
+      cleanupFailures.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+  if (databaseFixture) {
+    try {
+      await deleteTestResourceAndWait(databaseFixture, kubeConfig, 300_000);
+    } catch (error: unknown) {
+      cleanupFailures.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+  if (adminFixture) {
+    try {
+      await deleteTestResourceAndWait(adminFixture, kubeConfig, 300_000);
+    } catch (error: unknown) {
+      cleanupFailures.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+  for (const lease of [targetLease, controlLease]) {
+    if (!lease) continue;
+    try {
+      await deleteTestNamespaceAndWait(lease, kubeConfig);
+    } catch (error: unknown) {
+      cleanupFailures.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  if (testFailure || cleanupFailures.length > 0) {
+    throw new AggregateError(
+      [...(testFailure ? [testFailure] : []), ...cleanupFailures],
+      `${mode} Hatchet integration failed`
+    );
+  }
+}
+
+describeOrSkip('Hatchet direct and KRO integration', () => {
+  it('installs, updates, probes, and deletes in direct mode', async () => {
+    await proveMode('direct');
+  });
+
+  it('installs, updates, probes, and deletes in KRO mode', async () => {
+    await proveMode('kro');
+  });
+});

--- a/test/integration/hatchet/hatchet-installation.test.ts
+++ b/test/integration/hatchet/hatchet-installation.test.ts
@@ -218,29 +218,24 @@ async function assertLiveHelmContract(namespace: string, dashboardEnabled: boole
         image: { tag: DEFAULT_HATCHET_SERVER_VERSION },
         env: { SERVER_MSGQUEUE_KIND: 'postgres' },
       },
+      api: {
+        envFrom: [
+          { secretRef: { name: 'hatchet-shared-config' } },
+          { secretRef: { name: expect.stringContaining('hatchet-db-env-') } },
+          { secretRef: { name: expect.stringContaining('hatchet-admin-') } },
+        ],
+      },
+      engine: {
+        envFrom: [
+          { secretRef: { name: 'hatchet-shared-config' } },
+          { secretRef: { name: expect.stringContaining('hatchet-db-env-') } },
+          { secretRef: { name: expect.stringContaining('hatchet-admin-') } },
+        ],
+      },
       frontend: { enabled: dashboardEnabled },
     },
-    valuesFrom: [
-      {
-        kind: 'Secret',
-        name: expect.stringContaining('hatchet-db-'),
-        valuesKey: 'uri',
-        targetPath: 'sharedConfig.env.DATABASE_URL',
-      },
-      {
-        kind: 'Secret',
-        name: expect.stringContaining('hatchet-admin-'),
-        valuesKey: 'adminEmail',
-        targetPath: 'sharedConfig.defaultAdminEmail',
-      },
-      {
-        kind: 'Secret',
-        name: expect.stringContaining('hatchet-admin-'),
-        valuesKey: 'adminPassword',
-        targetPath: 'sharedConfig.defaultAdminPassword',
-      },
-    ],
   });
+  expect(spec).not.toHaveProperty('valuesFrom');
   const generation = release.metadata?.generation;
   const observedGeneration =
     status && typeof status === 'object' ? Reflect.get(status, 'observedGeneration') : undefined;
@@ -288,9 +283,36 @@ async function prepareAdminSecret(namespace: string, name: string): Promise<Reso
       metadata: { name },
       type: 'Opaque',
       stringData: {
-        adminEmail: `typekro-${runId}@example.test`,
-        adminPassword: `TypeKro-${runId}-Hatchet`,
+        ADMIN_EMAIL: `typekro-${runId}@example.test`,
+        ADMIN_PASSWORD: `TypeKro-${runId}-Hatchet`,
       },
+    },
+  });
+  const uid = secret.metadata?.uid;
+  if (!uid) {
+    throw new Error(`Created Secret ${namespace}/${name} has no UID`);
+  }
+  return {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: { namespace, name, uid },
+  };
+}
+
+async function prepareDatabaseEnvironmentSecret(
+  namespace: string,
+  sourceName: string,
+  name: string
+): Promise<ResourceIdentity> {
+  const uri = await waitForSecretValue(namespace, sourceName, 'uri', 60_000);
+  const secret = await createCoreV1ApiClient(
+    getIntegrationTestKubeConfig()
+  ).createNamespacedSecret({
+    namespace,
+    body: {
+      metadata: { name },
+      type: 'Opaque',
+      stringData: { DATABASE_URL: uri },
     },
   });
   const uid = secret.metadata?.uid;
@@ -338,6 +360,7 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
   const controlNamespace = `tk-hatchet-control-${suffix}`.slice(0, 63);
   const targetNamespace = `tk-hatchet-${suffix}`.slice(0, 63);
   const clusterName = `hatchet-db-${mode}`;
+  const databaseSecret = `hatchet-db-env-${mode}`;
   const adminSecret = `hatchet-admin-${mode}`;
   const kubeConfig = getIntegrationTestKubeConfig();
   const storageClass = await requireTestStorageClass({ kubeConfig });
@@ -350,6 +373,7 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
   let controlLease: TestNamespaceLease | undefined;
   let targetLease: TestNamespaceLease | undefined;
   let databaseFixture: ResourceIdentity | undefined;
+  let databaseSecretFixture: ResourceIdentity | undefined;
   let adminFixture: ResourceIdentity | undefined;
   let retainedRecoveryArtifacts: ResourceIdentity[] = [];
   let testFailure: Error | undefined;
@@ -358,6 +382,11 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
     controlLease = await createTestNamespace(controlNamespace, kubeConfig);
     targetLease = await createTestNamespace(targetNamespace, kubeConfig);
     databaseFixture = await prepareDatabase(targetNamespace, clusterName, storageClass);
+    databaseSecretFixture = await prepareDatabaseEnvironmentSecret(
+      targetNamespace,
+      `${clusterName}-app`,
+      databaseSecret
+    );
     adminFixture = await prepareAdminSecret(targetNamespace, adminSecret);
 
     const expectedEndpoint = `http://hatchet-api.${targetNamespace}.svc:8080`;
@@ -368,7 +397,7 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
       namespaceOwnership: 'external',
       repositoryNamespaceOwnership: 'external',
       database: {
-        connectionSecret: { name: `${clusterName}-app`, key: 'uri' },
+        connectionSecret: { name: databaseSecret },
       },
       adminCredentialsSecret: { name: adminSecret },
       dashboard: true,
@@ -407,7 +436,7 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
       namespaceOwnership: 'external',
       repositoryNamespaceOwnership: 'external',
       database: {
-        connectionSecret: { name: `${clusterName}-app`, key: 'uri' },
+        connectionSecret: { name: databaseSecret },
       },
       adminCredentialsSecret: { name: adminSecret },
       dashboard: false,
@@ -454,6 +483,13 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
   if (databaseFixture) {
     try {
       await deleteTestResourceAndWait(databaseFixture, kubeConfig, 300_000);
+    } catch (error: unknown) {
+      cleanupFailures.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+  if (databaseSecretFixture) {
+    try {
+      await deleteTestResourceAndWait(databaseSecretFixture, kubeConfig, 60_000);
     } catch (error: unknown) {
       cleanupFailures.push(error instanceof Error ? error : new Error(String(error)));
     }

--- a/test/integration/shared-bootstrap.ts
+++ b/test/integration/shared-bootstrap.ts
@@ -50,7 +50,7 @@ export const integrationTestBootstrap = kubernetesComposition(
     // 1. TypeKro Runtime (Flux + Kro) - Required for all tests
     const kroRuntimeComposition = typeKroRuntimeBootstrap({
       namespace: config.namespace,
-      fluxVersion: 'v2.7.5',
+      fluxVersion: 'v2.9.0',
       kroVersion: '0.9.2',
     });
     const kroRuntime = getCurrentCompositionContext()?.isReExecution

--- a/test/integration/shared-kubeconfig.ts
+++ b/test/integration/shared-kubeconfig.ts
@@ -1914,7 +1914,7 @@ async function isFluxReady(namespace = 'flux-system', kc?: k8s.KubeConfig): Prom
 export interface EnsureFluxOptions {
   /** Namespace to install Flux in (default: 'flux-system') */
   namespace?: string;
-  /** Flux version (default: 'v2.7.5') */
+  /** Flux version (default: 'v2.9.0') */
   version?: string;
   /** Timeout for waiting for Flux to be ready (default: 300000ms) */
   timeout?: number;
@@ -1936,7 +1936,7 @@ export interface EnsureFluxOptions {
 export async function ensureFluxInstalled(options: EnsureFluxOptions = {}): Promise<void> {
   const {
     namespace = 'flux-system',
-    version = 'v2.7.5',
+    version = 'v2.9.0',
     timeout = 300000,
     kubeConfig,
     verbose = true,


### PR DESCRIPTION
## Summary

- add an official Hatchet `hatchet-stack` installation composition with external PostgreSQL and administrator Secrets
- support direct and KRO deployment, externally owned namespaces, protected chart values, complete hydrated status, and retained recovery artifacts
- add generic graph-aware Flux `HelmRelease.spec.valuesFrom` support
- preserve CEL-derived `externalRef` identity through semantic direct execution and avoid factory canonicalization of observed resources
- require Flux to observe the current HelmRelease generation before reporting readiness

## Operational contract

The integration pins chart `0.13.3` and server `v0.94.10`, disables bundled PostgreSQL and RabbitMQ, keeps credentials out of the RGD and instance, and documents the chart-retained configuration/token Secrets as recovery artifacts when the target namespace is externally owned.

## Verification

- `bun run build`
- randomized suite: 5,156 passed, 13 skipped, 1 todo, 0 failed
- focused Hatchet/Helm/planning coverage: 72 passed
- documentation build, validation, example syntax, and link checks
- packed-package import and size checks
- live OrbStack direct + KRO test: 2 passed, 74 assertions; creates real CNPG state, installs, updates, validates the live Helm contract and pods, probes the Hatchet API, deletes via `factory.deleteInstance()`, verifies retained recovery artifacts, and completes cleanup