### PR TITLE
feat: add production OpenSearch integration

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -88,6 +88,7 @@ export default withMermaid(
               { text: 'Cilium', link: '/api/cilium/' },
               { text: 'Cert-Manager', link: '/api/cert-manager/' },
               { text: 'ClickHouse', link: '/api/clickhouse/' },
+              { text: 'OpenSearch', link: '/api/opensearch/' },
               { text: 'CloudNativePG', link: '/api/cnpg/' },
               { text: 'Flux', link: '/api/flux/' },
               { text: 'Harbor', link: '/api/harbor/' },

--- a/docs/api/opensearch/index.md
+++ b/docs/api/opensearch/index.md
@@ -16,21 +16,22 @@ import {
   makeOpenSearchCluster,
   openSearchCluster,
   openSearchOperatorBootstrap,
+  openSearchOperatorInstallation,
 } from 'typekro/opensearch';
 ```
 
 ## Operator bootstrap
 
-Install the cluster-scoped operator once. Its Helm repository is singleton
-owned, and the operator Namespace and HelmRelease use the `cluster` lifecycle
-scope by default.
+Install the cluster-scoped operator once. The complete operator installation,
+including its Namespace and HelmRelease, is owned by a singleton
+`OpenSearchOperatorInstallation` in `typekro-singletons`. The bootstrap CR is
+only a consumer reference; deleting it cannot uninstall the shared operator.
 
 ```typescript
 await openSearchOperatorBootstrap.factory('kro', {
   namespace: 'typekro-system',
 }).deploy({
   name: 'opensearch-operator',
-  namespace: 'opensearch-operator-system',
 });
 ```
 
@@ -146,8 +147,22 @@ be represented:
 `external-retain` deliberately does not create the Namespace. StatefulSet PVC
 retention cannot survive deletion of an owned Namespace.
 
-Use `factory.deleteInstance()` for cluster and operator teardown. Shared
-operator infrastructure requires explicit `scopes: ['cluster']` deletion.
+Use `factory.deleteInstance()` for cluster teardown. Deleting an
+`openSearchOperatorBootstrap` instance removes only that shared reference.
+Explicit platform teardown uses the owner composition and stable singleton
+instance identity:
+
+```typescript
+await openSearchOperatorInstallation.factory('kro', {
+  namespace: 'typekro-singletons',
+}).deleteInstance('opensearch-operator');
+```
+
+Use `openSearchOperatorInstallation` directly only when the caller
+intentionally wants an installation-local operator whose instance deletion
+uninstalls the controller. Runtime `shared` flags are deliberately unsupported:
+KRO child ownership is fixed when the RGD is built, not by instance schema
+values.
 
 ## TLS
 

--- a/docs/api/opensearch/index.md
+++ b/docs/api/opensearch/index.md
@@ -1,0 +1,183 @@
+---
+title: OpenSearch Factories
+description: Official OpenSearch Kubernetes operator lifecycle and cluster compositions
+---
+
+# OpenSearch Factories
+
+TypeKro wraps the official OpenSearch Kubernetes operator and its
+`opensearch.org/v1` `OpenSearchCluster` CRD. The integration does not copy the
+operator's StatefulSets or encode an alternate cluster controller.
+
+## Import
+
+```typescript
+import {
+  makeOpenSearchCluster,
+  openSearchCluster,
+  openSearchOperatorBootstrap,
+} from 'typekro/opensearch';
+```
+
+## Operator bootstrap
+
+Install the cluster-scoped operator once. Its Helm repository is singleton
+owned, and the operator Namespace and HelmRelease use the `cluster` lifecycle
+scope by default.
+
+```typescript
+await openSearchOperatorBootstrap.factory('kro', {
+  namespace: 'typekro-system',
+}).deploy({
+  name: 'opensearch-operator',
+  namespace: 'opensearch-operator-system',
+});
+```
+
+The pinned default is the official `opensearch-operator` chart `3.0.2` from
+`https://opensearch-project.github.io/opensearch-k8s-operator/`.
+
+## Development cluster
+
+```typescript
+await openSearchCluster.factory('kro', {
+  namespace: 'search-control',
+}).deploy({
+  name: 'search',
+  namespace: 'search-system',
+  storage: {
+    size: '20Gi',
+    storageClassName: 'local-path',
+  },
+  tls: { source: 'generated' },
+});
+```
+
+`openSearchCluster` is `makeOpenSearchCluster()` with the upstream minimum of
+three cluster-manager-capable nodes, generated TLS, no snapshot repository, and
+no NetworkPolicy.
+
+## Production topology
+
+Topology and fields that become Kubernetes path/map keys are fixed at
+composition construction. Runtime values remain typed KRO instance fields.
+
+```typescript
+const search = makeOpenSearchCluster({
+  profile: 'production',
+  nodes: 3,
+  tls: 'cert-manager',
+  snapshots: true,
+  snapshotCredentialKeys: {
+    accessKey: 'accessKey',
+    secretKey: 'secretKey',
+  },
+  networkPolicy: {
+    enabled: true,
+    ingressNamespaceLabels: {
+      'kubernetes.io/metadata.name': 'application-system',
+    },
+    egressCidrs: ['10.0.0.0/8'],
+  },
+});
+
+await search.factory('kro', {
+  namespace: 'search-control',
+}).deploy({
+  name: 'evidence',
+  namespace: 'search-system',
+  lifecycle: 'external-retain',
+  storage: {
+    size: '100Gi',
+    storageClassName: 'fast-expandable',
+  },
+  adminCredentialsSecret: {
+    name: 'evidence-admin-credentials',
+  },
+  dashboardCredentialsSecret: {
+    name: 'evidence-dashboards-credentials',
+  },
+  tls: {
+    source: 'cert-manager',
+    secretName: 'evidence-http-tls',
+    adminSecretName: 'evidence-admin-tls',
+    issuerName: 'platform-ca',
+    issuerKind: 'ClusterIssuer',
+    dnsNames: ['evidence.search.example.com'],
+  },
+  snapshots: {
+    repository: 'snapshots',
+    bucket: 'evidence-search',
+    endpoint: 'https://s3.example.com',
+    credentialsSecret: {
+      name: 'snapshot-credentials',
+    },
+  },
+  monitoring: true,
+});
+```
+
+The operator installs `repository-s3`, maps the declared Secret keys into the
+OpenSearch keystore, and registers the S3 repository. Secret values never enter
+the `OpenSearchCluster` manifest.
+
+## Lifecycle
+
+Lifecycle is one atomic field so an unsafe namespace/storage combination cannot
+be represented:
+
+| Value | Namespace owner | PVC expectation |
+| --- | --- | --- |
+| `owned-delete` | Cluster instance | Deleted with the instance namespace |
+| `external-delete` | External platform | PVC deletion is caller-managed |
+| `external-retain` | External platform | Operator-retained PVCs survive cluster deletion |
+
+`external-retain` deliberately does not create the Namespace. StatefulSet PVC
+retention cannot survive deletion of an owned Namespace.
+
+Use `factory.deleteInstance()` for cluster and operator teardown. Shared
+operator infrastructure requires explicit `scopes: ['cluster']` deletion.
+
+## TLS
+
+- `generated` lets the operator create transport, HTTP, and admin material.
+- `secret` consumes externally managed HTTP and admin certificate Secrets.
+- `cert-manager` creates the HTTP server Certificate and consumes a separately
+  supplied admin client certificate Secret.
+
+External HTTP certificates require `adminSecretName`; the integration does not
+silently pretend a server-only certificate is also a privileged client
+certificate.
+
+## Credentials
+
+`adminCredentialsSecret` and `dashboardCredentialsSecret` reference existing
+Secrets containing `username` and `password`. Supplying both makes credential
+ownership explicit and is recommended for production and externally owned
+Namespaces.
+
+When omitted, the operator creates `<name>-admin-password` and
+`<name>-dashboards-password`. The `credentialsSecret` status field reports the
+configured admin Secret or the operator-generated admin Secret name.
+
+## Status
+
+Both direct and KRO factories expose:
+
+```typescript
+{
+  ready: boolean;
+  failed: boolean;
+  phase: 'Installing' | 'Ready' | 'Failed';
+  endpoint: string;
+  credentialsSecret: string;
+  version: string;
+  availableNodes: number;
+  health: string;
+  snapshotRepository: string;
+}
+```
+
+Readiness requires operator initialization, the expected node count, and
+OpenSearch health `green` or `yellow`. Any failed component makes the phase
+`Failed`.

--- a/docs/api/opensearch/index.md
+++ b/docs/api/opensearch/index.md
@@ -36,6 +36,8 @@ await openSearchOperatorBootstrap.factory('kro', {
 
 The pinned default is the official `opensearch-operator` chart `3.0.2` from
 `https://opensearch-project.github.io/opensearch-k8s-operator/`.
+Direct and KRO bootstrap status both report the reconciled HelmRelease chart
+version alongside `ready`, `failed`, and `phase`.
 
 ## Development cluster
 
@@ -74,6 +76,9 @@ const search = makeOpenSearchCluster({
   },
   networkPolicy: {
     enabled: true,
+    // Defaults to opensearch-operator-system and is admitted separately from
+    // application traffic so operator health reconciliation remains live.
+    operatorNamespace: 'opensearch-operator-system',
     ingressNamespaceLabels: {
       'kubernetes.io/metadata.name': 'application-system',
     },
@@ -101,6 +106,7 @@ await search.factory('kro', {
     source: 'cert-manager',
     secretName: 'evidence-http-tls',
     adminSecretName: 'evidence-admin-tls',
+    adminDn: ['CN=opensearch-admin'],
     issuerName: 'platform-ca',
     issuerKind: 'ClusterIssuer',
     dnsNames: ['evidence.search.example.com'],
@@ -120,6 +126,11 @@ await search.factory('kro', {
 The operator installs `repository-s3`, maps the declared Secret keys into the
 OpenSearch keystore, and registers the S3 repository. Secret values never enter
 the `OpenSearchCluster` manifest.
+
+External TLS modes require a non-empty `adminDn` list matching the subject of
+the administrator certificate in `adminSecretName`. The production
+NetworkPolicy always admits the configured OpenSearch operator Namespace on the
+HTTP port in addition to the caller-selected application Namespace labels.
 
 ## Lifecycle
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
       "import": "./dist/factories/clickhouse/index.js",
       "types": "./dist/factories/clickhouse/index.d.ts"
     },
+    "./opensearch": {
+      "import": "./dist/factories/opensearch/index.js",
+      "types": "./dist/factories/opensearch/index.d.ts"
+    },
     "./flux": {
       "import": "./dist/factories/flux/index.js",
       "types": "./dist/factories/flux/index.d.ts"

--- a/src/factories/opensearch/compositions/cluster.ts
+++ b/src/factories/opensearch/compositions/cluster.ts
@@ -412,19 +412,19 @@ export function makeOpenSearchCluster<
         'cluster.status.componentsStatus.exists(c, c.status == "Failed" || c.status == "Error")'
       );
       const ready = Cel.expr<boolean>(
-        `cluster.status.initialized == true && cluster.status.availableNodes >= ${topology.nodes} && (cluster.status.health == "green" || cluster.status.health == "yellow")`
+        `cluster.status.initialized == true && cluster.status.availableNodes >= ${topology.nodes} && (cluster.status.health == "green" || cluster.status.health == "yellow") && cluster.status.version == cluster.spec.general.version`
       );
       return {
         ready,
         failed,
         phase: Cel.expr<'Ready' | 'Installing' | 'Failed'>(
-          `cluster.status.componentsStatus.exists(c, c.status == "Failed" || c.status == "Error") ? "Failed" : (cluster.status.initialized == true && cluster.status.availableNodes >= ${topology.nodes} && (cluster.status.health == "green" || cluster.status.health == "yellow") ? "Ready" : "Installing")`
+          `cluster.status.componentsStatus.exists(c, c.status == "Failed" || c.status == "Error") ? "Failed" : (cluster.status.initialized == true && cluster.status.availableNodes >= ${topology.nodes} && (cluster.status.health == "green" || cluster.status.health == "yellow") && cluster.status.version == cluster.spec.general.version ? "Ready" : "Installing")`
         ),
         endpoint: `https://${cluster.spec.general.serviceName}.${cluster.metadata.namespace}.svc.cluster.local:${OPENSEARCH_HTTP_PORT}`,
         credentialsSecret: Cel.expr<string>(
           `has(cluster.spec.security.config.adminCredentialsSecret) && cluster.spec.security.config.adminCredentialsSecret.name != "" ? cluster.spec.security.config.adminCredentialsSecret.name : string(cluster.metadata.name) + "-admin-password"`
         ),
-        version: cluster.spec.general.version,
+        version: cluster.status.version,
         availableNodes: cluster.status.availableNodes,
         health: cluster.status.health,
         snapshotRepository: Cel.expr<string>(

--- a/src/factories/opensearch/compositions/cluster.ts
+++ b/src/factories/opensearch/compositions/cluster.ts
@@ -7,17 +7,14 @@ import { isKubernetesRef } from '../../../utils/type-guards.js';
 import { certificate } from '../../cert-manager/resources/certificates.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
 import { networkPolicy } from '../../kubernetes/networking/network-policy.js';
-import {
-  OPENSEARCH_HTTP_PORT,
-  openSearchClusterResource,
-} from '../resources/cluster.js';
+import { DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE } from '../constants.js';
+import { OPENSEARCH_HTTP_PORT, openSearchClusterResource } from '../resources/cluster.js';
 import type {
   OpenSearchClusterConfig,
   OpenSearchClusterStatus,
   OpenSearchClusterTopology,
 } from '../types.js';
 import { OpenSearchClusterStatusSchema } from '../types.js';
-import { DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE } from '../constants.js';
 
 const DEFAULT_OPENSEARCH_VERSION = '3.2.0';
 
@@ -56,26 +53,21 @@ export interface OpenSearchClusterBuildOptions extends OpenSearchClusterTopology
   };
 }
 
-type OpenSearchClusterTlsConfig = NonNullable<
-  OpenSearchClusterConfig['tls']
->;
+type OpenSearchClusterTlsConfig = NonNullable<OpenSearchClusterConfig['tls']>;
 
-export type OpenSearchClusterConfigFor<
-  Options extends OpenSearchClusterBuildOptions,
-> = Omit<OpenSearchClusterConfig, 'tls' | 'snapshots'> & {
+export type OpenSearchClusterConfigFor<Options extends OpenSearchClusterBuildOptions> = Omit<
+  OpenSearchClusterConfig,
+  'tls' | 'snapshots'
+> & {
   readonly tls: Extract<
     OpenSearchClusterTlsConfig,
     {
-      readonly source: Options['tls'] extends undefined
-        ? 'generated'
-        : NonNullable<Options['tls']>;
+      readonly source: Options['tls'] extends undefined ? 'generated' : NonNullable<Options['tls']>;
     }
   >;
 } & (Options['snapshots'] extends true
     ? {
-        readonly snapshots: NonNullable<
-          OpenSearchClusterConfig['snapshots']
-        >;
+        readonly snapshots: NonNullable<OpenSearchClusterConfig['snapshots']>;
       }
     : { readonly snapshots?: never });
 
@@ -95,17 +87,21 @@ type OpenSearchClusterRuntimeSpec = Omit<
 function resolveTopology(options: OpenSearchClusterBuildOptions): ResolvedTopology {
   const profile = options.profile ?? 'development';
   const nodes = options.nodes ?? 3;
+  const roles = options.roles ?? ['cluster_manager', 'data', 'ingest'];
   if (!Number.isSafeInteger(nodes) || nodes < 3) {
     throw new Error(
       'makeOpenSearchCluster requires at least three nodes because the OpenSearch operator does not support single-node clusters.'
     );
   }
-  const pdb = options.podDisruptionBudget ??
+  if (!roles.includes('cluster_manager')) {
+    throw new Error(
+      'makeOpenSearchCluster roles must include cluster_manager because its single node pool must be able to elect a cluster manager.'
+    );
+  }
+  const pdb =
+    options.podDisruptionBudget ??
     (profile === 'production' ? { minAvailable: Math.max(1, nodes - 1) } : undefined);
-  if (
-    pdb?.minAvailable !== undefined &&
-    pdb.maxUnavailable !== undefined
-  ) {
+  if (pdb?.minAvailable !== undefined && pdb.maxUnavailable !== undefined) {
     throw new Error(
       'makeOpenSearchCluster podDisruptionBudget accepts minAvailable or maxUnavailable, not both.'
     );
@@ -113,7 +109,7 @@ function resolveTopology(options: OpenSearchClusterBuildOptions): ResolvedTopolo
   if (
     (pdb?.minAvailable !== undefined &&
       (!Number.isSafeInteger(pdb.minAvailable) ||
-        pdb.minAvailable < 0 ||
+        pdb.minAvailable < 1 ||
         pdb.minAvailable >= nodes)) ||
     (pdb?.maxUnavailable !== undefined &&
       (!Number.isSafeInteger(pdb.maxUnavailable) ||
@@ -128,8 +124,7 @@ function resolveTopology(options: OpenSearchClusterBuildOptions): ResolvedTopolo
     options.networkPolicy?.enabled === true
       ? {
           operatorNamespace:
-            options.networkPolicy.operatorNamespace ??
-            DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE,
+            options.networkPolicy.operatorNamespace ?? DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE,
           ingressNamespaceLabels: options.networkPolicy.ingressNamespaceLabels ?? {},
           egressNamespaceLabels: options.networkPolicy.egressNamespaceLabels ?? [],
           egressCidrs: options.networkPolicy.egressCidrs ?? [],
@@ -137,21 +132,13 @@ function resolveTopology(options: OpenSearchClusterBuildOptions): ResolvedTopolo
       : profile === 'production'
         ? {
             operatorNamespace:
-              options.networkPolicy?.operatorNamespace ??
-              DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE,
-            ingressNamespaceLabels:
-              options.networkPolicy?.ingressNamespaceLabels ?? {},
-            egressNamespaceLabels:
-              options.networkPolicy?.egressNamespaceLabels ?? [],
+              options.networkPolicy?.operatorNamespace ?? DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE,
+            ingressNamespaceLabels: options.networkPolicy?.ingressNamespaceLabels ?? {},
+            egressNamespaceLabels: options.networkPolicy?.egressNamespaceLabels ?? [],
             egressCidrs: options.networkPolicy?.egressCidrs ?? [],
           }
         : undefined;
-  if (
-    networkPolicy &&
-    !/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/u.test(
-      networkPolicy.operatorNamespace
-    )
-  ) {
+  if (networkPolicy && !/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/u.test(networkPolicy.operatorNamespace)) {
     throw new Error(
       'makeOpenSearchCluster networkPolicy.operatorNamespace must be a non-empty Kubernetes Namespace name.'
     );
@@ -168,7 +155,7 @@ function resolveTopology(options: OpenSearchClusterBuildOptions): ResolvedTopolo
   return {
     profile,
     nodes,
-    roles: options.roles ?? ['cluster_manager', 'data', 'ingest'],
+    roles,
     tls: options.tls ?? 'generated',
     snapshots: options.snapshots ?? false,
     snapshotCredentialKeys: {
@@ -238,10 +225,7 @@ export function makeOpenSearchCluster<
   const Options extends OpenSearchClusterBuildOptions = Record<never, never>,
 >(
   options: Options = {} as Options
-): CallableComposition<
-  OpenSearchClusterConfigFor<Options>,
-  OpenSearchClusterStatus
-> {
+): CallableComposition<OpenSearchClusterConfigFor<Options>, OpenSearchClusterStatus> {
   const topology = resolveTopology(options);
   const specSchema = buildSpecSchema(topology);
   return kubernetesComposition(
@@ -314,8 +298,7 @@ export function makeOpenSearchCluster<
           : {}),
         ...(spec.dashboardCredentialsSecret
           ? {
-              dashboardCredentialsSecret:
-                spec.dashboardCredentialsSecret,
+              dashboardCredentialsSecret: spec.dashboardCredentialsSecret,
             }
           : {}),
         tls:
@@ -332,13 +315,9 @@ export function makeOpenSearchCluster<
                   accessKeyKey: topology.snapshotCredentialKeys.accessKey,
                   secretKeyKey: topology.snapshotCredentialKeys.secretKey,
                 },
-                ...(spec.snapshots.endpoint
-                  ? { endpoint: spec.snapshots.endpoint }
-                  : {}),
+                ...(spec.snapshots.endpoint ? { endpoint: spec.snapshots.endpoint } : {}),
                 ...(spec.snapshots.region ? { region: spec.snapshots.region } : {}),
-                ...(spec.snapshots.basePath
-                  ? { basePath: spec.snapshots.basePath }
-                  : {}),
+                ...(spec.snapshots.basePath ? { basePath: spec.snapshots.basePath } : {}),
               },
             }
           : {}),
@@ -373,29 +352,32 @@ export function makeOpenSearchCluster<
                   {
                     namespaceSelector: {
                       matchLabels: {
-                        'kubernetes.io/metadata.name':
-                          topology.networkPolicy.operatorNamespace,
+                        'kubernetes.io/metadata.name': topology.networkPolicy.operatorNamespace,
                       },
                     },
                   },
                 ],
-                ports: [
-                  { protocol: 'TCP', port: OPENSEARCH_HTTP_PORT },
-                ],
+                ports: [{ protocol: 'TCP', port: OPENSEARCH_HTTP_PORT }],
               },
-              {
-                _from: [
-                  {
-                    namespaceSelector: {
-                      matchLabels:
-                        topology.networkPolicy.ingressNamespaceLabels,
+              ...(Object.keys(topology.networkPolicy.ingressNamespaceLabels).length > 0
+                ? [
+                    {
+                      _from: [
+                        {
+                          namespaceSelector: {
+                            matchLabels: topology.networkPolicy.ingressNamespaceLabels,
+                          },
+                        },
+                      ],
+                      ports: [
+                        {
+                          protocol: 'TCP' as const,
+                          port: OPENSEARCH_HTTP_PORT,
+                        },
+                      ],
                     },
-                  },
-                ],
-                ports: [
-                  { protocol: 'TCP', port: OPENSEARCH_HTTP_PORT },
-                ],
-              },
+                  ]
+                : []),
             ],
             egress: [
               { to: [{ podSelector: {} }] },
@@ -414,11 +396,9 @@ export function makeOpenSearchCluster<
                   { protocol: 'TCP', port: 53 },
                 ],
               },
-              ...topology.networkPolicy.egressNamespaceLabels.map(
-                (matchLabels) => ({
-                  to: [{ namespaceSelector: { matchLabels } }],
-                })
-              ),
+              ...topology.networkPolicy.egressNamespaceLabels.map((matchLabels) => ({
+                to: [{ namespaceSelector: { matchLabels } }],
+              })),
               ...topology.networkPolicy.egressCidrs.map((cidr) => ({
                 to: [{ ipBlock: { cidr } }],
               })),
@@ -456,14 +436,10 @@ export function makeOpenSearchCluster<
       ? undefined
       : {
           schemaFieldValidations: {
-            'tls.adminDn':
-              'size(self) > 0 && self.all(dn, size(dn) > 0)',
+            'tls.adminDn': 'size(self) > 0 && self.all(dn, size(dn) > 0)',
           },
         }
-  ) as unknown as CallableComposition<
-      OpenSearchClusterConfigFor<Options>,
-      OpenSearchClusterStatus
-    >;
+  ) as unknown as CallableComposition<OpenSearchClusterConfigFor<Options>, OpenSearchClusterStatus>;
 }
 
 export const openSearchCluster = makeOpenSearchCluster();

--- a/src/factories/opensearch/compositions/cluster.ts
+++ b/src/factories/opensearch/compositions/cluster.ts
@@ -17,6 +17,7 @@ import type {
   OpenSearchClusterTopology,
 } from '../types.js';
 import { OpenSearchClusterStatusSchema } from '../types.js';
+import { DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE } from '../constants.js';
 
 const DEFAULT_OPENSEARCH_VERSION = '3.2.0';
 
@@ -35,6 +36,7 @@ interface ResolvedTopology {
     readonly maxUnavailable?: number;
   };
   readonly networkPolicy?: {
+    readonly operatorNamespace: string;
     readonly ingressNamespaceLabels: Readonly<Record<string, string>>;
     readonly egressNamespaceLabels: readonly Readonly<Record<string, string>>[];
     readonly egressCidrs: readonly string[];
@@ -125,12 +127,18 @@ function resolveTopology(options: OpenSearchClusterBuildOptions): ResolvedTopolo
   const networkPolicy =
     options.networkPolicy?.enabled === true
       ? {
+          operatorNamespace:
+            options.networkPolicy.operatorNamespace ??
+            DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE,
           ingressNamespaceLabels: options.networkPolicy.ingressNamespaceLabels ?? {},
           egressNamespaceLabels: options.networkPolicy.egressNamespaceLabels ?? [],
           egressCidrs: options.networkPolicy.egressCidrs ?? [],
         }
       : profile === 'production'
         ? {
+            operatorNamespace:
+              options.networkPolicy?.operatorNamespace ??
+              DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE,
             ingressNamespaceLabels:
               options.networkPolicy?.ingressNamespaceLabels ?? {},
             egressNamespaceLabels:
@@ -138,6 +146,16 @@ function resolveTopology(options: OpenSearchClusterBuildOptions): ResolvedTopolo
             egressCidrs: options.networkPolicy?.egressCidrs ?? [],
           }
         : undefined;
+  if (
+    networkPolicy &&
+    !/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/u.test(
+      networkPolicy.operatorNamespace
+    )
+  ) {
+    throw new Error(
+      'makeOpenSearchCluster networkPolicy.operatorNamespace must be a non-empty Kubernetes Namespace name.'
+    );
+  }
   if (
     profile === 'production' &&
     networkPolicy &&
@@ -188,7 +206,7 @@ function buildSpecSchema(topology: ResolvedTopology) {
       source: '"secret"',
       secretName: 'string > 0',
       adminSecretName: 'string > 0',
-      'adminDn?': 'string[]',
+      adminDn: '(string > 0)[] > 0',
     };
   } else {
     shape.tls = {
@@ -198,7 +216,7 @@ function buildSpecSchema(topology: ResolvedTopology) {
       issuerName: 'string > 0',
       'issuerKind?': '"Issuer" | "ClusterIssuer"',
       dnsNames: 'string[] > 0',
-      'adminDn?': 'string[]',
+      adminDn: '(string > 0)[] > 0',
     };
   }
   if (topology.snapshots) {
@@ -354,6 +372,21 @@ export function makeOpenSearchCluster<
                 _from: [
                   {
                     namespaceSelector: {
+                      matchLabels: {
+                        'kubernetes.io/metadata.name':
+                          topology.networkPolicy.operatorNamespace,
+                      },
+                    },
+                  },
+                ],
+                ports: [
+                  { protocol: 'TCP', port: OPENSEARCH_HTTP_PORT },
+                ],
+              },
+              {
+                _from: [
+                  {
+                    namespaceSelector: {
                       matchLabels:
                         topology.networkPolicy.ingressNamespaceLabels,
                     },
@@ -418,7 +451,15 @@ export function makeOpenSearchCluster<
           'has(cluster.spec.general.snapshotRepositories) && cluster.spec.general.snapshotRepositories.size() > 0 ? cluster.spec.general.snapshotRepositories[0].name : ""'
         ),
       };
-    }
+    },
+    topology.tls === 'generated'
+      ? undefined
+      : {
+          schemaFieldValidations: {
+            'tls.adminDn':
+              'size(self) > 0 && self.all(dn, size(dn) > 0)',
+          },
+        }
   ) as unknown as CallableComposition<
       OpenSearchClusterConfigFor<Options>,
       OpenSearchClusterStatus
@@ -434,7 +475,7 @@ function externalTls(
   readonly source: 'secret' | 'cert-manager';
   readonly secretName: string;
   readonly adminSecretName: string;
-  readonly adminDn?: readonly string[];
+  readonly adminDn: readonly string[];
 } {
   if (tls.source === 'generated') {
     throw new Error(
@@ -445,6 +486,6 @@ function externalTls(
     source,
     secretName: tls.secretName,
     adminSecretName: tls.adminSecretName,
-    ...(tls.adminDn ? { adminDn: tls.adminDn } : {}),
+    adminDn: tls.adminDn,
   };
 }

--- a/src/factories/opensearch/compositions/cluster.ts
+++ b/src/factories/opensearch/compositions/cluster.ts
@@ -1,0 +1,450 @@
+import { type } from 'arktype';
+import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { setIncludeWhen } from '../../../core/metadata/resource-metadata.js';
+import { Cel } from '../../../core/references/cel.js';
+import type { CallableComposition } from '../../../core/types/deployment.js';
+import { isKubernetesRef } from '../../../utils/type-guards.js';
+import { certificate } from '../../cert-manager/resources/certificates.js';
+import { namespace } from '../../kubernetes/core/namespace.js';
+import { networkPolicy } from '../../kubernetes/networking/network-policy.js';
+import {
+  OPENSEARCH_HTTP_PORT,
+  openSearchClusterResource,
+} from '../resources/cluster.js';
+import type {
+  OpenSearchClusterConfig,
+  OpenSearchClusterStatus,
+  OpenSearchClusterTopology,
+} from '../types.js';
+import { OpenSearchClusterStatusSchema } from '../types.js';
+
+const DEFAULT_OPENSEARCH_VERSION = '3.2.0';
+
+interface ResolvedTopology {
+  readonly profile: 'development' | 'production';
+  readonly nodes: number;
+  readonly roles: readonly ('cluster_manager' | 'data' | 'ingest')[];
+  readonly tls: 'generated' | 'secret' | 'cert-manager';
+  readonly snapshots: boolean;
+  readonly snapshotCredentialKeys: {
+    readonly accessKey: string;
+    readonly secretKey: string;
+  };
+  readonly podDisruptionBudget?: {
+    readonly minAvailable?: number;
+    readonly maxUnavailable?: number;
+  };
+  readonly networkPolicy?: {
+    readonly ingressNamespaceLabels: Readonly<Record<string, string>>;
+    readonly egressNamespaceLabels: readonly Readonly<Record<string, string>>[];
+    readonly egressCidrs: readonly string[];
+  };
+}
+
+export interface OpenSearchClusterBuildOptions extends OpenSearchClusterTopology {
+  readonly tls?: 'generated' | 'secret' | 'cert-manager';
+  readonly snapshots?: boolean;
+  /**
+   * OpenSearch operator keystore mappings use Secret keys as YAML map keys,
+   * so these are build-time path fragments rather than runtime values.
+   */
+  readonly snapshotCredentialKeys?: {
+    readonly accessKey?: string;
+    readonly secretKey?: string;
+  };
+}
+
+type OpenSearchClusterTlsConfig = NonNullable<
+  OpenSearchClusterConfig['tls']
+>;
+
+export type OpenSearchClusterConfigFor<
+  Options extends OpenSearchClusterBuildOptions,
+> = Omit<OpenSearchClusterConfig, 'tls' | 'snapshots'> & {
+  readonly tls: Extract<
+    OpenSearchClusterTlsConfig,
+    {
+      readonly source: Options['tls'] extends undefined
+        ? 'generated'
+        : NonNullable<Options['tls']>;
+    }
+  >;
+} & (Options['snapshots'] extends true
+    ? {
+        readonly snapshots: NonNullable<
+          OpenSearchClusterConfig['snapshots']
+        >;
+      }
+    : { readonly snapshots?: never });
+
+type OpenSearchClusterRuntimeSpec = Omit<
+  OpenSearchClusterConfig,
+  'name' | 'namespace' | 'storage' | 'tls'
+> & {
+  readonly name: string;
+  readonly namespace: string;
+  readonly storage: {
+    readonly size: string;
+    readonly storageClassName?: string;
+  };
+  readonly tls: NonNullable<OpenSearchClusterConfig['tls']>;
+};
+
+function resolveTopology(options: OpenSearchClusterBuildOptions): ResolvedTopology {
+  const profile = options.profile ?? 'development';
+  const nodes = options.nodes ?? 3;
+  if (!Number.isSafeInteger(nodes) || nodes < 3) {
+    throw new Error(
+      'makeOpenSearchCluster requires at least three nodes because the OpenSearch operator does not support single-node clusters.'
+    );
+  }
+  const pdb = options.podDisruptionBudget ??
+    (profile === 'production' ? { minAvailable: Math.max(1, nodes - 1) } : undefined);
+  if (
+    pdb?.minAvailable !== undefined &&
+    pdb.maxUnavailable !== undefined
+  ) {
+    throw new Error(
+      'makeOpenSearchCluster podDisruptionBudget accepts minAvailable or maxUnavailable, not both.'
+    );
+  }
+  if (
+    (pdb?.minAvailable !== undefined &&
+      (!Number.isSafeInteger(pdb.minAvailable) ||
+        pdb.minAvailable < 0 ||
+        pdb.minAvailable >= nodes)) ||
+    (pdb?.maxUnavailable !== undefined &&
+      (!Number.isSafeInteger(pdb.maxUnavailable) ||
+        pdb.maxUnavailable < 0 ||
+        pdb.maxUnavailable >= nodes))
+  ) {
+    throw new Error(
+      'makeOpenSearchCluster PodDisruptionBudget must preserve at least one available node.'
+    );
+  }
+  const networkPolicy =
+    options.networkPolicy?.enabled === true
+      ? {
+          ingressNamespaceLabels: options.networkPolicy.ingressNamespaceLabels ?? {},
+          egressNamespaceLabels: options.networkPolicy.egressNamespaceLabels ?? [],
+          egressCidrs: options.networkPolicy.egressCidrs ?? [],
+        }
+      : profile === 'production'
+        ? {
+            ingressNamespaceLabels:
+              options.networkPolicy?.ingressNamespaceLabels ?? {},
+            egressNamespaceLabels:
+              options.networkPolicy?.egressNamespaceLabels ?? [],
+            egressCidrs: options.networkPolicy?.egressCidrs ?? [],
+          }
+        : undefined;
+  if (
+    profile === 'production' &&
+    networkPolicy &&
+    Object.keys(networkPolicy.ingressNamespaceLabels).length === 0
+  ) {
+    throw new Error(
+      'makeOpenSearchCluster production network policy requires ingressNamespaceLabels.'
+    );
+  }
+  return {
+    profile,
+    nodes,
+    roles: options.roles ?? ['cluster_manager', 'data', 'ingest'],
+    tls: options.tls ?? 'generated',
+    snapshots: options.snapshots ?? false,
+    snapshotCredentialKeys: {
+      accessKey: options.snapshotCredentialKeys?.accessKey ?? 'accessKey',
+      secretKey: options.snapshotCredentialKeys?.secretKey ?? 'secretKey',
+    },
+    ...(pdb ? { podDisruptionBudget: pdb } : {}),
+    ...(networkPolicy ? { networkPolicy } : {}),
+  };
+}
+
+function buildSpecSchema(topology: ResolvedTopology) {
+  const shape: Record<string, unknown> = {
+    name: 'string > 0',
+    namespace: 'string > 0',
+    'version?': 'string > 0',
+    'serviceName?': 'string > 0',
+    'lifecycle?': '"owned-delete" | "external-delete" | "external-retain"',
+    storage: {
+      size: 'string > 0',
+      'storageClassName?': 'string > 0',
+    },
+    'resources?': {
+      'requests?': { 'cpu?': 'string', 'memory?': 'string' },
+      'limits?': { 'cpu?': 'string', 'memory?': 'string' },
+    },
+    'adminCredentialsSecret?': { name: 'string > 0' },
+    'dashboardCredentialsSecret?': { name: 'string > 0' },
+    'monitoring?': 'boolean',
+  };
+  if (topology.tls === 'generated') {
+    shape.tls = { source: '"generated"' };
+  } else if (topology.tls === 'secret') {
+    shape.tls = {
+      source: '"secret"',
+      secretName: 'string > 0',
+      adminSecretName: 'string > 0',
+      'adminDn?': 'string[]',
+    };
+  } else {
+    shape.tls = {
+      source: '"cert-manager"',
+      secretName: 'string > 0',
+      adminSecretName: 'string > 0',
+      issuerName: 'string > 0',
+      'issuerKind?': '"Issuer" | "ClusterIssuer"',
+      dnsNames: 'string[] > 0',
+      'adminDn?': 'string[]',
+    };
+  }
+  if (topology.snapshots) {
+    shape.snapshots = {
+      repository: 'string > 0',
+      bucket: 'string > 0',
+      credentialsSecret: {
+        name: 'string > 0',
+      },
+      'endpoint?': 'string',
+      'region?': 'string',
+      'basePath?': 'string',
+    };
+  }
+  return type(shape as never);
+}
+
+export function makeOpenSearchCluster<
+  const Options extends OpenSearchClusterBuildOptions = Record<never, never>,
+>(
+  options: Options = {} as Options
+): CallableComposition<
+  OpenSearchClusterConfigFor<Options>,
+  OpenSearchClusterStatus
+> {
+  const topology = resolveTopology(options);
+  const specSchema = buildSpecSchema(topology);
+  return kubernetesComposition(
+    {
+      name: 'opensearch-cluster',
+      kind: 'OpenSearchClusterInstallation',
+      spec: specSchema as never,
+      status: OpenSearchClusterStatusSchema,
+    },
+    (spec: OpenSearchClusterRuntimeSpec) => {
+      const lifecycle = spec.lifecycle ?? 'owned-delete';
+      const clusterNamespace = namespace({
+        metadata: {
+          name: spec.namespace,
+          labels: {
+            'app.kubernetes.io/name': 'opensearch',
+            'app.kubernetes.io/instance': spec.name,
+            'app.kubernetes.io/managed-by': 'typekro',
+          },
+        },
+        id: 'clusterNamespace',
+      });
+      if (isKubernetesRef(spec.name)) {
+        setIncludeWhen(clusterNamespace, [
+          Cel.expr<boolean>(
+            '!has(schema.spec.lifecycle) || schema.spec.lifecycle == "owned-delete"'
+          ),
+        ]);
+      } else if (lifecycle !== 'owned-delete') {
+        setIncludeWhen(clusterNamespace, [false]);
+      }
+      let serverCertificate: ReturnType<typeof certificate> | undefined;
+      if (topology.tls === 'cert-manager') {
+        const tls = spec.tls as Extract<
+          NonNullable<OpenSearchClusterConfig['tls']>,
+          { source: 'cert-manager' }
+        >;
+        serverCertificate = certificate({
+          name: `${spec.name}-http`,
+          namespace: spec.namespace,
+          spec: {
+            secretName: tls.secretName,
+            issuerRef: {
+              name: tls.issuerName,
+              kind: tls.issuerKind ?? 'ClusterIssuer',
+            },
+            dnsNames: tls.dnsNames,
+            usages: ['server auth'],
+          },
+          id: 'httpCertificate',
+        });
+      }
+      const cluster = openSearchClusterResource({
+        name: spec.name,
+        namespace: spec.namespace,
+        version: spec.version ?? DEFAULT_OPENSEARCH_VERSION,
+        serviceName: spec.serviceName ?? spec.name,
+        nodes: topology.nodes,
+        roles: topology.roles,
+        storage: {
+          size: spec.storage.size,
+          ...(spec.storage.storageClassName
+            ? { storageClassName: spec.storage.storageClassName }
+            : {}),
+          deletionPolicy: lifecycle === 'external-retain' ? 'retain' : 'delete',
+        },
+        ...(spec.resources ? { resources: spec.resources } : {}),
+        ...(spec.adminCredentialsSecret
+          ? { adminCredentialsSecret: spec.adminCredentialsSecret }
+          : {}),
+        ...(spec.dashboardCredentialsSecret
+          ? {
+              dashboardCredentialsSecret:
+                spec.dashboardCredentialsSecret,
+            }
+          : {}),
+        tls:
+          topology.tls === 'generated'
+            ? { source: 'generated' }
+            : externalTls(spec.tls, topology.tls),
+        ...(topology.snapshots && spec.snapshots
+          ? {
+              snapshots: {
+                repository: spec.snapshots.repository,
+                bucket: spec.snapshots.bucket,
+                credentialsSecret: {
+                  name: spec.snapshots.credentialsSecret.name,
+                  accessKeyKey: topology.snapshotCredentialKeys.accessKey,
+                  secretKeyKey: topology.snapshotCredentialKeys.secretKey,
+                },
+                ...(spec.snapshots.endpoint
+                  ? { endpoint: spec.snapshots.endpoint }
+                  : {}),
+                ...(spec.snapshots.region ? { region: spec.snapshots.region } : {}),
+                ...(spec.snapshots.basePath
+                  ? { basePath: spec.snapshots.basePath }
+                  : {}),
+              },
+            }
+          : {}),
+        monitoring: spec.monitoring ?? false,
+        ...(topology.podDisruptionBudget
+          ? { podDisruptionBudget: topology.podDisruptionBudget }
+          : {}),
+        id: 'cluster',
+      });
+      if (serverCertificate) cluster.dependsOn(serverCertificate);
+
+      if (topology.networkPolicy) {
+        const podSelector = {
+          matchLabels: {
+            'opensearch.org/opensearch-cluster': spec.name,
+          },
+        };
+        networkPolicy({
+          metadata: {
+            name: `${spec.name}-default`,
+            namespace: spec.namespace,
+          },
+          spec: {
+            podSelector,
+            policyTypes: ['Ingress', 'Egress'],
+            ingress: [
+              {
+                _from: [{ podSelector: {} }],
+              },
+              {
+                _from: [
+                  {
+                    namespaceSelector: {
+                      matchLabels:
+                        topology.networkPolicy.ingressNamespaceLabels,
+                    },
+                  },
+                ],
+                ports: [
+                  { protocol: 'TCP', port: OPENSEARCH_HTTP_PORT },
+                ],
+              },
+            ],
+            egress: [
+              { to: [{ podSelector: {} }] },
+              {
+                to: [
+                  {
+                    namespaceSelector: {
+                      matchLabels: {
+                        'kubernetes.io/metadata.name': 'kube-system',
+                      },
+                    },
+                  },
+                ],
+                ports: [
+                  { protocol: 'UDP', port: 53 },
+                  { protocol: 'TCP', port: 53 },
+                ],
+              },
+              ...topology.networkPolicy.egressNamespaceLabels.map(
+                (matchLabels) => ({
+                  to: [{ namespaceSelector: { matchLabels } }],
+                })
+              ),
+              ...topology.networkPolicy.egressCidrs.map((cidr) => ({
+                to: [{ ipBlock: { cidr } }],
+              })),
+            ],
+          },
+          id: 'networkPolicy',
+        });
+      }
+
+      const failed = Cel.expr<boolean>(
+        'cluster.status.componentsStatus.exists(c, c.status == "Failed" || c.status == "Error")'
+      );
+      const ready = Cel.expr<boolean>(
+        `cluster.status.initialized == true && cluster.status.availableNodes >= ${topology.nodes} && (cluster.status.health == "green" || cluster.status.health == "yellow")`
+      );
+      return {
+        ready,
+        failed,
+        phase: Cel.expr<'Ready' | 'Installing' | 'Failed'>(
+          `cluster.status.componentsStatus.exists(c, c.status == "Failed" || c.status == "Error") ? "Failed" : (cluster.status.initialized == true && cluster.status.availableNodes >= ${topology.nodes} && (cluster.status.health == "green" || cluster.status.health == "yellow") ? "Ready" : "Installing")`
+        ),
+        endpoint: `https://${cluster.spec.general.serviceName}.${cluster.metadata.namespace}.svc.cluster.local:${OPENSEARCH_HTTP_PORT}`,
+        credentialsSecret: Cel.expr<string>(
+          `has(cluster.spec.security.config.adminCredentialsSecret) && cluster.spec.security.config.adminCredentialsSecret.name != "" ? cluster.spec.security.config.adminCredentialsSecret.name : string(cluster.metadata.name) + "-admin-password"`
+        ),
+        version: cluster.spec.general.version,
+        availableNodes: cluster.status.availableNodes,
+        health: cluster.status.health,
+        snapshotRepository: Cel.expr<string>(
+          'has(cluster.spec.general.snapshotRepositories) && cluster.spec.general.snapshotRepositories.size() > 0 ? cluster.spec.general.snapshotRepositories[0].name : ""'
+        ),
+      };
+    }
+  ) as unknown as CallableComposition<
+      OpenSearchClusterConfigFor<Options>,
+      OpenSearchClusterStatus
+    >;
+}
+
+export const openSearchCluster = makeOpenSearchCluster();
+
+function externalTls(
+  tls: NonNullable<OpenSearchClusterConfig['tls']>,
+  source: 'secret' | 'cert-manager'
+): {
+  readonly source: 'secret' | 'cert-manager';
+  readonly secretName: string;
+  readonly adminSecretName: string;
+  readonly adminDn?: readonly string[];
+} {
+  if (tls.source === 'generated') {
+    throw new Error(
+      `makeOpenSearchCluster configured TLS source ${source}, but the instance supplied generated TLS.`
+    );
+  }
+  return {
+    source,
+    secretName: tls.secretName,
+    adminSecretName: tls.adminSecretName,
+    ...(tls.adminDn ? { adminDn: tls.adminDn } : {}),
+  };
+}

--- a/src/factories/opensearch/compositions/index.ts
+++ b/src/factories/opensearch/compositions/index.ts
@@ -1,0 +1,3 @@
+export * from './cluster.js';
+export * from './operator-bootstrap.js';
+export * from './repository.js';

--- a/src/factories/opensearch/compositions/operator-bootstrap.ts
+++ b/src/factories/opensearch/compositions/operator-bootstrap.ts
@@ -16,6 +16,7 @@ import {
   OpenSearchOperatorBootstrapStatusSchema,
 } from '../types.js';
 import { openSearchHelmRepositoryBootstrap } from './repository.js';
+import { DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE } from '../constants.js';
 
 export const openSearchOperatorBootstrap = kubernetesComposition(
   {
@@ -25,7 +26,8 @@ export const openSearchOperatorBootstrap = kubernetesComposition(
     status: OpenSearchOperatorBootstrapStatusSchema,
   },
   (spec: OpenSearchOperatorBootstrapConfig) => {
-    const operatorNamespace = spec.namespace || 'opensearch-operator-system';
+    const operatorNamespace =
+      spec.namespace || DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE;
     const version = spec.version || DEFAULT_OPENSEARCH_OPERATOR_VERSION;
     const repositoryName =
       spec.repositoryName || DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_NAME;
@@ -64,7 +66,7 @@ export const openSearchOperatorBootstrap = kubernetesComposition(
     }
     return {
       ...helmReleaseConditionSummary(release),
-      version,
+      version: release.spec.chart.spec.version,
     };
   }
 );

--- a/src/factories/opensearch/compositions/operator-bootstrap.ts
+++ b/src/factories/opensearch/compositions/operator-bootstrap.ts
@@ -1,9 +1,9 @@
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
-import { setMetadataField } from '../../../core/metadata/index.js';
 import { singleton } from '../../../core/singleton/singleton.js';
 import { helmReleaseConditionSummary } from '../../helm/status.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
+import { DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE } from '../constants.js';
 import {
   DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_NAME,
   DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_URL,
@@ -11,29 +11,32 @@ import {
   openSearchOperatorHelmRelease,
 } from '../resources/helm.js';
 import {
+  type OpenSearchOperatorBootstrapBuildOptions,
   type OpenSearchOperatorBootstrapConfig,
   OpenSearchOperatorBootstrapConfigSchema,
   OpenSearchOperatorBootstrapStatusSchema,
+  type OpenSearchOperatorReferenceConfig,
+  OpenSearchOperatorReferenceConfigSchema,
 } from '../types.js';
 import { openSearchHelmRepositoryBootstrap } from './repository.js';
-import { DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE } from '../constants.js';
 
-export const openSearchOperatorBootstrap = kubernetesComposition(
+/**
+ * Explicitly owned operator installation. Deleting its KRO instance uninstalls
+ * the operator; shared consumers should use openSearchOperatorBootstrap.
+ */
+export const openSearchOperatorInstallation = kubernetesComposition(
   {
-    name: 'opensearch-operator-bootstrap',
-    kind: 'OpenSearchOperatorBootstrap',
+    name: 'opensearch-operator-installation',
+    kind: 'OpenSearchOperatorInstallation',
     spec: OpenSearchOperatorBootstrapConfigSchema,
     status: OpenSearchOperatorBootstrapStatusSchema,
   },
   (spec: OpenSearchOperatorBootstrapConfig) => {
-    const operatorNamespace =
-      spec.namespace || DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE;
+    const operatorNamespace = spec.namespace || DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE;
     const version = spec.version || DEFAULT_OPENSEARCH_OPERATOR_VERSION;
-    const repositoryName =
-      spec.repositoryName || DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_NAME;
+    const repositoryName = spec.repositoryName || DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_NAME;
     const repositoryNamespace = spec.repositoryNamespace || DEFAULT_FLUX_NAMESPACE;
-    const shared = spec.shared !== false;
-    const operatorNamespaceResource = namespace({
+    namespace({
       metadata: {
         name: operatorNamespace,
         labels: {
@@ -60,13 +63,49 @@ export const openSearchOperatorBootstrap = kubernetesComposition(
       values: spec.customValues,
       id: 'operatorRelease',
     });
-    if (shared) {
-      setMetadataField(operatorNamespaceResource, 'scopes', ['cluster']);
-      setMetadataField(release, 'scopes', ['cluster']);
-    }
     return {
       ...helmReleaseConditionSummary(release),
       version: release.spec.chart.spec.version,
     };
   }
 );
+
+/**
+ * Create a shared operator reference whose complete installation is owned by
+ * one singleton instance in typekro-singletons. Ownership is build-time so a
+ * KRO schema proxy can never silently change lifecycle semantics.
+ */
+export function makeOpenSearchOperatorBootstrap(
+  options: OpenSearchOperatorBootstrapBuildOptions = {}
+) {
+  const installation: OpenSearchOperatorBootstrapConfig = {
+    name: options.name ?? 'opensearch-operator',
+    namespace: options.namespace ?? DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE,
+    version: options.version ?? DEFAULT_OPENSEARCH_OPERATOR_VERSION,
+    repositoryName: options.repositoryName ?? DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_NAME,
+    repositoryNamespace: options.repositoryNamespace ?? DEFAULT_FLUX_NAMESPACE,
+    ...(options.customValues ? { customValues: options.customValues } : {}),
+  };
+  return kubernetesComposition(
+    {
+      name: 'opensearch-operator-bootstrap',
+      kind: 'OpenSearchOperatorBootstrap',
+      spec: OpenSearchOperatorReferenceConfigSchema,
+      status: OpenSearchOperatorBootstrapStatusSchema,
+    },
+    (_spec: OpenSearchOperatorReferenceConfig) => {
+      const owner = singleton(openSearchOperatorInstallation, {
+        id: 'opensearch-operator',
+        spec: installation,
+      });
+      return {
+        ready: owner.status.ready,
+        failed: owner.status.failed,
+        phase: owner.status.phase,
+        version: owner.status.version,
+      };
+    }
+  );
+}
+
+export const openSearchOperatorBootstrap = makeOpenSearchOperatorBootstrap();

--- a/src/factories/opensearch/compositions/operator-bootstrap.ts
+++ b/src/factories/opensearch/compositions/operator-bootstrap.ts
@@ -1,0 +1,70 @@
+import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
+import { setMetadataField } from '../../../core/metadata/index.js';
+import { singleton } from '../../../core/singleton/singleton.js';
+import { helmReleaseConditionSummary } from '../../helm/status.js';
+import { namespace } from '../../kubernetes/core/namespace.js';
+import {
+  DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_NAME,
+  DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_URL,
+  DEFAULT_OPENSEARCH_OPERATOR_VERSION,
+  openSearchOperatorHelmRelease,
+} from '../resources/helm.js';
+import {
+  type OpenSearchOperatorBootstrapConfig,
+  OpenSearchOperatorBootstrapConfigSchema,
+  OpenSearchOperatorBootstrapStatusSchema,
+} from '../types.js';
+import { openSearchHelmRepositoryBootstrap } from './repository.js';
+
+export const openSearchOperatorBootstrap = kubernetesComposition(
+  {
+    name: 'opensearch-operator-bootstrap',
+    kind: 'OpenSearchOperatorBootstrap',
+    spec: OpenSearchOperatorBootstrapConfigSchema,
+    status: OpenSearchOperatorBootstrapStatusSchema,
+  },
+  (spec: OpenSearchOperatorBootstrapConfig) => {
+    const operatorNamespace = spec.namespace || 'opensearch-operator-system';
+    const version = spec.version || DEFAULT_OPENSEARCH_OPERATOR_VERSION;
+    const repositoryName =
+      spec.repositoryName || DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_NAME;
+    const repositoryNamespace = spec.repositoryNamespace || DEFAULT_FLUX_NAMESPACE;
+    const shared = spec.shared !== false;
+    const operatorNamespaceResource = namespace({
+      metadata: {
+        name: operatorNamespace,
+        labels: {
+          'app.kubernetes.io/name': 'opensearch-operator',
+          'app.kubernetes.io/managed-by': 'typekro',
+        },
+      },
+      id: 'operatorNamespace',
+    });
+    const _repository = singleton(openSearchHelmRepositoryBootstrap, {
+      id: 'opensearch-helm-repository',
+      spec: {
+        name: repositoryName,
+        namespace: repositoryNamespace,
+        url: DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_URL,
+      },
+    });
+    const release = openSearchOperatorHelmRelease({
+      name: spec.name,
+      namespace: operatorNamespace,
+      version,
+      repositoryName,
+      repositoryNamespace,
+      values: spec.customValues,
+      id: 'operatorRelease',
+    });
+    if (shared) {
+      setMetadataField(operatorNamespaceResource, 'scopes', ['cluster']);
+      setMetadataField(release, 'scopes', ['cluster']);
+    }
+    return {
+      ...helmReleaseConditionSummary(release),
+      version,
+    };
+  }
+);

--- a/src/factories/opensearch/compositions/repository.ts
+++ b/src/factories/opensearch/compositions/repository.ts
@@ -1,0 +1,30 @@
+import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { Cel } from '../../../core/references/cel.js';
+import { openSearchOperatorHelmRepository } from '../resources/helm.js';
+import {
+  OpenSearchHelmRepositorySingletonSpecSchema,
+  OpenSearchHelmRepositorySingletonStatusSchema,
+} from '../types.js';
+
+export const openSearchHelmRepositoryBootstrap = kubernetesComposition(
+  {
+    name: 'opensearch-helm-repository',
+    kind: 'OpenSearchHelmRepository',
+    spec: OpenSearchHelmRepositorySingletonSpecSchema,
+    status: OpenSearchHelmRepositorySingletonStatusSchema,
+  },
+  (spec) => {
+    const repository = openSearchOperatorHelmRepository({
+      name: spec.name,
+      namespace: spec.namespace,
+      url: spec.url,
+      id: 'repository',
+    });
+    return {
+      ready: Cel.expr<boolean>(
+        repository.status.conditions,
+        '.exists(c, c.type == "Ready" && c.status == "True")'
+      ),
+    };
+  }
+);

--- a/src/factories/opensearch/constants.ts
+++ b/src/factories/opensearch/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_OPENSEARCH_OPERATOR_NAMESPACE =
+  'opensearch-operator-system';

--- a/src/factories/opensearch/index.ts
+++ b/src/factories/opensearch/index.ts
@@ -6,5 +6,6 @@
  * certificate, and network-policy resources.
  */
 export * from './compositions/index.js';
+export * from './constants.js';
 export * from './resources/index.js';
 export * from './types.js';

--- a/src/factories/opensearch/index.ts
+++ b/src/factories/opensearch/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Official OpenSearch Kubernetes operator integration for TypeKro.
+ *
+ * The operator bootstrap owns the cluster-scoped controller and CRDs. Cluster
+ * compositions own only their declared namespace, OpenSearchCluster,
+ * certificate, and network-policy resources.
+ */
+export * from './compositions/index.js';
+export * from './resources/index.js';
+export * from './types.js';

--- a/src/factories/opensearch/resources/cluster.ts
+++ b/src/factories/opensearch/resources/cluster.ts
@@ -78,7 +78,7 @@ function compileOpenSearchClusterSpec(
           http: {
             generate: false as const,
             secret: { name: config.tls.secretName },
-            ...(config.tls.adminDn ? { adminDn: config.tls.adminDn } : {}),
+            adminDn: config.tls.adminDn,
           },
           transport: { generate: true as const, perNode: true as const },
         };

--- a/src/factories/opensearch/resources/cluster.ts
+++ b/src/factories/opensearch/resources/cluster.ts
@@ -37,24 +37,28 @@ export function openSearchClusterReadinessEvaluator(liveResource: unknown): Reso
     };
   }
   const expectedNodes =
-    observed?.spec?.nodePools.reduce(
-      (total, pool) => total + pool.replicas,
-      0
-    ) ?? 1;
+    observed?.spec?.nodePools.reduce((total, pool) => total + pool.replicas, 0) ?? 1;
+  const expectedVersion = observed?.spec?.general.version;
+  const observedVersion = status.version;
   const ready =
     status.initialized === true &&
     (status.availableNodes ?? 0) >= expectedNodes &&
-    ['green', 'yellow'].includes(status.health?.toLowerCase() ?? '');
+    ['green', 'yellow'].includes(status.health?.toLowerCase() ?? '') &&
+    typeof expectedVersion === 'string' &&
+    observedVersion === expectedVersion;
   return ready
     ? {
         ready: true,
         reason: 'ClusterReady',
-        message: `${status.availableNodes ?? 0} nodes available; health=${status.health}`,
+        message: `${status.availableNodes ?? 0} nodes available; health=${status.health}; version=${observedVersion}`,
       }
     : {
         ready: false,
-        reason: status.phase || 'ClusterProgressing',
-        message: `${status.availableNodes ?? 0} nodes available; health=${status.health ?? 'unknown'}`,
+        reason:
+          expectedVersion && observedVersion && observedVersion !== expectedVersion
+            ? 'VersionProgressing'
+            : status.phase || 'ClusterProgressing',
+        message: `${status.availableNodes ?? 0} nodes available; health=${status.health ?? 'unknown'}; version=${observedVersion ?? 'unknown'}; desiredVersion=${expectedVersion ?? 'unknown'}`,
       };
 }
 
@@ -98,10 +102,8 @@ function compileOpenSearchClusterSpec(
                 secret: {
                   name: snapshot.credentialsSecret.name,
                   keyMappings: {
-                    [snapshot.credentialsSecret.accessKeyKey]:
-                      's3.client.default.access_key',
-                    [snapshot.credentialsSecret.secretKeyKey]:
-                      's3.client.default.secret_key',
+                    [snapshot.credentialsSecret.accessKeyKey]: 's3.client.default.access_key',
+                    [snapshot.credentialsSecret.secretKeyKey]: 's3.client.default.secret_key',
                   },
                 },
               },
@@ -136,8 +138,7 @@ function compileOpenSearchClusterSpec(
       enable: false,
       ...(config.dashboardCredentialsSecret
         ? {
-            opensearchCredentialsSecret:
-              config.dashboardCredentialsSecret,
+            opensearchCredentialsSecret: config.dashboardCredentialsSecret,
           }
         : {}),
     },

--- a/src/factories/opensearch/resources/cluster.ts
+++ b/src/factories/opensearch/resources/cluster.ts
@@ -1,0 +1,211 @@
+import { registerPortableReadinessEvaluator } from '../../../core/readiness/index.js';
+import type { Composable, Enhanced, ResourceStatus } from '../../../core/types/index.js';
+import { createResource } from '../../shared.js';
+import type {
+  OpenSearchClusterObservedStatus,
+  OpenSearchClusterResourceConfig,
+  OpenSearchClusterResourceSpec,
+} from '../types.js';
+
+export const OPENSEARCH_HTTP_PORT = 9200;
+
+export function openSearchClusterReadinessEvaluator(liveResource: unknown): ResourceStatus {
+  const observed = liveResource as
+    | {
+        readonly spec?: OpenSearchClusterResourceSpec;
+        readonly status?: OpenSearchClusterObservedStatus;
+      }
+    | undefined;
+  const status = observed?.status;
+  if (!status) {
+    return {
+      ready: false,
+      reason: 'StatusMissing',
+      message: 'OpenSearchCluster has no observed status yet',
+    };
+  }
+  const failedComponent = status.componentsStatus?.find(({ status: componentStatus }) =>
+    ['failed', 'error'].includes(componentStatus?.toLowerCase() ?? '')
+  );
+  if (failedComponent) {
+    return {
+      ready: false,
+      reason: 'ComponentFailed',
+      message:
+        failedComponent.description ??
+        `OpenSearch component ${failedComponent.component ?? '<unknown>'} failed`,
+    };
+  }
+  const expectedNodes =
+    observed?.spec?.nodePools.reduce(
+      (total, pool) => total + pool.replicas,
+      0
+    ) ?? 1;
+  const ready =
+    status.initialized === true &&
+    (status.availableNodes ?? 0) >= expectedNodes &&
+    ['green', 'yellow'].includes(status.health?.toLowerCase() ?? '');
+  return ready
+    ? {
+        ready: true,
+        reason: 'ClusterReady',
+        message: `${status.availableNodes ?? 0} nodes available; health=${status.health}`,
+      }
+    : {
+        ready: false,
+        reason: status.phase || 'ClusterProgressing',
+        message: `${status.availableNodes ?? 0} nodes available; health=${status.health ?? 'unknown'}`,
+      };
+}
+
+registerPortableReadinessEvaluator(
+  'typekro.readiness.opensearch.cluster',
+  '1',
+  openSearchClusterReadinessEvaluator
+);
+
+function compileOpenSearchClusterSpec(
+  config: Composable<OpenSearchClusterResourceConfig>
+): OpenSearchClusterResourceSpec {
+  const snapshot = config.snapshots;
+  const tls =
+    config.tls.source === 'generated'
+      ? {
+          http: { generate: true as const },
+          transport: { generate: true as const, perNode: true as const },
+        }
+      : {
+          http: {
+            generate: false as const,
+            secret: { name: config.tls.secretName },
+            ...(config.tls.adminDn ? { adminDn: config.tls.adminDn } : {}),
+          },
+          transport: { generate: true as const, perNode: true as const },
+        };
+  return {
+    general: {
+      serviceName: config.serviceName,
+      version: config.version,
+      httpPort: OPENSEARCH_HTTP_PORT,
+      vendor: 'opensearch',
+      ...(snapshot ? { pluginsList: ['repository-s3'] } : {}),
+      drainDataNodes: true,
+      monitoring: { enable: config.monitoring },
+      ...(snapshot
+        ? {
+            keystore: [
+              {
+                secret: {
+                  name: snapshot.credentialsSecret.name,
+                  keyMappings: {
+                    [snapshot.credentialsSecret.accessKeyKey]:
+                      's3.client.default.access_key',
+                    [snapshot.credentialsSecret.secretKeyKey]:
+                      's3.client.default.secret_key',
+                  },
+                },
+              },
+            ],
+            snapshotRepositories: [
+              {
+                name: snapshot.repository,
+                type: 's3' as const,
+                settings: {
+                  bucket: snapshot.bucket,
+                  ...(snapshot.endpoint ? { endpoint: snapshot.endpoint } : {}),
+                  ...(snapshot.region ? { region: snapshot.region } : {}),
+                  ...(snapshot.basePath ? { base_path: snapshot.basePath } : {}),
+                },
+              },
+            ],
+          }
+        : {}),
+    },
+    security: {
+      config: {
+        ...(config.adminCredentialsSecret
+          ? { adminCredentialsSecret: config.adminCredentialsSecret }
+          : {}),
+        ...(config.tls.source === 'generated'
+          ? {}
+          : { adminSecret: { name: config.tls.adminSecretName } }),
+      },
+      tls,
+    },
+    dashboards: {
+      enable: false,
+      ...(config.dashboardCredentialsSecret
+        ? {
+            opensearchCredentialsSecret:
+              config.dashboardCredentialsSecret,
+          }
+        : {}),
+    },
+    nodePools: [
+      {
+        component: 'nodes',
+        replicas: config.nodes,
+        roles: config.roles,
+        diskSize: config.storage.size,
+        ...(config.storage.storageClassName
+          ? {
+              persistence: {
+                pvc: {
+                  storageClass: config.storage.storageClassName,
+                  accessModes: ['ReadWriteOnce'] as const,
+                },
+              },
+            }
+          : {}),
+        ...(config.resources ? { resources: config.resources } : {}),
+        ...(config.podDisruptionBudget
+          ? {
+              pdb: {
+                enable: true as const,
+                ...(config.podDisruptionBudget.minAvailable !== undefined
+                  ? { minAvailable: config.podDisruptionBudget.minAvailable }
+                  : {}),
+                ...(config.podDisruptionBudget.maxUnavailable !== undefined
+                  ? { maxUnavailable: config.podDisruptionBudget.maxUnavailable }
+                  : {}),
+              },
+            }
+          : {}),
+      },
+    ],
+  };
+}
+
+export function openSearchClusterResource(
+  config: Composable<OpenSearchClusterResourceConfig>
+): Enhanced<OpenSearchClusterResourceSpec, OpenSearchClusterObservedStatus> {
+  return createResource(
+    {
+      apiVersion: 'opensearch.org/v1',
+      kind: 'OpenSearchCluster',
+      metadata: {
+        name: config.name,
+        namespace: config.namespace,
+        labels: {
+          'app.kubernetes.io/name': 'opensearch',
+          'app.kubernetes.io/instance': config.name,
+          'app.kubernetes.io/managed-by': 'typekro',
+        },
+        ...(config.storage.deletionPolicy === 'retain'
+          ? {
+              annotations: {
+                'typekro.dev/storage-retention':
+                  'PVC retention applies only while the externally owned namespace survives',
+              },
+            }
+          : {}),
+      },
+      spec: compileOpenSearchClusterSpec(config),
+      ...(config.id ? { id: config.id } : {}),
+    },
+    { scope: 'namespaced' }
+  ).withReadinessEvaluator(openSearchClusterReadinessEvaluator) as Enhanced<
+    OpenSearchClusterResourceSpec,
+    OpenSearchClusterObservedStatus
+  >;
+}

--- a/src/factories/opensearch/resources/helm.ts
+++ b/src/factories/opensearch/resources/helm.ts
@@ -1,0 +1,69 @@
+import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
+import { setMetadataField } from '../../../core/metadata/resource-metadata.js';
+import { Cel } from '../../../core/references/cel.js';
+import type { Composable, Enhanced } from '../../../core/types/index.js';
+import { isKubernetesRef } from '../../../utils/type-guards.js';
+import { helmRelease } from '../../helm/helm-release.js';
+import {
+  createHelmRepositoryReadinessEvaluator,
+  helmRepository,
+  type HelmRepositorySpec,
+  type HelmRepositoryStatus,
+} from '../../helm/helm-repository.js';
+import { createLabeledHelmReleaseEvaluator } from '../../helm/readiness-evaluators.js';
+import type { HelmReleaseSpec, HelmReleaseStatus } from '../../helm/types.js';
+import type { OpenSearchOperatorHelmReleaseConfig } from '../types.js';
+
+export const DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_URL =
+  'https://opensearch-project.github.io/opensearch-k8s-operator/';
+export const DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_NAME = 'opensearch-operator';
+export const OPENSEARCH_OPERATOR_CHART_NAME = 'opensearch-operator';
+export const DEFAULT_OPENSEARCH_OPERATOR_VERSION = '3.0.2';
+
+export function openSearchOperatorHelmRepository(
+  config: Composable<{
+    readonly name?: string;
+    readonly namespace?: string;
+    readonly url?: string;
+    readonly interval?: string;
+    readonly id?: string;
+  }>
+): Enhanced<HelmRepositorySpec, HelmRepositoryStatus> {
+  const repository = helmRepository({
+    name: config.name || DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_NAME,
+    namespace: config.namespace || DEFAULT_FLUX_NAMESPACE,
+    url: config.url || DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_URL,
+    interval: config.interval || '5m',
+    ...(config.id ? { id: config.id } : {}),
+  }).withReadinessEvaluator(
+    createHelmRepositoryReadinessEvaluator('OpenSearch')
+  ) as Enhanced<HelmRepositorySpec, HelmRepositoryStatus>;
+  setMetadataField(repository, 'scopes', ['cluster']);
+  return repository;
+}
+
+export function openSearchOperatorHelmRelease(
+  config: Composable<OpenSearchOperatorHelmReleaseConfig>
+): Enhanced<HelmReleaseSpec, HelmReleaseStatus> {
+  return helmRelease({
+    name: config.name,
+    namespace: config.namespace,
+    chart: {
+      repository: DEFAULT_OPENSEARCH_OPERATOR_REPOSITORY_URL,
+      name: OPENSEARCH_OPERATOR_CHART_NAME,
+      version: config.version,
+    },
+    sourceRef: {
+      name: config.repositoryName,
+      namespace: config.repositoryNamespace,
+      kind: 'HelmRepository',
+    },
+    driftDetection: { mode: 'enabled' },
+    values: isKubernetesRef(config.values)
+      ? Cel.default(config.values, {})
+      : (config.values ?? {}),
+    ...(config.id ? { id: config.id } : {}),
+  }).withReadinessEvaluator(
+    createLabeledHelmReleaseEvaluator('OpenSearch')
+  ) as Enhanced<HelmReleaseSpec, HelmReleaseStatus>;
+}

--- a/src/factories/opensearch/resources/index.ts
+++ b/src/factories/opensearch/resources/index.ts
@@ -1,0 +1,2 @@
+export * from './cluster.js';
+export * from './helm.js';

--- a/src/factories/opensearch/types.ts
+++ b/src/factories/opensearch/types.ts
@@ -3,17 +3,36 @@ import type { TypeKroChartValue } from '../../core/types/common.js';
 import type { Composable } from '../../core/types/index.js';
 
 export const OpenSearchOperatorBootstrapConfigSchema = type({
-  name: 'string',
-  'namespace?': 'string',
-  'version?': 'string',
-  'shared?': 'boolean',
-  'repositoryName?': 'string',
-  'repositoryNamespace?': 'string',
+  name: 'string > 0',
+  'namespace?': 'string > 0',
+  'version?': 'string > 0',
+  'repositoryName?': 'string > 0',
+  'repositoryNamespace?': 'string > 0',
   'customValues?': 'Record<string, unknown>',
 });
 
 export type OpenSearchOperatorBootstrapConfig =
   typeof OpenSearchOperatorBootstrapConfigSchema.infer;
+
+export const OpenSearchOperatorReferenceConfigSchema = type({
+  name: 'string > 0',
+});
+
+export type OpenSearchOperatorReferenceConfig =
+  typeof OpenSearchOperatorReferenceConfigSchema.infer;
+
+export interface OpenSearchOperatorBootstrapBuildOptions {
+  readonly name?: string;
+  readonly namespace?: string;
+  readonly version?: string;
+  readonly repositoryName?: string;
+  readonly repositoryNamespace?: string;
+  /**
+   * Concrete build-time values for the singleton operator installation.
+   * Runtime schema references cannot participate in singleton ownership.
+   */
+  readonly customValues?: Record<string, unknown>;
+}
 
 export const OpenSearchOperatorBootstrapStatusSchema = type({
   ready: 'boolean',
@@ -239,9 +258,7 @@ export interface OpenSearchClusterResourceSpec {
         readonly accessModes: readonly ['ReadWriteOnce'];
       };
     };
-    readonly resources?: Composable<
-      NonNullable<OpenSearchClusterResourceConfig['resources']>
-    >;
+    readonly resources?: Composable<NonNullable<OpenSearchClusterResourceConfig['resources']>>;
     readonly pdb?: {
       readonly enable: true;
       readonly minAvailable?: number;

--- a/src/factories/opensearch/types.ts
+++ b/src/factories/opensearch/types.ts
@@ -76,7 +76,7 @@ export const OpenSearchClusterConfigSchema = type({
       source: '"secret"',
       secretName: 'string > 0',
       adminSecretName: 'string > 0',
-      'adminDn?': 'string[]',
+      adminDn: '(string > 0)[] > 0',
     })
     .or({
       source: '"cert-manager"',
@@ -85,7 +85,7 @@ export const OpenSearchClusterConfigSchema = type({
       issuerName: 'string > 0',
       'issuerKind?': '"Issuer" | "ClusterIssuer"',
       dnsNames: 'string[] > 0',
-      'adminDn?': 'string[]',
+      adminDn: '(string > 0)[] > 0',
     }),
   'snapshots?': {
     repository: 'string > 0',
@@ -128,6 +128,13 @@ export interface OpenSearchClusterTopology {
   };
   readonly networkPolicy?: {
     readonly enabled: boolean;
+    /**
+     * Namespace containing the OpenSearch operator. Its health probes are
+     * always admitted independently of caller traffic.
+     *
+     * @default 'opensearch-operator-system'
+     */
+    readonly operatorNamespace?: string;
     readonly ingressNamespaceLabels?: Readonly<Record<string, string>>;
     readonly egressNamespaceLabels?: readonly Readonly<Record<string, string>>[];
     readonly egressCidrs?: readonly string[];
@@ -158,7 +165,7 @@ export interface OpenSearchClusterResourceConfig {
         readonly source: 'secret' | 'cert-manager';
         readonly secretName: string;
         readonly adminSecretName: string;
-        readonly adminDn?: readonly string[];
+        readonly adminDn: readonly string[];
       };
   readonly snapshots?: {
     readonly repository: string;
@@ -209,7 +216,7 @@ export interface OpenSearchClusterResourceSpec {
         | {
             readonly generate: false;
             readonly secret: { readonly name: string };
-            readonly adminDn?: readonly string[];
+            readonly adminDn: readonly string[];
           };
       readonly transport: {
         readonly generate: true;

--- a/src/factories/opensearch/types.ts
+++ b/src/factories/opensearch/types.ts
@@ -1,0 +1,258 @@
+import { type } from 'arktype';
+import type { TypeKroChartValue } from '../../core/types/common.js';
+import type { Composable } from '../../core/types/index.js';
+
+export const OpenSearchOperatorBootstrapConfigSchema = type({
+  name: 'string',
+  'namespace?': 'string',
+  'version?': 'string',
+  'shared?': 'boolean',
+  'repositoryName?': 'string',
+  'repositoryNamespace?': 'string',
+  'customValues?': 'Record<string, unknown>',
+});
+
+export type OpenSearchOperatorBootstrapConfig =
+  typeof OpenSearchOperatorBootstrapConfigSchema.infer;
+
+export const OpenSearchOperatorBootstrapStatusSchema = type({
+  ready: 'boolean',
+  failed: 'boolean',
+  phase: '"Ready" | "Installing" | "Failed"',
+  version: 'string',
+});
+
+export type OpenSearchOperatorBootstrapStatus =
+  typeof OpenSearchOperatorBootstrapStatusSchema.infer;
+
+export const OpenSearchHelmRepositorySingletonSpecSchema = type({
+  name: 'string',
+  namespace: 'string',
+  url: 'string',
+});
+
+export const OpenSearchHelmRepositorySingletonStatusSchema = type({
+  ready: 'boolean',
+});
+
+export interface OpenSearchOperatorHelmReleaseConfig {
+  readonly name: string;
+  readonly namespace: string;
+  readonly version: string;
+  readonly repositoryName: string;
+  readonly repositoryNamespace: string;
+  readonly values?: TypeKroChartValue<Record<string, unknown>>;
+  readonly id?: string;
+}
+
+export const OpenSearchClusterConfigSchema = type({
+  name: 'string > 0',
+  namespace: 'string > 0',
+  'version?': 'string',
+  'serviceName?': 'string',
+  /**
+   * One atomic lifecycle choice avoids combinations that would claim retained
+   * PVCs while deleting their containing Namespace.
+   */
+  'lifecycle?': '"owned-delete" | "external-delete" | "external-retain"',
+  'adminCredentialsSecret?': {
+    name: 'string > 0',
+  },
+  'dashboardCredentialsSecret?': {
+    name: 'string > 0',
+  },
+  storage: {
+    size: 'string > 0',
+    'storageClassName?': 'string',
+  },
+  'resources?': {
+    'requests?': { 'cpu?': 'string', 'memory?': 'string' },
+    'limits?': { 'cpu?': 'string', 'memory?': 'string' },
+  },
+  tls: type({
+    source: '"generated"',
+  })
+    .or({
+      source: '"secret"',
+      secretName: 'string > 0',
+      adminSecretName: 'string > 0',
+      'adminDn?': 'string[]',
+    })
+    .or({
+      source: '"cert-manager"',
+      secretName: 'string > 0',
+      adminSecretName: 'string > 0',
+      issuerName: 'string > 0',
+      'issuerKind?': '"Issuer" | "ClusterIssuer"',
+      dnsNames: 'string[] > 0',
+      'adminDn?': 'string[]',
+    }),
+  'snapshots?': {
+    repository: 'string > 0',
+    bucket: 'string > 0',
+    credentialsSecret: {
+      name: 'string > 0',
+      'accessKeyKey?': 'string > 0',
+      'secretKeyKey?': 'string > 0',
+    },
+    'endpoint?': 'string',
+    'region?': 'string',
+    'basePath?': 'string',
+  },
+  'monitoring?': 'boolean',
+});
+
+export type OpenSearchClusterConfig = typeof OpenSearchClusterConfigSchema.infer;
+
+export const OpenSearchClusterStatusSchema = type({
+  ready: 'boolean',
+  failed: 'boolean',
+  phase: '"Ready" | "Installing" | "Failed"',
+  endpoint: 'string',
+  credentialsSecret: 'string',
+  version: 'string',
+  availableNodes: 'number',
+  health: 'string',
+  snapshotRepository: 'string',
+});
+
+export type OpenSearchClusterStatus = typeof OpenSearchClusterStatusSchema.infer;
+
+export interface OpenSearchClusterTopology {
+  readonly profile?: 'development' | 'production';
+  readonly nodes?: number;
+  readonly roles?: readonly ('cluster_manager' | 'data' | 'ingest')[];
+  readonly podDisruptionBudget?: {
+    readonly minAvailable?: number;
+    readonly maxUnavailable?: number;
+  };
+  readonly networkPolicy?: {
+    readonly enabled: boolean;
+    readonly ingressNamespaceLabels?: Readonly<Record<string, string>>;
+    readonly egressNamespaceLabels?: readonly Readonly<Record<string, string>>[];
+    readonly egressCidrs?: readonly string[];
+  };
+}
+
+export interface OpenSearchClusterResourceConfig {
+  readonly name: string;
+  readonly namespace: string;
+  readonly version: string;
+  readonly serviceName: string;
+  readonly nodes: number;
+  readonly roles: readonly ('cluster_manager' | 'data' | 'ingest')[];
+  readonly storage: {
+    readonly size: string;
+    readonly storageClassName?: string;
+    readonly deletionPolicy: 'retain' | 'delete';
+  };
+  readonly resources?: {
+    readonly requests?: { readonly cpu?: string; readonly memory?: string };
+    readonly limits?: { readonly cpu?: string; readonly memory?: string };
+  };
+  readonly adminCredentialsSecret?: { readonly name: string };
+  readonly dashboardCredentialsSecret?: { readonly name: string };
+  readonly tls:
+    | { readonly source: 'generated' }
+    | {
+        readonly source: 'secret' | 'cert-manager';
+        readonly secretName: string;
+        readonly adminSecretName: string;
+        readonly adminDn?: readonly string[];
+      };
+  readonly snapshots?: {
+    readonly repository: string;
+    readonly bucket: string;
+    readonly credentialsSecret: {
+      readonly name: string;
+      readonly accessKeyKey: string;
+      readonly secretKeyKey: string;
+    };
+    readonly endpoint?: string;
+    readonly region?: string;
+    readonly basePath?: string;
+  };
+  readonly monitoring: boolean;
+  readonly podDisruptionBudget?: OpenSearchClusterTopology['podDisruptionBudget'];
+  readonly id?: string;
+}
+
+export interface OpenSearchClusterResourceSpec {
+  readonly general: {
+    readonly serviceName: string;
+    readonly version: string;
+    readonly httpPort: number;
+    readonly vendor: 'opensearch';
+    readonly pluginsList?: readonly string[];
+    readonly drainDataNodes: boolean;
+    readonly monitoring: { readonly enable: boolean };
+    readonly keystore?: readonly {
+      readonly secret: {
+        readonly name: string;
+        readonly keyMappings: Readonly<Record<string, string>>;
+      };
+    }[];
+    readonly snapshotRepositories?: readonly {
+      readonly name: string;
+      readonly type: 's3';
+      readonly settings: Readonly<Record<string, string>>;
+    }[];
+  };
+  readonly security: {
+    readonly config: {
+      readonly adminCredentialsSecret?: { readonly name: string };
+      readonly adminSecret?: { readonly name: string };
+    };
+    readonly tls: {
+      readonly http:
+        | { readonly generate: true }
+        | {
+            readonly generate: false;
+            readonly secret: { readonly name: string };
+            readonly adminDn?: readonly string[];
+          };
+      readonly transport: {
+        readonly generate: true;
+        readonly perNode: true;
+      };
+    };
+  };
+  readonly dashboards?: {
+    readonly enable: boolean;
+    readonly opensearchCredentialsSecret?: { readonly name: string };
+  };
+  readonly nodePools: readonly {
+    readonly component: string;
+    readonly replicas: number;
+    readonly roles: readonly ('cluster_manager' | 'data' | 'ingest')[];
+    readonly diskSize: string;
+    readonly persistence?: {
+      readonly pvc: {
+        readonly storageClass?: string;
+        readonly accessModes: readonly ['ReadWriteOnce'];
+      };
+    };
+    readonly resources?: Composable<
+      NonNullable<OpenSearchClusterResourceConfig['resources']>
+    >;
+    readonly pdb?: {
+      readonly enable: true;
+      readonly minAvailable?: number;
+      readonly maxUnavailable?: number;
+    };
+  }[];
+}
+
+export interface OpenSearchClusterObservedStatus {
+  readonly phase?: string;
+  readonly health?: string;
+  readonly version?: string;
+  readonly initialized?: boolean;
+  readonly availableNodes?: number;
+  readonly componentsStatus?: readonly {
+    readonly component?: string;
+    readonly status?: string;
+    readonly description?: string;
+    readonly conditions?: readonly string[];
+  }[];
+}

--- a/test/factories/opensearch/factory-modes.test.ts
+++ b/test/factories/opensearch/factory-modes.test.ts
@@ -1,0 +1,217 @@
+import { loadAll } from 'js-yaml';
+import { describe, expect, test } from 'vitest';
+import {
+  makeOpenSearchCluster,
+  openSearchCluster,
+  openSearchOperatorBootstrap,
+} from '../../../src/factories/opensearch/index.js';
+import { openSearchClusterReadinessEvaluator } from '../../../src/factories/opensearch/resources/cluster.js';
+
+function documents(yaml: string): Record<string, unknown>[] {
+  return loadAll(yaml).filter(
+    (document): document is Record<string, unknown> =>
+      document !== null && typeof document === 'object'
+  );
+}
+
+describe('OpenSearch integration', () => {
+  test('waits for every declared node before reporting direct readiness', () => {
+    const progressing = openSearchClusterReadinessEvaluator({
+      spec: { nodePools: [{ replicas: 3 }] },
+      status: {
+        initialized: true,
+        availableNodes: 1,
+        health: 'yellow',
+      },
+    });
+    const ready = openSearchClusterReadinessEvaluator({
+      spec: { nodePools: [{ replicas: 3 }] },
+      status: {
+        initialized: true,
+        availableNodes: 3,
+        health: 'green',
+      },
+    });
+    expect(progressing.ready).toBe(false);
+    expect(ready.ready).toBe(true);
+  });
+
+  test('emits a bounded development cluster in direct mode', () => {
+    const yaml = openSearchCluster.factory('direct', {
+      namespace: 'typekro-system',
+    }).toYaml({
+      name: 'search',
+      namespace: 'search-system',
+      storage: { size: '10Gi', storageClassName: 'local-path' },
+      tls: { source: 'generated' },
+      adminCredentialsSecret: { name: 'search-admin' },
+      dashboardCredentialsSecret: { name: 'search-dashboards' },
+    });
+    expect(yaml).toContain('apiVersion: opensearch.org/v1');
+    expect(yaml).toContain('kind: OpenSearchCluster');
+    expect(yaml).toContain('name: search-system');
+    expect(yaml).toContain('replicas: 3');
+    expect(yaml).toContain('diskSize: 10Gi');
+    expect(yaml).toContain('storageClass: local-path');
+    expect(yaml).toContain('generate: true');
+    expect(yaml).toContain('opensearchCredentialsSecret:');
+    expect(yaml).toContain('name: search-dashboards');
+    expect(yaml).not.toContain('__typekro');
+  });
+
+  test('rejects unsupported single-node topologies before deployment', () => {
+    expect(() => makeOpenSearchCluster({ nodes: 1 })).toThrow(
+      'requires at least three nodes'
+    );
+  });
+
+  test('makes retained storage require an externally owned namespace by construction', () => {
+    const yaml = openSearchCluster.factory('direct', {
+      namespace: 'typekro-system',
+    }).toYaml({
+      name: 'retained',
+      namespace: 'retained-search',
+      lifecycle: 'external-retain',
+      storage: { size: '20Gi' },
+      tls: { source: 'generated' },
+    });
+    expect(
+      documents(yaml).some(
+        (document) =>
+          document.kind === 'Namespace' &&
+          (document.metadata as { name?: string })?.name === 'retained-search'
+      )
+    ).toBe(false);
+    expect(yaml).toContain('typekro.dev/storage-retention');
+  });
+
+  test('emits production PDB, network isolation, cert-manager, and snapshots', () => {
+    const cluster = makeOpenSearchCluster({
+      profile: 'production',
+      tls: 'cert-manager',
+      snapshots: true,
+      snapshotCredentialKeys: {
+        accessKey: 'access',
+        secretKey: 'secret',
+      },
+      networkPolicy: {
+        enabled: true,
+        ingressNamespaceLabels: {
+          'kubernetes.io/metadata.name': 'application-system',
+        },
+        egressCidrs: ['10.0.0.0/8'],
+      },
+    });
+    const yaml = cluster.factory('direct', {
+      namespace: 'typekro-system',
+    }).toYaml({
+      name: 'evidence',
+      namespace: 'search-system',
+      lifecycle: 'external-retain',
+      storage: { size: '100Gi', storageClassName: 'fast' },
+      tls: {
+        source: 'cert-manager',
+        secretName: 'evidence-http-tls',
+        adminSecretName: 'evidence-admin-tls',
+        issuerName: 'platform-ca',
+        issuerKind: 'ClusterIssuer',
+        dnsNames: ['evidence.search.example.com'],
+      },
+      snapshots: {
+        repository: 'snapshots',
+        bucket: 'evidence-search',
+        endpoint: 'https://s3.example.com',
+        credentialsSecret: {
+          name: 'snapshot-credentials',
+        },
+      },
+      monitoring: true,
+    });
+    expect(yaml).toContain('kind: Certificate');
+    expect(yaml).toContain('secretName: evidence-http-tls');
+    expect(yaml).toContain('kind: NetworkPolicy');
+    expect(yaml).toContain('10.0.0.0/8');
+    expect(yaml).toContain('minAvailable: 2');
+    expect(yaml).toContain('repository-s3');
+    expect(yaml).toContain('s3.client.default.access_key');
+    expect(yaml).toContain('name: snapshots');
+    expect(yaml).toContain('adminSecret:');
+    expect(yaml).toContain('name: evidence-admin-tls');
+  });
+
+  test('serializes a complete KRO status and runtime spec contract', () => {
+    const cluster = makeOpenSearchCluster({
+      tls: 'secret',
+      snapshots: true,
+    });
+    const factory = cluster.factory('kro', {
+      namespace: 'typekro-system',
+    });
+    const yaml = factory.toYaml();
+    const instance = factory.toYaml({
+      name: 'search',
+      namespace: 'search-system',
+      lifecycle: 'external-retain',
+      storage: { size: '20Gi' },
+      tls: {
+        source: 'secret',
+        secretName: 'http-tls',
+        adminSecretName: 'admin-tls',
+      },
+      snapshots: {
+        repository: 'snapshots',
+        bucket: 'search',
+        credentialsSecret: { name: 'snapshot-credentials' },
+      },
+    });
+    expect(yaml).toContain('kind: ResourceGraphDefinition');
+    expect(yaml).toContain('OpenSearchClusterInstallation');
+    expect(yaml).not.toContain('__KUBERNETES_REF__');
+    expect(yaml).toContain('${schema.spec.storage.size}');
+    expect(yaml).toContain('${cluster.status.availableNodes}');
+    expect(yaml).toContain('${cluster.status.health}');
+    expect(yaml).toContain(
+      'cluster.spec.security.config.adminCredentialsSecret.name != ""'
+    );
+    expect(yaml).toContain(
+      'cluster.spec.general.snapshotRepositories.size() > 0'
+    );
+    expect(yaml).toContain('credentialsSecret:');
+    expect(yaml).toContain('snapshotRepository:');
+    expect(instance).toContain('kind: OpenSearchClusterInstallation');
+    expect(instance).toContain('lifecycle: external-retain');
+
+    const ownedInstance = factory.toYaml({
+      name: 'owned',
+      namespace: 'owned-search',
+      lifecycle: 'owned-delete',
+      storage: { size: '20Gi' },
+      tls: {
+        source: 'secret',
+        secretName: 'http-tls',
+        adminSecretName: 'admin-tls',
+      },
+      snapshots: {
+        repository: 'snapshots',
+        bucket: 'search',
+        credentialsSecret: { name: 'snapshot-credentials' },
+      },
+    });
+    expect(ownedInstance).toContain('kind: Namespace');
+    expect(instance).not.toContain('kind: Namespace');
+  });
+
+  test('owns the operator repository once and defaults shared lifecycle', () => {
+    const factory = openSearchOperatorBootstrap.factory('kro', {
+      namespace: 'typekro-system',
+    });
+    const yaml = factory.toYaml();
+    const instance = factory.toYaml({
+      name: 'opensearch-operator',
+    });
+    expect(yaml).toContain('opensearch-operator-bootstrap');
+    expect(yaml).toContain('opensearch-helm-repository');
+    expect(yaml).toContain('3.0.2');
+    expect(instance).toContain('kind: OpenSearchOperatorBootstrap');
+  });
+});

--- a/test/factories/opensearch/factory-modes.test.ts
+++ b/test/factories/opensearch/factory-modes.test.ts
@@ -18,23 +18,52 @@ function documents(yaml: string): Record<string, unknown>[] {
 describe('OpenSearch integration', () => {
   test('waits for every declared node before reporting direct readiness', () => {
     const progressing = openSearchClusterReadinessEvaluator({
-      spec: { nodePools: [{ replicas: 3 }] },
+      spec: {
+        general: { version: '3.2.0' },
+        nodePools: [{ replicas: 3 }],
+      },
       status: {
         initialized: true,
         availableNodes: 1,
         health: 'yellow',
+        version: '3.2.0',
       },
     });
     const ready = openSearchClusterReadinessEvaluator({
-      spec: { nodePools: [{ replicas: 3 }] },
+      spec: {
+        general: { version: '3.2.0' },
+        nodePools: [{ replicas: 3 }],
+      },
       status: {
         initialized: true,
         availableNodes: 3,
         health: 'green',
+        version: '3.2.0',
       },
     });
     expect(progressing.ready).toBe(false);
     expect(ready.ready).toBe(true);
+  });
+
+  test('waits for the operator-observed version before completing an upgrade', () => {
+    const stale = openSearchClusterReadinessEvaluator({
+      spec: {
+        general: { version: '3.2.0' },
+        nodePools: [{ replicas: 3 }],
+      },
+      status: {
+        initialized: true,
+        availableNodes: 3,
+        health: 'green',
+        version: '3.1.0',
+      },
+    });
+    expect(stale).toMatchObject({
+      ready: false,
+      reason: 'VersionProgressing',
+    });
+    expect(stale.message).toContain('version=3.1.0');
+    expect(stale.message).toContain('desiredVersion=3.2.0');
   });
 
   test('emits a bounded development cluster in direct mode', () => {
@@ -196,6 +225,9 @@ describe('OpenSearch integration', () => {
     );
     expect(yaml).toContain('${cluster.status.availableNodes}');
     expect(yaml).toContain('${cluster.status.health}');
+    expect(yaml).toContain('${cluster.status.version}');
+    expect(yaml).toContain('cluster.status.version == cluster.spec.general.version');
+    expect(yaml).not.toContain('version: ${cluster.spec.general.version}');
     expect(yaml).toContain('cluster.spec.security.config.adminCredentialsSecret.name != ""');
     expect(yaml).toContain('cluster.spec.general.snapshotRepositories.size() > 0');
     expect(yaml).toContain('credentialsSecret:');

--- a/test/factories/opensearch/factory-modes.test.ts
+++ b/test/factories/opensearch/factory-modes.test.ts
@@ -4,6 +4,7 @@ import {
   makeOpenSearchCluster,
   openSearchCluster,
   openSearchOperatorBootstrap,
+  openSearchOperatorInstallation,
 } from '../../../src/factories/opensearch/index.js';
 import { openSearchClusterReadinessEvaluator } from '../../../src/factories/opensearch/resources/cluster.js';
 
@@ -37,16 +38,18 @@ describe('OpenSearch integration', () => {
   });
 
   test('emits a bounded development cluster in direct mode', () => {
-    const yaml = openSearchCluster.factory('direct', {
-      namespace: 'typekro-system',
-    }).toYaml({
-      name: 'search',
-      namespace: 'search-system',
-      storage: { size: '10Gi', storageClassName: 'local-path' },
-      tls: { source: 'generated' },
-      adminCredentialsSecret: { name: 'search-admin' },
-      dashboardCredentialsSecret: { name: 'search-dashboards' },
-    });
+    const yaml = openSearchCluster
+      .factory('direct', {
+        namespace: 'typekro-system',
+      })
+      .toYaml({
+        name: 'search',
+        namespace: 'search-system',
+        storage: { size: '10Gi', storageClassName: 'local-path' },
+        tls: { source: 'generated' },
+        adminCredentialsSecret: { name: 'search-admin' },
+        dashboardCredentialsSecret: { name: 'search-dashboards' },
+      });
     expect(yaml).toContain('apiVersion: opensearch.org/v1');
     expect(yaml).toContain('kind: OpenSearchCluster');
     expect(yaml).toContain('name: search-system');
@@ -60,21 +63,35 @@ describe('OpenSearch integration', () => {
   });
 
   test('rejects unsupported single-node topologies before deployment', () => {
-    expect(() => makeOpenSearchCluster({ nodes: 1 })).toThrow(
-      'requires at least three nodes'
+    expect(() => makeOpenSearchCluster({ nodes: 1 })).toThrow('requires at least three nodes');
+  });
+
+  test('rejects a single node pool without cluster-manager-capable nodes', () => {
+    expect(() => makeOpenSearchCluster({ roles: ['data'] })).toThrow(
+      'roles must include cluster_manager'
     );
   });
 
+  test('requires a PDB to preserve at least one node', () => {
+    expect(() =>
+      makeOpenSearchCluster({
+        podDisruptionBudget: { minAvailable: 0 },
+      })
+    ).toThrow('must preserve at least one available node');
+  });
+
   test('makes retained storage require an externally owned namespace by construction', () => {
-    const yaml = openSearchCluster.factory('direct', {
-      namespace: 'typekro-system',
-    }).toYaml({
-      name: 'retained',
-      namespace: 'retained-search',
-      lifecycle: 'external-retain',
-      storage: { size: '20Gi' },
-      tls: { source: 'generated' },
-    });
+    const yaml = openSearchCluster
+      .factory('direct', {
+        namespace: 'typekro-system',
+      })
+      .toYaml({
+        name: 'retained',
+        namespace: 'retained-search',
+        lifecycle: 'external-retain',
+        storage: { size: '20Gi' },
+        tls: { source: 'generated' },
+      });
     expect(
       documents(yaml).some(
         (document) =>
@@ -102,41 +119,39 @@ describe('OpenSearch integration', () => {
         egressCidrs: ['10.0.0.0/8'],
       },
     });
-    const yaml = cluster.factory('direct', {
-      namespace: 'typekro-system',
-    }).toYaml({
-      name: 'evidence',
-      namespace: 'search-system',
-      lifecycle: 'external-retain',
-      storage: { size: '100Gi', storageClassName: 'fast' },
-      tls: {
-        source: 'cert-manager',
-        secretName: 'evidence-http-tls',
-        adminSecretName: 'evidence-admin-tls',
-        adminDn: ['CN=opensearch-admin'],
-        issuerName: 'platform-ca',
-        issuerKind: 'ClusterIssuer',
-        dnsNames: ['evidence.search.example.com'],
-      },
-      snapshots: {
-        repository: 'snapshots',
-        bucket: 'evidence-search',
-        endpoint: 'https://s3.example.com',
-        credentialsSecret: {
-          name: 'snapshot-credentials',
+    const yaml = cluster
+      .factory('direct', {
+        namespace: 'typekro-system',
+      })
+      .toYaml({
+        name: 'evidence',
+        namespace: 'search-system',
+        lifecycle: 'external-retain',
+        storage: { size: '100Gi', storageClassName: 'fast' },
+        tls: {
+          source: 'cert-manager',
+          secretName: 'evidence-http-tls',
+          adminSecretName: 'evidence-admin-tls',
+          adminDn: ['CN=opensearch-admin'],
+          issuerName: 'platform-ca',
+          issuerKind: 'ClusterIssuer',
+          dnsNames: ['evidence.search.example.com'],
         },
-      },
-      monitoring: true,
-    });
+        snapshots: {
+          repository: 'snapshots',
+          bucket: 'evidence-search',
+          endpoint: 'https://s3.example.com',
+          credentialsSecret: {
+            name: 'snapshot-credentials',
+          },
+        },
+        monitoring: true,
+      });
     expect(yaml).toContain('kind: Certificate');
     expect(yaml).toContain('secretName: evidence-http-tls');
     expect(yaml).toContain('kind: NetworkPolicy');
-    expect(yaml).toContain(
-      'kubernetes.io/metadata.name: opensearch-operator-system'
-    );
-    expect(yaml).toContain(
-      'kubernetes.io/metadata.name: application-system'
-    );
+    expect(yaml).toContain('kubernetes.io/metadata.name: opensearch-operator-system');
+    expect(yaml).toContain('kubernetes.io/metadata.name: application-system');
     expect(yaml).toContain('10.0.0.0/8');
     expect(yaml).toContain('minAvailable: 2');
     expect(yaml).toContain('repository-s3');
@@ -177,16 +192,12 @@ describe('OpenSearch integration', () => {
     expect(yaml).not.toContain('__KUBERNETES_REF__');
     expect(yaml).toContain('${schema.spec.storage.size}');
     expect(yaml).toContain(
-      "adminDn: '[]string | minItems=1 validation=\"size(self) > 0 && self.all(dn, size(dn) > 0)\"'"
+      'adminDn: \'[]string | minItems=1 validation="size(self) > 0 && self.all(dn, size(dn) > 0)"\''
     );
     expect(yaml).toContain('${cluster.status.availableNodes}');
     expect(yaml).toContain('${cluster.status.health}');
-    expect(yaml).toContain(
-      'cluster.spec.security.config.adminCredentialsSecret.name != ""'
-    );
-    expect(yaml).toContain(
-      'cluster.spec.general.snapshotRepositories.size() > 0'
-    );
+    expect(yaml).toContain('cluster.spec.security.config.adminCredentialsSecret.name != ""');
+    expect(yaml).toContain('cluster.spec.general.snapshotRepositories.size() > 0');
     expect(yaml).toContain('credentialsSecret:');
     expect(yaml).toContain('snapshotRepository:');
     expect(instance).toContain('kind: OpenSearchClusterInstallation');
@@ -222,19 +233,52 @@ describe('OpenSearch integration', () => {
       name: 'opensearch-operator',
     });
     expect(yaml).toContain('opensearch-operator-bootstrap');
+    expect(yaml).toContain('opensearch-operator-installation');
     expect(yaml).toContain('opensearch-helm-repository');
     expect(yaml).toContain('3.0.2');
-    expect(yaml).toContain(
-      'version: ${operatorRelease.spec.chart.spec.version}'
-    );
+    expect(yaml).toContain('version: ${operatorRelease.spec.chart.spec.version}');
     expect(instance).toContain('kind: OpenSearchOperatorBootstrap');
+    expect(instance).toContain('kind: OpenSearchOperatorInstallation');
+    expect(instance).toContain('namespace: typekro-singletons');
+  });
+
+  test('exposes local operator ownership only through the explicit installation composition', () => {
+    const yaml = openSearchOperatorInstallation
+      .factory('kro', {
+        namespace: 'operator-control',
+      })
+      .toYaml({
+        name: 'local-opensearch-operator',
+        namespace: 'local-opensearch-operator-system',
+      });
+    expect(yaml).toContain('kind: OpenSearchOperatorInstallation');
+    expect(yaml).toContain('name: local-opensearch-operator-system');
+    expect(yaml).toContain('kind: OpenSearchHelmRepository');
+    expect(yaml).toContain('namespace: typekro-singletons');
+    expect(yaml).not.toContain('kind: OpenSearchOperatorBootstrap');
+  });
+
+  test('omits an all-namespace ingress rule when caller labels are absent', () => {
+    const yaml = makeOpenSearchCluster({
+      networkPolicy: { enabled: true },
+    })
+      .factory('direct', {
+        namespace: 'typekro-system',
+      })
+      .toYaml({
+        name: 'isolated',
+        namespace: 'isolated-search',
+        storage: { size: '20Gi' },
+        tls: { source: 'generated' },
+      });
+    expect(yaml).not.toContain('matchLabels: {}');
+    expect(yaml).toContain('kubernetes.io/metadata.name: opensearch-operator-system');
   });
 
   test('requires a non-empty external TLS admin DN in direct and KRO inputs', () => {
-    const direct = makeOpenSearchCluster({ tls: 'secret' }).factory(
-      'direct',
-      { namespace: 'typekro-system' }
-    );
+    const direct = makeOpenSearchCluster({ tls: 'secret' }).factory('direct', {
+      namespace: 'typekro-system',
+    });
     expect(() =>
       direct.toYaml({
         name: 'search',
@@ -249,10 +293,9 @@ describe('OpenSearch integration', () => {
       })
     ).toThrow();
 
-    const kro = makeOpenSearchCluster({ tls: 'cert-manager' }).factory(
-      'kro',
-      { namespace: 'typekro-system' }
-    );
+    const kro = makeOpenSearchCluster({ tls: 'cert-manager' }).factory('kro', {
+      namespace: 'typekro-system',
+    });
     expect(() =>
       kro.toYaml({
         name: 'search',

--- a/test/factories/opensearch/factory-modes.test.ts
+++ b/test/factories/opensearch/factory-modes.test.ts
@@ -113,6 +113,7 @@ describe('OpenSearch integration', () => {
         source: 'cert-manager',
         secretName: 'evidence-http-tls',
         adminSecretName: 'evidence-admin-tls',
+        adminDn: ['CN=opensearch-admin'],
         issuerName: 'platform-ca',
         issuerKind: 'ClusterIssuer',
         dnsNames: ['evidence.search.example.com'],
@@ -130,6 +131,12 @@ describe('OpenSearch integration', () => {
     expect(yaml).toContain('kind: Certificate');
     expect(yaml).toContain('secretName: evidence-http-tls');
     expect(yaml).toContain('kind: NetworkPolicy');
+    expect(yaml).toContain(
+      'kubernetes.io/metadata.name: opensearch-operator-system'
+    );
+    expect(yaml).toContain(
+      'kubernetes.io/metadata.name: application-system'
+    );
     expect(yaml).toContain('10.0.0.0/8');
     expect(yaml).toContain('minAvailable: 2');
     expect(yaml).toContain('repository-s3');
@@ -157,6 +164,7 @@ describe('OpenSearch integration', () => {
         source: 'secret',
         secretName: 'http-tls',
         adminSecretName: 'admin-tls',
+        adminDn: ['CN=opensearch-admin'],
       },
       snapshots: {
         repository: 'snapshots',
@@ -168,6 +176,9 @@ describe('OpenSearch integration', () => {
     expect(yaml).toContain('OpenSearchClusterInstallation');
     expect(yaml).not.toContain('__KUBERNETES_REF__');
     expect(yaml).toContain('${schema.spec.storage.size}');
+    expect(yaml).toContain(
+      "adminDn: '[]string | minItems=1 validation=\"size(self) > 0 && self.all(dn, size(dn) > 0)\"'"
+    );
     expect(yaml).toContain('${cluster.status.availableNodes}');
     expect(yaml).toContain('${cluster.status.health}');
     expect(yaml).toContain(
@@ -190,6 +201,7 @@ describe('OpenSearch integration', () => {
         source: 'secret',
         secretName: 'http-tls',
         adminSecretName: 'admin-tls',
+        adminDn: ['CN=opensearch-admin'],
       },
       snapshots: {
         repository: 'snapshots',
@@ -212,6 +224,64 @@ describe('OpenSearch integration', () => {
     expect(yaml).toContain('opensearch-operator-bootstrap');
     expect(yaml).toContain('opensearch-helm-repository');
     expect(yaml).toContain('3.0.2');
+    expect(yaml).toContain(
+      'version: ${operatorRelease.spec.chart.spec.version}'
+    );
     expect(instance).toContain('kind: OpenSearchOperatorBootstrap');
+  });
+
+  test('requires a non-empty external TLS admin DN in direct and KRO inputs', () => {
+    const direct = makeOpenSearchCluster({ tls: 'secret' }).factory(
+      'direct',
+      { namespace: 'typekro-system' }
+    );
+    expect(() =>
+      direct.toYaml({
+        name: 'search',
+        namespace: 'search-system',
+        storage: { size: '20Gi' },
+        tls: {
+          source: 'secret',
+          secretName: 'http-tls',
+          adminSecretName: 'admin-tls',
+          adminDn: [],
+        },
+      })
+    ).toThrow();
+
+    const kro = makeOpenSearchCluster({ tls: 'cert-manager' }).factory(
+      'kro',
+      { namespace: 'typekro-system' }
+    );
+    expect(() =>
+      kro.toYaml({
+        name: 'search',
+        namespace: 'search-system',
+        storage: { size: '20Gi' },
+        tls: {
+          source: 'cert-manager',
+          secretName: 'http-tls',
+          adminSecretName: 'admin-tls',
+          adminDn: [],
+          issuerName: 'platform-ca',
+          dnsNames: ['search.example.test'],
+        },
+      })
+    ).toThrow();
+  });
+
+  test('rejects an empty operator namespace in a NetworkPolicy topology', () => {
+    expect(() =>
+      makeOpenSearchCluster({
+        profile: 'production',
+        networkPolicy: {
+          enabled: true,
+          operatorNamespace: '',
+          ingressNamespaceLabels: {
+            'kubernetes.io/metadata.name': 'application-system',
+          },
+        },
+      })
+    ).toThrow(/operatorNamespace/);
   });
 });

--- a/test/integration/opensearch/opensearch-cluster.test.ts
+++ b/test/integration/opensearch/opensearch-cluster.test.ts
@@ -4,6 +4,7 @@ import { isNotFoundError } from '../../../src/core/deployment/k8s-helpers.js';
 import {
   createBunCompatibleCoreV1Api,
   createBunCompatibleCustomObjectsApi,
+  createBunCompatibleNetworkingV1Api,
 } from '../../../src/core/kubernetes/index.js';
 import {
   makeOpenSearchCluster,
@@ -154,7 +155,7 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
         ].map((name) => createTestNamespace(name, kubeConfig))
       ))
     );
-    const operatorFactory = openSearchOperatorBootstrap.factory('direct', {
+    const operatorFactory = openSearchOperatorBootstrap.factory('kro', {
       namespace: operatorControlNamespace,
       waitForReady: true,
       timeout: 900_000,
@@ -166,6 +167,23 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
       shared: true,
     });
     expect(operator.status).toMatchObject({
+      ready: true,
+      failed: false,
+      phase: 'Ready',
+      version: '3.0.2',
+    });
+    const customApi = createBunCompatibleCustomObjectsApi(kubeConfig);
+    const instanceRaw = await customApi.getNamespacedCustomObject({
+      group: 'kro.run',
+      version: 'v1alpha1',
+      namespace: operatorControlNamespace,
+      plural: 'opensearchoperatorbootstraps',
+      name: 'opensearch-operator',
+    });
+    const instance = (
+      instanceRaw as { readonly body?: Record<string, unknown> }
+    ).body ?? instanceRaw;
+    expect(Reflect.get(instance, 'status')).toMatchObject({
       ready: true,
       failed: false,
       phase: 'Ready',
@@ -290,7 +308,16 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
       kroNamespace,
       'kro-search'
     );
-    const factory = makeOpenSearchCluster().factory('kro', {
+    const factory = makeOpenSearchCluster({
+      profile: 'production',
+      networkPolicy: {
+        enabled: true,
+        operatorNamespace,
+        ingressNamespaceLabels: {
+          'kubernetes.io/metadata.name': kroControlNamespace,
+        },
+      },
+    }).factory('kro', {
       namespace: kroControlNamespace,
       waitForReady: true,
       timeout: 900_000,
@@ -352,6 +379,26 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
         availableNodes: 3,
         health: expect.stringMatching(/green|yellow/),
       });
+      const networkingApi =
+        createBunCompatibleNetworkingV1Api(kubeConfig);
+      const policy = await networkingApi.readNamespacedNetworkPolicy({
+        namespace: kroNamespace,
+        name: 'kro-search-default',
+      });
+      expect(policy.spec).toBeDefined();
+      const admittedNamespaces = policy.spec?.ingress
+        ?.flatMap((rule) => rule._from ?? [])
+        .flatMap((peer) =>
+          peer.namespaceSelector?.matchLabels?.[
+            'kubernetes.io/metadata.name'
+          ] ?? []
+        );
+      expect(admittedNamespaces).toEqual(
+        expect.arrayContaining([
+          operatorNamespace,
+          kroControlNamespace,
+        ])
+      );
     } catch (error) {
       testFailed = true;
       testError = error;

--- a/test/integration/opensearch/opensearch-cluster.test.ts
+++ b/test/integration/opensearch/opensearch-cluster.test.ts
@@ -1,6 +1,6 @@
-import { afterAll, beforeAll, describe, expect, test, setDefaultTimeout } from 'bun:test';
-import { getKubeConfig } from '../../../src/core/kubernetes/client-provider.js';
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from 'bun:test';
 import { isNotFoundError } from '../../../src/core/deployment/k8s-helpers.js';
+import { getKubeConfig } from '../../../src/core/kubernetes/client-provider.js';
 import {
   createBunCompatibleCoreV1Api,
   createBunCompatibleCustomObjectsApi,
@@ -23,9 +23,7 @@ import {
 
 const clusterAvailable = await isClusterAvailable();
 const describeOrSkip =
-  clusterAvailable || process.env.REQUIRE_CLUSTER_TESTS === 'true'
-    ? describe
-    : describe.skip;
+  clusterAvailable || process.env.REQUIRE_CLUSTER_TESTS === 'true' ? describe : describe.skip;
 
 setDefaultTimeout(1_500_000);
 
@@ -80,9 +78,7 @@ async function deleteCredentials(
     deleteTestSecretAndWait(namespace, names.admin, kubeConfig),
     deleteTestSecretAndWait(namespace, names.dashboards, kubeConfig),
   ]);
-  const errors = results.flatMap((result) =>
-    result.status === 'rejected' ? [result.reason] : []
-  );
+  const errors = results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []));
   if (errors.length > 0) {
     throw new AggregateError(errors, `Credential cleanup failed in ${namespace}`);
   }
@@ -98,17 +94,13 @@ async function deleteDataPvcs(
     namespace,
   });
   const claims = listed.items.filter(
-    (claim) =>
-      claim.metadata?.labels?.['opensearch.org/opensearch-cluster'] ===
-      clusterName
+    (claim) => claim.metadata?.labels?.['opensearch.org/opensearch-cluster'] === clusterName
   );
   for (const claim of claims) {
     const name = claim.metadata?.name;
     const uid = claim.metadata?.uid;
     if (!name || !uid) {
-      throw new Error(
-        `Refusing OpenSearch PVC cleanup in ${namespace}: identity is incomplete`
-      );
+      throw new Error(`Refusing OpenSearch PVC cleanup in ${namespace}: identity is incomplete`);
     }
     try {
       await coreApi.deleteNamespacedPersistentVolumeClaim({
@@ -148,11 +140,9 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
     storageClass = await requireTestStorageClass({ kubeConfig });
     leases.push(
       ...(await Promise.all(
-        [
-          directNamespace,
-          kroControlNamespace,
-          kroNamespace,
-        ].map((name) => createTestNamespace(name, kubeConfig))
+        [directNamespace, kroControlNamespace, kroNamespace].map((name) =>
+          createTestNamespace(name, kubeConfig)
+        )
       ))
     );
     const operatorFactory = openSearchOperatorBootstrap.factory('kro', {
@@ -163,8 +153,6 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
     });
     const operator = await operatorFactory.deploy({
       name: 'opensearch-operator',
-      namespace: operatorNamespace,
-      shared: true,
     });
     expect(operator.status).toMatchObject({
       ready: true,
@@ -180,9 +168,8 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
       plural: 'opensearchoperatorbootstraps',
       name: 'opensearch-operator',
     });
-    const instance = (
-      instanceRaw as { readonly body?: Record<string, unknown> }
-    ).body ?? instanceRaw;
+    const instance =
+      (instanceRaw as { readonly body?: Record<string, unknown> }).body ?? instanceRaw;
     expect(Reflect.get(instance, 'status')).toMatchObject({
       ready: true,
       failed: false,
@@ -200,9 +187,7 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
       leases.map((lease) => deleteTestNamespaceAndWait(lease, kubeConfig))
     );
     errors.push(
-      ...namespaceResults.flatMap((result) =>
-        result.status === 'rejected' ? [result.reason] : []
-      )
+      ...namespaceResults.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []))
     );
     if (errors.length > 0) {
       throw new AggregateError(errors, 'OpenSearch integration cleanup failed');
@@ -210,11 +195,7 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
   });
 
   test('deploys, updates, reports complete status, and deletes in direct mode', async () => {
-    const credentials = await createCredentials(
-      kubeConfig,
-      directNamespace,
-      'direct-search'
-    );
+    const credentials = await createCredentials(kubeConfig, directNamespace, 'direct-search');
     const factory = makeOpenSearchCluster().factory('direct', {
       namespace: directNamespace,
       waitForReady: true,
@@ -249,9 +230,7 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
       expect(deployed.status.endpoint).toBe(
         `https://direct-search.${directNamespace}.svc.cluster.local:9200`
       );
-      expect(deployed.status.credentialsSecret).toBe(
-        credentials.admin
-      );
+      expect(deployed.status.credentialsSecret).toBe(credentials.admin);
 
       const updated = await factory.deploy({
         name: 'direct-search',
@@ -282,32 +261,21 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
       240_000
     ).catch((error) => cleanupErrors.push(error));
     if (cleanupErrors.length === 0) {
-      await deleteCredentials(
-        kubeConfig,
-        directNamespace,
-        credentials
-      ).catch((error) => cleanupErrors.push(error));
-      await deleteDataPvcs(
-        kubeConfig,
-        directNamespace,
-        'direct-search'
-      ).catch((error) => cleanupErrors.push(error));
+      await deleteCredentials(kubeConfig, directNamespace, credentials).catch((error) =>
+        cleanupErrors.push(error)
+      );
+      await deleteDataPvcs(kubeConfig, directNamespace, 'direct-search').catch((error) =>
+        cleanupErrors.push(error)
+      );
     }
-    const errors = [
-      ...(testFailed ? [testError] : []),
-      ...cleanupErrors,
-    ];
+    const errors = [...(testFailed ? [testError] : []), ...cleanupErrors];
     if (errors.length > 0) {
       throw new AggregateError(errors, 'Direct OpenSearch test failed');
     }
   });
 
   test('deploys an RGD, projects live status, and deletes through KRO finalization', async () => {
-    const credentials = await createCredentials(
-      kubeConfig,
-      kroNamespace,
-      'kro-search'
-    );
+    const credentials = await createCredentials(kubeConfig, kroNamespace, 'kro-search');
     const factory = makeOpenSearchCluster({
       profile: 'production',
       networkPolicy: {
@@ -355,9 +323,8 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
         plural: 'opensearchclusters',
         name: 'kro-search',
       });
-      const cluster = (
-        clusterRaw as { readonly body?: Record<string, unknown> }
-      ).body ?? clusterRaw;
+      const cluster =
+        (clusterRaw as { readonly body?: Record<string, unknown> }).body ?? clusterRaw;
       expect(Reflect.get(cluster, 'status')).toMatchObject({
         initialized: true,
         availableNodes: 3,
@@ -370,17 +337,15 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
         plural: 'opensearchclusterinstallations',
         name: 'kro-search',
       });
-      const instance = (
-        instanceRaw as { readonly body?: Record<string, unknown> }
-      ).body ?? instanceRaw;
+      const instance =
+        (instanceRaw as { readonly body?: Record<string, unknown> }).body ?? instanceRaw;
       expect(Reflect.get(instance, 'status')).toMatchObject({
         ready: true,
         phase: 'Ready',
         availableNodes: 3,
         health: expect.stringMatching(/green|yellow/),
       });
-      const networkingApi =
-        createBunCompatibleNetworkingV1Api(kubeConfig);
+      const networkingApi = createBunCompatibleNetworkingV1Api(kubeConfig);
       const policy = await networkingApi.readNamespacedNetworkPolicy({
         namespace: kroNamespace,
         name: 'kro-search-default',
@@ -388,16 +353,11 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
       expect(policy.spec).toBeDefined();
       const admittedNamespaces = policy.spec?.ingress
         ?.flatMap((rule) => rule._from ?? [])
-        .flatMap((peer) =>
-          peer.namespaceSelector?.matchLabels?.[
-            'kubernetes.io/metadata.name'
-          ] ?? []
+        .flatMap(
+          (peer) => peer.namespaceSelector?.matchLabels?.['kubernetes.io/metadata.name'] ?? []
         );
       expect(admittedNamespaces).toEqual(
-        expect.arrayContaining([
-          operatorNamespace,
-          kroControlNamespace,
-        ])
+        expect.arrayContaining([operatorNamespace, kroControlNamespace])
       );
     } catch (error) {
       testFailed = true;
@@ -412,19 +372,14 @@ describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
       240_000
     ).catch((error) => cleanupErrors.push(error));
     if (cleanupErrors.length === 0) {
-      await deleteCredentials(
-        kubeConfig,
-        kroNamespace,
-        credentials
-      ).catch((error) => cleanupErrors.push(error));
-      await deleteDataPvcs(kubeConfig, kroNamespace, 'kro-search').catch(
-        (error) => cleanupErrors.push(error)
+      await deleteCredentials(kubeConfig, kroNamespace, credentials).catch((error) =>
+        cleanupErrors.push(error)
+      );
+      await deleteDataPvcs(kubeConfig, kroNamespace, 'kro-search').catch((error) =>
+        cleanupErrors.push(error)
       );
     }
-    const errors = [
-      ...(testFailed ? [testError] : []),
-      ...cleanupErrors,
-    ];
+    const errors = [...(testFailed ? [testError] : []), ...cleanupErrors];
     if (errors.length > 0) {
       throw new AggregateError(errors, 'KRO OpenSearch test failed');
     }

--- a/test/integration/opensearch/opensearch-cluster.test.ts
+++ b/test/integration/opensearch/opensearch-cluster.test.ts
@@ -1,0 +1,385 @@
+import { afterAll, beforeAll, describe, expect, test, setDefaultTimeout } from 'bun:test';
+import { getKubeConfig } from '../../../src/core/kubernetes/client-provider.js';
+import { isNotFoundError } from '../../../src/core/deployment/k8s-helpers.js';
+import {
+  createBunCompatibleCoreV1Api,
+  createBunCompatibleCustomObjectsApi,
+} from '../../../src/core/kubernetes/index.js';
+import {
+  makeOpenSearchCluster,
+  openSearchOperatorBootstrap,
+} from '../../../src/factories/opensearch/index.js';
+import {
+  createTestNamespace,
+  deleteTestFactoryInstanceAndRecoverNamespaces,
+  deleteTestNamespaceAndWait,
+  deleteTestSecretAndWait,
+  isClusterAvailable,
+  requireTestStorageClass,
+  type TestNamespaceLease,
+  waitForResourceAbsent,
+} from '../shared-kubeconfig.js';
+
+const clusterAvailable = await isClusterAvailable();
+const describeOrSkip =
+  clusterAvailable || process.env.REQUIRE_CLUSTER_TESTS === 'true'
+    ? describe
+    : describe.skip;
+
+setDefaultTimeout(1_500_000);
+
+async function createCredentials(
+  kubeConfig: ReturnType<typeof getKubeConfig>,
+  namespace: string,
+  clusterName: string
+): Promise<{
+  readonly admin: string;
+  readonly dashboards: string;
+}> {
+  const admin = `${clusterName}-test-admin`;
+  const dashboards = `${clusterName}-test-dashboards`;
+  const coreApi = createBunCompatibleCoreV1Api(kubeConfig);
+  await Promise.all([
+    coreApi.createNamespacedSecret({
+      namespace,
+      body: {
+        metadata: {
+          name: admin,
+          labels: { 'typekro.dev/integration-test': 'owned' },
+        },
+        stringData: {
+          username: 'admin',
+          password: 'TypeKro-OpenSearch-Test-Only-123!',
+        },
+      },
+    }),
+    coreApi.createNamespacedSecret({
+      namespace,
+      body: {
+        metadata: {
+          name: dashboards,
+          labels: { 'typekro.dev/integration-test': 'owned' },
+        },
+        stringData: {
+          username: 'kibanaserver',
+          password: 'TypeKro-Dashboards-Test-Only-123!',
+        },
+      },
+    }),
+  ]);
+  return { admin, dashboards };
+}
+
+async function deleteCredentials(
+  kubeConfig: ReturnType<typeof getKubeConfig>,
+  namespace: string,
+  names: { readonly admin: string; readonly dashboards: string }
+): Promise<void> {
+  const results = await Promise.allSettled([
+    deleteTestSecretAndWait(namespace, names.admin, kubeConfig),
+    deleteTestSecretAndWait(namespace, names.dashboards, kubeConfig),
+  ]);
+  const errors = results.flatMap((result) =>
+    result.status === 'rejected' ? [result.reason] : []
+  );
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `Credential cleanup failed in ${namespace}`);
+  }
+}
+
+async function deleteDataPvcs(
+  kubeConfig: ReturnType<typeof getKubeConfig>,
+  namespace: string,
+  clusterName: string
+): Promise<void> {
+  const coreApi = createBunCompatibleCoreV1Api(kubeConfig);
+  const listed = await coreApi.listNamespacedPersistentVolumeClaim({
+    namespace,
+  });
+  const claims = listed.items.filter(
+    (claim) =>
+      claim.metadata?.labels?.['opensearch.org/opensearch-cluster'] ===
+      clusterName
+  );
+  for (const claim of claims) {
+    const name = claim.metadata?.name;
+    const uid = claim.metadata?.uid;
+    if (!name || !uid) {
+      throw new Error(
+        `Refusing OpenSearch PVC cleanup in ${namespace}: identity is incomplete`
+      );
+    }
+    try {
+      await coreApi.deleteNamespacedPersistentVolumeClaim({
+        namespace,
+        name,
+        body: { preconditions: { uid } },
+      });
+    } catch (error) {
+      if (isNotFoundError(error)) continue;
+      throw error;
+    }
+    await waitForResourceAbsent(
+      {
+        apiVersion: 'v1',
+        kind: 'PersistentVolumeClaim',
+        metadata: { namespace, name },
+      },
+      kubeConfig,
+      60_000
+    );
+  }
+}
+
+describeOrSkip('OpenSearch direct and KRO lifecycle', () => {
+  const suffix = crypto.randomUUID().slice(0, 8);
+  const operatorControlNamespace = 'typekro-system';
+  const operatorNamespace = 'opensearch-operator-system';
+  const directNamespace = `typekro-os-direct-${suffix}`;
+  const kroControlNamespace = `typekro-os-kro-control-${suffix}`;
+  const kroNamespace = `typekro-os-kro-${suffix}`;
+  const leases: TestNamespaceLease[] = [];
+  let kubeConfig: ReturnType<typeof getKubeConfig>;
+  let storageClass: string;
+
+  beforeAll(async () => {
+    kubeConfig = getKubeConfig({ skipTLSVerify: true });
+    storageClass = await requireTestStorageClass({ kubeConfig });
+    leases.push(
+      ...(await Promise.all(
+        [
+          directNamespace,
+          kroControlNamespace,
+          kroNamespace,
+        ].map((name) => createTestNamespace(name, kubeConfig))
+      ))
+    );
+    const operatorFactory = openSearchOperatorBootstrap.factory('direct', {
+      namespace: operatorControlNamespace,
+      waitForReady: true,
+      timeout: 900_000,
+      kubeConfig,
+    });
+    const operator = await operatorFactory.deploy({
+      name: 'opensearch-operator',
+      namespace: operatorNamespace,
+      shared: true,
+    });
+    expect(operator.status).toMatchObject({
+      ready: true,
+      failed: false,
+      phase: 'Ready',
+      version: '3.0.2',
+    });
+  });
+
+  afterAll(async () => {
+    const errors: unknown[] = [];
+    // The operator, its CRDs, and HelmRepository are cluster platform
+    // infrastructure. Shared lifecycle intentionally retains and reuses them
+    // across suites; only the per-run data-plane instances are ephemeral.
+    const namespaceResults = await Promise.allSettled(
+      leases.map((lease) => deleteTestNamespaceAndWait(lease, kubeConfig))
+    );
+    errors.push(
+      ...namespaceResults.flatMap((result) =>
+        result.status === 'rejected' ? [result.reason] : []
+      )
+    );
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'OpenSearch integration cleanup failed');
+    }
+  });
+
+  test('deploys, updates, reports complete status, and deletes in direct mode', async () => {
+    const credentials = await createCredentials(
+      kubeConfig,
+      directNamespace,
+      'direct-search'
+    );
+    const factory = makeOpenSearchCluster().factory('direct', {
+      namespace: directNamespace,
+      waitForReady: true,
+      timeout: 900_000,
+      kubeConfig,
+    });
+    let testFailed = false;
+    let testError: unknown;
+    try {
+      const deployed = await factory.deploy({
+        name: 'direct-search',
+        namespace: directNamespace,
+        version: '3.2.0',
+        lifecycle: 'external-delete',
+        storage: { size: '1Gi', storageClassName: storageClass },
+        tls: { source: 'generated' },
+        adminCredentialsSecret: { name: credentials.admin },
+        dashboardCredentialsSecret: { name: credentials.dashboards },
+        resources: {
+          requests: { cpu: '100m', memory: '768Mi' },
+          limits: { cpu: '1000m', memory: '1Gi' },
+        },
+      });
+      expect(deployed.status).toMatchObject({
+        ready: true,
+        failed: false,
+        phase: 'Ready',
+        version: '3.2.0',
+        availableNodes: 3,
+      });
+      expect(['green', 'yellow']).toContain(deployed.status.health);
+      expect(deployed.status.endpoint).toBe(
+        `https://direct-search.${directNamespace}.svc.cluster.local:9200`
+      );
+      expect(deployed.status.credentialsSecret).toBe(
+        credentials.admin
+      );
+
+      const updated = await factory.deploy({
+        name: 'direct-search',
+        namespace: directNamespace,
+        version: '3.2.0',
+        lifecycle: 'external-delete',
+        storage: { size: '1Gi', storageClassName: storageClass },
+        tls: { source: 'generated' },
+        adminCredentialsSecret: { name: credentials.admin },
+        dashboardCredentialsSecret: { name: credentials.dashboards },
+        monitoring: true,
+        resources: {
+          requests: { cpu: '100m', memory: '768Mi' },
+          limits: { cpu: '1000m', memory: '1Gi' },
+        },
+      });
+      expect(updated.status.ready).toBe(true);
+    } catch (error) {
+      testFailed = true;
+      testError = error;
+    }
+    const cleanupErrors: unknown[] = [];
+    await deleteTestFactoryInstanceAndRecoverNamespaces(
+      factory,
+      'direct-search',
+      [],
+      kubeConfig,
+      240_000
+    ).catch((error) => cleanupErrors.push(error));
+    if (cleanupErrors.length === 0) {
+      await deleteCredentials(
+        kubeConfig,
+        directNamespace,
+        credentials
+      ).catch((error) => cleanupErrors.push(error));
+      await deleteDataPvcs(
+        kubeConfig,
+        directNamespace,
+        'direct-search'
+      ).catch((error) => cleanupErrors.push(error));
+    }
+    const errors = [
+      ...(testFailed ? [testError] : []),
+      ...cleanupErrors,
+    ];
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'Direct OpenSearch test failed');
+    }
+  });
+
+  test('deploys an RGD, projects live status, and deletes through KRO finalization', async () => {
+    const credentials = await createCredentials(
+      kubeConfig,
+      kroNamespace,
+      'kro-search'
+    );
+    const factory = makeOpenSearchCluster().factory('kro', {
+      namespace: kroControlNamespace,
+      waitForReady: true,
+      timeout: 900_000,
+      kubeConfig,
+    });
+    let testFailed = false;
+    let testError: unknown;
+    try {
+      const deployed = await factory.deploy({
+        name: 'kro-search',
+        namespace: kroNamespace,
+        version: '3.2.0',
+        lifecycle: 'external-delete',
+        storage: { size: '1Gi', storageClassName: storageClass },
+        tls: { source: 'generated' },
+        adminCredentialsSecret: { name: credentials.admin },
+        dashboardCredentialsSecret: { name: credentials.dashboards },
+        resources: {
+          requests: { cpu: '100m', memory: '768Mi' },
+          limits: { cpu: '1000m', memory: '1Gi' },
+        },
+      });
+      expect(deployed.status).toMatchObject({
+        ready: true,
+        failed: false,
+        phase: 'Ready',
+        version: '3.2.0',
+        availableNodes: 3,
+      });
+      const customApi = createBunCompatibleCustomObjectsApi(kubeConfig);
+      const clusterRaw = await customApi.getNamespacedCustomObject({
+        group: 'opensearch.org',
+        version: 'v1',
+        namespace: kroNamespace,
+        plural: 'opensearchclusters',
+        name: 'kro-search',
+      });
+      const cluster = (
+        clusterRaw as { readonly body?: Record<string, unknown> }
+      ).body ?? clusterRaw;
+      expect(Reflect.get(cluster, 'status')).toMatchObject({
+        initialized: true,
+        availableNodes: 3,
+      });
+
+      const instanceRaw = await customApi.getNamespacedCustomObject({
+        group: 'kro.run',
+        version: 'v1alpha1',
+        namespace: kroControlNamespace,
+        plural: 'opensearchclusterinstallations',
+        name: 'kro-search',
+      });
+      const instance = (
+        instanceRaw as { readonly body?: Record<string, unknown> }
+      ).body ?? instanceRaw;
+      expect(Reflect.get(instance, 'status')).toMatchObject({
+        ready: true,
+        phase: 'Ready',
+        availableNodes: 3,
+        health: expect.stringMatching(/green|yellow/),
+      });
+    } catch (error) {
+      testFailed = true;
+      testError = error;
+    }
+    const cleanupErrors: unknown[] = [];
+    await deleteTestFactoryInstanceAndRecoverNamespaces(
+      factory,
+      'kro-search',
+      [],
+      kubeConfig,
+      240_000
+    ).catch((error) => cleanupErrors.push(error));
+    if (cleanupErrors.length === 0) {
+      await deleteCredentials(
+        kubeConfig,
+        kroNamespace,
+        credentials
+      ).catch((error) => cleanupErrors.push(error));
+      await deleteDataPvcs(kubeConfig, kroNamespace, 'kro-search').catch(
+        (error) => cleanupErrors.push(error)
+      );
+    }
+    const errors = [
+      ...(testFailed ? [testError] : []),
+      ...cleanupErrors,
+    ];
+    if (errors.length > 0) {
+      throw new AggregateError(errors, 'KRO OpenSearch test failed');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add the official OpenSearch operator bootstrap with singleton-owned shared infrastructure
- add a production-oriented OpenSearch cluster composition with build-time topology, TLS, snapshots, lifecycle policy, and complete status
- support direct and KRO modes with typed generated/secret/cert-manager TLS variants
- document the API and export it as `typekro/opensearch`

## Safety and lifecycle
- require the upstream minimum of three cluster-manager nodes
- make persistent-data ownership explicit with `owned-delete`, `external-delete`, and `external-retain`
- preserve shared operator infrastructure across consumer deletion
- keep credentials external when explicitly supplied
- clean external-delete PVCs by exact labels and owner UID during test teardown

## Verification
- 7 focused unit tests / 43 assertions
- direct and KRO OrbStack lifecycle tests passed (deploy, update, complete status, delete/finalize, cleanup)
- randomized suite: 5,157 passed, 0 failed
- build, all typechecks, lint, docs validation, VitePress build, and diff checks passed

This remains draft for independent API and production-safety review.