### PR TITLE
fix(core): map arktype `object` primitive to KRO `object` (fixes #128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Arktype `object` now maps to KRO `object` instead of `string`.** A bare `type('object')` is represented by
+  arktype as the string `"object"`, which the KRO type mapper had no case for, so it fell through to the
+  `string` default. Every schemaless-object field was therefore declared `string` in the generated RGD and KRO
+  admission dropped whatever object a caller sent. `object[]` is fixed by the same change (the array branch
+  recurses). Affects any factory using `type('object')` for passthrough config — Dagster, APISIX, Ory,
+  ClickHouse — not just Dagster.
+- **Dagster's raw `values` escape hatch is genuinely opaque.** It had been assigned the fully typed
+  `helmValuesSchemaShape`, making a CLOSED schema out of a field documented as *raw official chart values*; its
+  `postgresql` sub-shape reused the convenience shape, so bundled-subchart settings (`primary.*`,
+  `nodeSelector`, `persistence`) were unreachable through either documented route. Typed convenience remains on
+  the high-level API (`postgresql`, `webserver`, `runLauncher`, …).
+
+### Added
+
+- **`allowBreakingChanges` factory option.** Stamps `kro.run/allow-breaking-changes: "true"` on the generated
+  RGD. The same option already existed at composition level, but a consumer of a SHIPPED composition
+  (`dagsterBootstrap`, `apisixBootstrap`, …) cannot reach that, so there was no way to migrate an
+  already-deployed RGD. Off by default.
+
+### ⚠️ UPGRADE NOTE — existing deployments need one authorized converge
+
+The `object` correction changes the DECLARED TYPE of existing RGD fields (52 of them in the Dagster RGD alone).
+KRO refuses breaking CRD updates, **and the refusal is silent**: the apply succeeds, the RGD reports
+`Ready=True`, and the registered CRD keeps its OLD schema. The only evidence is a controller log line:
+
+```
+cannot update CRD <plural>.kro.run: breaking changes detected: Type changed from string to object; ...
+```
+
+So an upgrade can appear to land while nothing changed and values continue to be pruned. To migrate, authorize
+it for the one converge that performs the change:
+
+```ts
+myComposition.factory('kro', { allowBreakingChanges: true })
+```
+
+then drop the option again. Verify with:
+
+```
+kubectl get crd <plural>.kro.run \
+  -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.values.type}'
+```
+
+It should print `object`. Deleting and recreating the RGD also works (KRO re-registers the CRD from scratch)
+but destroys existing custom resources, so prefer the annotation. Do not enable it globally: it disables a real
+safety check, and a genuinely lossy change (narrowing a type, dropping a field) can strand existing CRs.
+
 ## [0.21.0] - 2026-07-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "test:packed-imports": "node scripts/test-packed-imports.mjs",
     "test:all": "bun run test && bun run test:integration:all",
     "test:integration": "./scripts/run-integration-tests.sh",
-    "test:integration:dagster": "bun test test/integration/dagster/bootstrap-composition.test.ts --timeout 900000",
+    "test:integration:dagster": "bun test test/integration/dagster/ --timeout 900000",
     "test:integration:required": "REQUIRE_CLUSTER_TESTS=true ./scripts/run-integration-tests.sh",
     "test:integration:debug": "DEBUG_MODE=true ./scripts/run-integration-tests.sh",
     "typecheck": "bun run typecheck:lib && bun run typecheck:examples && bun run typecheck:tests",

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -4571,6 +4571,12 @@ export class KroResourceFactoryImpl<
       {
         ...(this.factoryOptions.compositionOptions as SerializationOptions | undefined),
         namespace: this.namespace,
+        // Factory-level override. The composition option of the same name is unreachable for a consumer of a
+        // SHIPPED composition (its definition lives in TypeKro), so without this there is no way to authorize
+        // the one-off CRD schema migration KRO would otherwise silently refuse.
+        ...(this.factoryOptions.allowBreakingChanges === undefined
+          ? {}
+          : { allowBreakingChanges: this.factoryOptions.allowBreakingChanges }),
       },
       kroSchema
     );
@@ -4600,10 +4606,12 @@ export class KroResourceFactoryImpl<
   }
 
   private buildRgdYaml(spec?: TSpec): string {
-    return serializeResourceGraphDefinitionToYaml(
-      this.buildRgdManifest(spec),
-      this.factoryOptions.compositionOptions as SerializationOptions | undefined
-    );
+    return serializeResourceGraphDefinitionToYaml(this.buildRgdManifest(spec), {
+      ...(this.factoryOptions.compositionOptions as SerializationOptions | undefined),
+      ...(this.factoryOptions.allowBreakingChanges === undefined
+        ? {}
+        : { allowBreakingChanges: this.factoryOptions.allowBreakingChanges }),
+    });
   }
 
   /**

--- a/src/core/serialization/schema.ts
+++ b/src/core/serialization/schema.ts
@@ -133,6 +133,18 @@ function getKroTypeFromJson(node: unknown): string {
       case 'string':
       case 'boolean':
         return node;
+      // Arktype represents a bare `type('object')` as the STRING "object" (not as
+      // `{ domain: "object" }`, which the object branch above already handles). Omitting it here fell
+      // through to the `'string'` default, so every schemaless-object field was declared `string` in the
+      // RGD — and KRO admission then PRUNED any real object a caller sent, silently. That is what made
+      // Dagster's documented Helm `values` escape hatches unusable, and it affects every factory using
+      // `type('object')` for passthrough config. KRO models `object` as schemaless (`type: object` with
+      // `x-kubernetes-preserve-unknown-fields: true`), which is exactly the representation needed.
+      //
+      // `object[]` needs no separate case: the array branch above recurses through here, so a
+      // `sequence` of "object" now yields `[]object`.
+      case 'object':
+        return 'object';
     }
   }
 

--- a/src/core/types/deployment.ts
+++ b/src/core/types/deployment.ts
@@ -670,6 +670,27 @@ export interface PublicFactoryOptions extends BaseDeploymentConfig {
    */
   instanceNamespace?: string;
 
+  /**
+   * Stamp `kro.run/allow-breaking-changes: "true"` on the generated ResourceGraphDefinition, authorizing KRO
+   * to apply a CRD schema change it would otherwise refuse.
+   *
+   * WHY THIS EXISTS AT FACTORY LEVEL. The same flag is available as a *composition* option, but a consumer of
+   * a SHIPPED composition (`dagsterBootstrap`, `apisixBootstrap`, …) cannot reach that — the composition is
+   * defined inside TypeKro. Without a factory-level switch there is no way to migrate an already-deployed RGD.
+   *
+   * WHEN YOU NEED IT. KRO refuses breaking CRD updates, and the refusal is EASY TO MISS: `kubectl apply`
+   * reports success, the RGD reports `Ready=True`, and only the controller log says
+   * `cannot update CRD ...: breaking changes detected`. The registered CRD silently keeps its old schema, so
+   * an upgrade appears to land while nothing changed. Set this for the one converge that performs the
+   * migration, then remove it.
+   *
+   * Scoped to a single factory deliberately — do not turn it on globally. It disables a real safety check, and
+   * a schema change that is genuinely lossy (narrowing a type, dropping a field) can strand existing CRs.
+   *
+   * @default false
+   */
+  allowBreakingChanges?: boolean;
+
   /** Explicit KubeConfig override for cluster connection */
   kubeConfig?: KubeConfig;
 

--- a/src/factories/dagster/types.ts
+++ b/src/factories/dagster/types.ts
@@ -418,36 +418,27 @@ const globalSchemaShape = {
 const serviceAccountSchemaShape = {
   'create?': 'boolean',
   'name?': 'string',
-  // Record<string,string> (not objectMapSchema/`object`) so the generated CRD field is an object map with
-  // string values — `object` serializes to `type: string`, which k8s rejects for an annotations map (422).
+  // `Record<string,string>` rather than `object`: annotations ARE a string→string map, so the precise type
+  // is the right one — it documents the contract and rejects a non-string value at the boundary.
+  // (The previous rationale here said `object` "serializes to `type: string`". That was true, but it was
+  // describing the converter BUG this workaround was hiding: arktype renders a bare `type('object')` as the
+  // string "object", which the KRO type mapper had no case for and defaulted to `string`. Fixed in
+  // core/serialization/schema.ts — `object` now maps to KRO's schemaless `object`.)
   'annotations?': 'Record<string, string>',
 } as const;
 
-const helmValuesSchemaShape = {
-  ...globalSchemaShape,
-  'global?': globalSchemaShape,
-  'serviceAccount?': serviceAccountSchemaShape,
-  'nameOverride?': 'string',
-  'fullnameOverride?': 'string',
-  'rbacEnabled?': 'boolean',
-  'imagePullSecrets?': namedRefSchema.array(),
-  'dagsterWebserver?': webserverSchemaShape,
-  'dagsterDaemon?': daemonSchemaShape,
-  'dagster-user-deployments?': userDeploymentsSchemaShape,
-  'postgresql?': postgresqlSchemaShape,
-  'generatePostgresqlPasswordSecret?': 'boolean',
-  'generateCeleryConfigSecret?': 'boolean',
-  'rabbitmq?': rabbitmqSchemaShape,
-  'redis?': redisSchemaShape,
-  'runLauncher?': runLauncherSchemaShape,
-  'scheduler?': schedulerSchemaShape,
-  'computeLogManager?': computeLogManagerSchemaShape,
-  'flower?': flowerSchemaShape,
-  'ingress?': ingressSchemaShape,
-  'pythonLogs?': objectMapSchema,
-  'busybox?': objectMapSchema,
-  'extraManifests?': 'unknown[]',
-} as const;
+// NOTE: there is deliberately NO arktype shape for the raw `values` escape hatch.
+//
+// It used to be a fully typed `helmValuesSchemaShape`, which made the field a CLOSED schema: KRO admission
+// pruned any chart value the shape didn't model, silently. That defeated the field's entire purpose — it is
+// advertised as "raw official chart values", i.e. arbitrary. Notably its `postgresql` sub-shape reused the
+// TypeKro CONVENIENCE shape, so bundled-postgres subchart settings (`primary.*`, `nodeSelector`,
+// `persistence`) could never be set through either documented route.
+//
+// `values` is now `objectMapSchema` (`type('object')` → KRO `object`, i.e. schemaless with
+// `x-kubernetes-preserve-unknown-fields: true`), so whatever the caller sends reaches the HelmRelease.
+// Typed convenience stays at the high-level API (`postgresql`, `webserver`, `runLauncher`, …) and the
+// `DagsterHelmValues` TS interface still documents the common fields for authors.
 
 /** Kubernetes Secret key reference used for Dagster sensitive chart values. */
 export interface DagsterSecretKeyRef {
@@ -892,7 +883,7 @@ export const DagsterBootstrapConfigSchema = type({
   'rabbitmq?': rabbitmqSchemaShape,
   'redis?': redisSchemaShape,
   'global?': globalSchemaShape,
-  'values?': helmValuesSchemaShape,
+  'values?': objectMapSchema,
 });
 
 /** Configuration for deploying Dagster through the bootstrap composition. */
@@ -1010,7 +1001,7 @@ export const DagsterHelmReleaseConfigSchema = type({
   'version?': 'string',
   'repositoryName?': 'string',
   'repositoryNamespace?': 'string',
-  'values?': helmValuesSchemaShape,
+  'values?': objectMapSchema,
   'id?': 'string',
 });
 

--- a/src/factories/dagster/types.ts
+++ b/src/factories/dagster/types.ts
@@ -414,19 +414,6 @@ const globalSchemaShape = {
   'dagsterInstanceConfigMap?': 'string',
 } as const;
 
-/** Official chart `serviceAccount` block — notably `annotations` (e.g. IRSA `eks.amazonaws.com/role-arn`). */
-const serviceAccountSchemaShape = {
-  'create?': 'boolean',
-  'name?': 'string',
-  // `Record<string,string>` rather than `object`: annotations ARE a string→string map, so the precise type
-  // is the right one — it documents the contract and rejects a non-string value at the boundary.
-  // (The previous rationale here said `object` "serializes to `type: string`". That was true, but it was
-  // describing the converter BUG this workaround was hiding: arktype renders a bare `type('object')` as the
-  // string "object", which the KRO type mapper had no case for and defaulted to `string`. Fixed in
-  // core/serialization/schema.ts — `object` now maps to KRO's schemaless `object`.)
-  'annotations?': 'Record<string, string>',
-} as const;
-
 // NOTE: there is deliberately NO arktype shape for the raw `values` escape hatch.
 //
 // It used to be a fully typed `helmValuesSchemaShape`, which made the field a CLOSED schema: KRO admission
@@ -439,6 +426,12 @@ const serviceAccountSchemaShape = {
 // `x-kubernetes-preserve-unknown-fields: true`), so whatever the caller sends reaches the HelmRelease.
 // Typed convenience stays at the high-level API (`postgresql`, `webserver`, `runLauncher`, …) and the
 // `DagsterHelmValues` TS interface still documents the common fields for authors.
+//
+// Removing the typed shape also retired its `serviceAccount` sub-shape, whose comment used to justify
+// `Record<string,string>` for annotations on the grounds that `object` "serializes to type: string". That was
+// this converter bug stated as if it were a rule. `Record<string,string>` would still be the RIGHT choice for
+// annotations on its own merits (they really are a string→string map) — but the reason given was wrong, and
+// worth flagging in case the same reasoning was copied elsewhere.
 
 /** Kubernetes Secret key reference used for Dagster sensitive chart values. */
 export interface DagsterSecretKeyRef {

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { load } from 'js-yaml';
+import { load, loadAll } from 'js-yaml';
 import {
   dagsterBootstrap,
   dagsterHelmRepositoryBootstrap,
@@ -14,6 +14,16 @@ import {
 // Direct composition imports were rejected because `typekro/dagster` is the
 // approved user-facing seam.
 describe('Dagster bootstrap composition', () => {
+  /** The RGD's `spec.schema.spec` — the declared CRD field types KRO admission enforces. */
+  const bootstrapSchemaSpec = (): Record<string, any> => {
+    const docs = loadAll(dagsterBootstrap.toYaml()) as Array<any>;
+    // Select by SCHEMA kind: toYaml() emits two RGDs (the HelmRepository one first), so matching on
+    // `kind: ResourceGraphDefinition` silently picks the wrong document.
+    const rgd = docs.find((d) => d?.spec?.schema?.kind === 'DagsterBootstrap');
+    if (!rgd) throw new Error('no DagsterBootstrap RGD in dagsterBootstrap.toYaml()');
+    return rgd.spec.schema.spec as Record<string, any>;
+  };
+
   it('Accept valid Dagster bootstrap config through the config schema', () => {
     const result = DagsterBootstrapConfigSchema({
       name: 'analytics',
@@ -146,6 +156,33 @@ describe('Dagster bootstrap composition', () => {
     expect(instanceBundle).toContain('namespace: typekro-singletons');
     expect(instanceBundle).toContain('typekro.io/singleton-spec-fingerprint');
     expect(instanceBundle).toContain('kind: DagsterBootstrap');
+  });
+
+  // The escape hatches must be SCHEMALESS in the RGD. Asserting the CEL reference exists (as the test
+  // below does) is not enough: a field can be referenced and still be typed `string`, in which case KRO
+  // admission PRUNES whatever object the caller sent and the reference resolves to nothing. That is exactly
+  // how both documented Dagster passthroughs stayed broken while tests passed — so assert the TYPE.
+  it('Declare every raw Helm values escape hatch as KRO `object`, not `string`', () => {
+    const spec = bootstrapSchemaSpec();
+
+    // The top-level chart-values passthrough.
+    expect(spec.values).toBe('object');
+    // The per-subchart passthroughs. These are the ONLY route to bundled-subchart settings such as
+    // postgresql `primary.persistence.enabled` or `nodeSelector`, none of which the convenience shapes model.
+    expect(spec.postgresql.values).toBe('object');
+    expect(spec.rabbitmq.values).toBe('object');
+    expect(spec.redis.values).toBe('object');
+  });
+
+  it('Keep typed convenience fields typed — opaque `values` must not swallow the whole API', () => {
+    const spec = bootstrapSchemaSpec();
+
+    // Making `values` opaque is a deliberate narrowing of where schemalessness applies. The high-level
+    // convenience API must stay strongly typed, or the CRD stops documenting anything.
+    expect(spec.name).toBe('string');
+    expect(spec.postgresql.enabled).toBe('boolean');
+    expect(spec.postgresql.servicePort).toBe('integer');
+    expect(spec.postgresql.host).toBe('string');
   });
 
   it('Preserve graph-aware Helm values in ResourceGraphDefinition YAML without raw markers', () => {

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -14,14 +14,21 @@ import {
 // Direct composition imports were rejected because `typekro/dagster` is the
 // approved user-facing seam.
 describe('Dagster bootstrap composition', () => {
+  /** Just enough of an RGD document to select one and read its declared schema types. */
+  interface RgdDocument {
+    kind?: string;
+    spec?: { schema?: { kind?: string; spec?: Record<string, unknown> } };
+  }
+
   /** The RGD's `spec.schema.spec` — the declared CRD field types KRO admission enforces. */
-  const bootstrapSchemaSpec = (): Record<string, any> => {
-    const docs = loadAll(dagsterBootstrap.toYaml()) as Array<any>;
+  const bootstrapSchemaSpec = (): Record<string, unknown> => {
+    const docs = loadAll(dagsterBootstrap.toYaml()) as RgdDocument[];
     // Select by SCHEMA kind: toYaml() emits two RGDs (the HelmRepository one first), so matching on
     // `kind: ResourceGraphDefinition` silently picks the wrong document.
-    const rgd = docs.find((d) => d?.spec?.schema?.kind === 'DagsterBootstrap');
-    if (!rgd) throw new Error('no DagsterBootstrap RGD in dagsterBootstrap.toYaml()');
-    return rgd.spec.schema.spec as Record<string, any>;
+    const schemaSpec = docs.find((d) => d.spec?.schema?.kind === 'DagsterBootstrap')?.spec?.schema
+      ?.spec;
+    if (!schemaSpec) throw new Error('no DagsterBootstrap RGD in dagsterBootstrap.toYaml()');
+    return schemaSpec;
   };
 
   it('Accept valid Dagster bootstrap config through the config schema', () => {

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -192,6 +192,21 @@ describe('Dagster bootstrap composition', () => {
     expect(spec.postgresql.host).toBe('string');
   });
 
+  // The migration switch for the schemaless-`object` correction. It has to work at FACTORY level: the same
+  // option exists on a composition, but `dagsterBootstrap`'s composition is defined inside TypeKro, so a
+  // consumer cannot reach it — leaving no way to authorize the one-off CRD schema change KRO otherwise
+  // refuses (silently: apply succeeds, RGD reports Ready, CRD keeps its old schema).
+  it('Stamps kro.run/allow-breaking-changes only when the factory opts in', () => {
+    expect(dagsterBootstrap.toYaml()).not.toContain('allow-breaking-changes');
+    expect(dagsterBootstrap.factory('kro', { allowBreakingChanges: true }).toYaml()).toContain(
+      'kro.run/allow-breaking-changes'
+    );
+    // Off by default: a safety check should never be disabled by merely passing other options.
+    expect(dagsterBootstrap.factory('kro', { namespace: 'dagster' }).toYaml()).not.toContain(
+      'allow-breaking-changes'
+    );
+  });
+
   it('Preserve graph-aware Helm values in ResourceGraphDefinition YAML without raw markers', () => {
     const yaml = dagsterBootstrap.toYaml();
 

--- a/test/factories/dagster/bootstrap-composition.test.ts
+++ b/test/factories/dagster/bootstrap-composition.test.ts
@@ -14,14 +14,30 @@ import {
 // Direct composition imports were rejected because `typekro/dagster` is the
 // approved user-facing seam.
 describe('Dagster bootstrap composition', () => {
+  /**
+   * A KRO SimpleSchema node: either a type string (`'string'`, `'object'`, `'[]object'`, …) or a nested map of
+   * fields. Recursive so nested reads stay typed — `Record<string, unknown>` would make every child `unknown`.
+   */
+  type SchemaNode = string | { readonly [field: string]: SchemaNode };
+
   /** Just enough of an RGD document to select one and read its declared schema types. */
   interface RgdDocument {
     kind?: string;
-    spec?: { schema?: { kind?: string; spec?: Record<string, unknown> } };
+    spec?: { schema?: { kind?: string; spec?: Record<string, SchemaNode> } };
   }
 
+  /** Read a nested field's declared type, e.g. `at(spec.postgresql, 'values')`. */
+  const at = (node: SchemaNode | undefined, ...path: string[]): SchemaNode | undefined => {
+    let cursor = node;
+    for (const key of path) {
+      if (typeof cursor !== 'object' || cursor === null) return undefined;
+      cursor = cursor[key];
+    }
+    return cursor;
+  };
+
   /** The RGD's `spec.schema.spec` — the declared CRD field types KRO admission enforces. */
-  const bootstrapSchemaSpec = (): Record<string, unknown> => {
+  const bootstrapSchemaSpec = (): Record<string, SchemaNode> => {
     const docs = loadAll(dagsterBootstrap.toYaml()) as RgdDocument[];
     // Select by SCHEMA kind: toYaml() emits two RGDs (the HelmRepository one first), so matching on
     // `kind: ResourceGraphDefinition` silently picks the wrong document.
@@ -176,9 +192,9 @@ describe('Dagster bootstrap composition', () => {
     expect(spec.values).toBe('object');
     // The per-subchart passthroughs. These are the ONLY route to bundled-subchart settings such as
     // postgresql `primary.persistence.enabled` or `nodeSelector`, none of which the convenience shapes model.
-    expect(spec.postgresql.values).toBe('object');
-    expect(spec.rabbitmq.values).toBe('object');
-    expect(spec.redis.values).toBe('object');
+    expect(at(spec.postgresql, 'values')).toBe('object');
+    expect(at(spec.rabbitmq, 'values')).toBe('object');
+    expect(at(spec.redis, 'values')).toBe('object');
   });
 
   it('Keep typed convenience fields typed — opaque `values` must not swallow the whole API', () => {
@@ -187,9 +203,9 @@ describe('Dagster bootstrap composition', () => {
     // Making `values` opaque is a deliberate narrowing of where schemalessness applies. The high-level
     // convenience API must stay strongly typed, or the CRD stops documenting anything.
     expect(spec.name).toBe('string');
-    expect(spec.postgresql.enabled).toBe('boolean');
-    expect(spec.postgresql.servicePort).toBe('integer');
-    expect(spec.postgresql.host).toBe('string');
+    expect(at(spec.postgresql, 'enabled')).toBe('boolean');
+    expect(at(spec.postgresql, 'servicePort')).toBe('integer');
+    expect(at(spec.postgresql, 'host')).toBe('string');
   });
 
   // The migration switch for the schemaless-`object` correction. It has to work at FACTORY level: the same

--- a/test/integration/dagster/schema-migration.test.ts
+++ b/test/integration/dagster/schema-migration.test.ts
@@ -42,8 +42,13 @@ const RGD_PLURAL = 'resourcegraphdefinitions';
  */
 const RUN_ID = Math.random().toString(36).slice(2, 8);
 const RGD_NAME = `schema-migration-probe-${RUN_ID}`;
-const CR_PLURAL = `schemamigrationprobes${RUN_ID}`;
 const CR_KIND = `SchemaMigrationProbe${RUN_ID}`;
+/**
+ * DERIVED, never hand-written: KRO builds the CRD plural as `kind.toLowerCase() + 's'`. Hand-building it put
+ * the `s` before the run suffix (`…probes<id>` vs KRO's `…probe<id>s`), so every CRD lookup missed and the
+ * fixture timed out waiting for a schema that was registered under the other name.
+ */
+const CR_PLURAL = `${CR_KIND.toLowerCase()}s`;
 
 /** An RGD declaring `values` as the type given — the only difference between legacy and corrected. */
 const rgd = (valuesType: 'string' | 'object', allowBreaking: boolean): object => ({

--- a/test/integration/dagster/schema-migration.test.ts
+++ b/test/integration/dagster/schema-migration.test.ts
@@ -1,0 +1,192 @@
+/**
+ * LIVE migration test: an ALREADY-DEPLOYED RGD whose field was declared `string` being moved to the corrected
+ * schemaless `object`.
+ *
+ * Why this needs a test of its own. Fixing the arktype `object` mapping changes the declared TYPE of existing
+ * fields (52 of them in the Dagster RGD alone), and KRO refuses breaking CRD updates. The refusal is very easy
+ * to miss:
+ *   - `kubectl apply` / the API create reports SUCCESS,
+ *   - the RGD reports `Ready=True`,
+ *   - the registered CRD silently keeps its OLD schema,
+ *   - and the only evidence is a controller log line:
+ *       `cannot update CRD ...: breaking changes detected: Type changed from string to object; ...`
+ * So an operator upgrading TypeKro would see a clean upgrade while nothing actually changed — the same
+ * silent-no-op shape as the bug being fixed. This test pins both halves: the refusal, and the authorized path.
+ *
+ * The legacy RGD is hand-authored rather than generated from an older TypeKro, so the test states the
+ * before-state explicitly instead of depending on git history.
+ */
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from 'bun:test';
+import * as k8s from '@kubernetes/client-node';
+import { createBunCompatibleApiClient } from '../../../src/core/kubernetes/bun-api-client.js';
+import {
+  createCustomObjectsApiClient,
+  getIntegrationTestKubeConfig,
+  isClusterAvailable,
+} from '../shared-kubeconfig.js';
+
+setDefaultTimeout(300000);
+
+const clusterAvailable = await isClusterAvailable();
+const describeLiveOrSkip = clusterAvailable ? describe : describe.skip;
+
+const GROUP = 'kro.run';
+const VERSION = 'v1alpha1';
+const RGD_PLURAL = 'resourcegraphdefinitions';
+const RGD_NAME = 'schema-migration-probe';
+const CR_PLURAL = 'schemamigrationprobes';
+const CR_KIND = 'SchemaMigrationProbe';
+
+/** An RGD declaring `values` as the type given — the only difference between legacy and corrected. */
+const rgd = (valuesType: 'string' | 'object', allowBreaking: boolean): object => ({
+  apiVersion: `${GROUP}/${VERSION}`,
+  kind: 'ResourceGraphDefinition',
+  metadata: {
+    name: RGD_NAME,
+    ...(allowBreaking ? { annotations: { 'kro.run/allow-breaking-changes': 'true' } } : {}),
+  },
+  spec: {
+    schema: {
+      apiVersion: VERSION,
+      kind: CR_KIND,
+      spec: { name: 'string', values: valuesType },
+      status: {},
+    },
+    resources: [
+      {
+        id: 'probeCfg',
+        template: {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          metadata: { name: '${schema.spec.name}-probe', namespace: 'default' },
+          data: { role: 'probe' },
+        },
+      },
+    ],
+  },
+});
+
+describeLiveOrSkip('migrating an existing RGD from `string` to schemaless `object`', () => {
+  const kc = getIntegrationTestKubeConfig();
+  const custom = createCustomObjectsApiClient(kc);
+  const apiext = createBunCompatibleApiClient(kc, k8s.ApiextensionsV1Api);
+
+  const applyRgd = async (body: object): Promise<void> => {
+    await custom
+      .createClusterCustomObject({ group: GROUP, version: VERSION, plural: RGD_PLURAL, body })
+      .catch(async (e: unknown) => {
+        if (!String(e).includes('AlreadyExists') && !String(e).includes('409')) throw e;
+        // UPDATE the existing RGD — that is the whole point here. Replacing it would delete the CRD and
+        // destroy the very before-state the test depends on.
+        const live = (await custom.getClusterCustomObject({
+          group: GROUP,
+          version: VERSION,
+          plural: RGD_PLURAL,
+          name: RGD_NAME,
+        })) as { metadata?: { resourceVersion?: string } };
+        await custom.replaceClusterCustomObject({
+          group: GROUP,
+          version: VERSION,
+          plural: RGD_PLURAL,
+          name: RGD_NAME,
+          body: {
+            ...body,
+            metadata: {
+              ...(body as { metadata: object }).metadata,
+              resourceVersion: live.metadata?.resourceVersion,
+            },
+          },
+        });
+      });
+  };
+
+  /** The declared type of `spec.values` on the REGISTERED CRD, or undefined until it is Established. */
+  const registeredValuesType = async (): Promise<string | undefined> =>
+    apiext
+      .readCustomResourceDefinition({ name: `${CR_PLURAL}.${GROUP}` })
+      .then((crd) => {
+        const established = crd.status?.conditions?.some(
+          (c) => c.type === 'Established' && c.status === 'True'
+        );
+        if (!established) return undefined;
+        const props = crd.spec.versions[0]?.schema?.openAPIV3Schema?.properties?.spec
+          ?.properties as Record<string, { type?: string }> | undefined;
+        return props?.values?.type;
+      })
+      .catch(() => undefined);
+
+  const waitForValuesType = async (want: string): Promise<boolean> => {
+    for (let i = 0; i < 60; i++) {
+      if ((await registeredValuesType()) === want) return true;
+      await Bun.sleep(1000);
+    }
+    return false;
+  };
+
+  beforeAll(async () => {
+    // Start from a clean slate so "the CRD still says string" cannot be an artifact of a previous run.
+    await custom
+      .deleteClusterCustomObject({ group: GROUP, version: VERSION, plural: RGD_PLURAL, name: RGD_NAME })
+      .catch(() => {});
+    await apiext
+      .deleteCustomResourceDefinition({ name: `${CR_PLURAL}.${GROUP}` })
+      .catch(() => {});
+    for (let i = 0; i < 60; i++) {
+      if ((await registeredValuesType()) === undefined) break;
+      await Bun.sleep(1000);
+    }
+    // Seed the legacy state WITH the annotation. Reverting `object` back to `string` is itself a breaking
+    // change, so if a previous run left the CRD at `object` (KRO's GC of the CRD can lag the RGD delete) an
+    // un-annotated seed would be refused and the fixture would never establish. The annotation here is
+    // fixture setup — the behaviour under test is the UN-annotated upgrade in the first `it`.
+    await applyRgd(rgd('string', true));
+    expect(await waitForValuesType('string')).toBe(true);
+  });
+
+  afterAll(async () => {
+    const failures: string[] = [];
+    await custom
+      .deleteClusterCustomObject({ group: GROUP, version: VERSION, plural: RGD_PLURAL, name: RGD_NAME })
+      .catch((e: unknown) => failures.push(`rgd/${RGD_NAME}: ${String(e)}`));
+    // WAIT for the RGD to actually be gone before touching its CRD. Delete them back-to-back and KRO, still
+    // reconciling the not-yet-observed RGD deletion, simply RE-REGISTERS the CRD — leaving one behind on
+    // every run.
+    for (let i = 0; i < 60; i++) {
+      const stillThere = await custom
+        .getClusterCustomObject({ group: GROUP, version: VERSION, plural: RGD_PLURAL, name: RGD_NAME })
+        .then(() => true)
+        .catch(() => false);
+      if (!stillThere) break;
+      await Bun.sleep(1000);
+    }
+    // Deleting the RGD does NOT reap the CRD KRO registered for it, so remove it explicitly or every run
+    // leaves one behind. Safe to delete unconditionally: this kind is owned solely by this test.
+    await apiext
+      .deleteCustomResourceDefinition({ name: `${CR_PLURAL}.${GROUP}` })
+      .catch((e: unknown) => failures.push(`crd/${CR_PLURAL}.${GROUP}: ${String(e)}`));
+    if (failures.length > 0) throw new Error(`cleanup failed:\n${failures.join('\n')}`);
+  });
+
+  it('SILENTLY refuses the corrected schema without authorization — the upgrade trap', async () => {
+    await applyRgd(rgd('object', false));
+
+    // The RGD update itself is accepted, which is exactly why this is dangerous.
+    const live = (await custom.getClusterCustomObject({
+      group: GROUP,
+      version: VERSION,
+      plural: RGD_PLURAL,
+      name: RGD_NAME,
+    })) as { spec?: { schema?: { spec?: Record<string, unknown> } } };
+    expect(live.spec?.schema?.spec?.values).toBe('object');
+
+    // ...but the CRD an operator's CRs are validated against does NOT move. Give KRO ample time to prove it
+    // is a refusal rather than a slow reconcile.
+    expect(await waitForValuesType('object')).toBe(false);
+    expect(await registeredValuesType()).toBe('string');
+  });
+
+  it('applies the corrected schema when the migration is explicitly authorized', async () => {
+    await applyRgd(rgd('object', true));
+    expect(await waitForValuesType('object')).toBe(true);
+  });
+});

--- a/test/integration/dagster/schema-migration.test.ts
+++ b/test/integration/dagster/schema-migration.test.ts
@@ -44,11 +44,12 @@ const RUN_ID = Math.random().toString(36).slice(2, 8);
 const RGD_NAME = `schema-migration-probe-${RUN_ID}`;
 const CR_KIND = `SchemaMigrationProbe${RUN_ID}`;
 /**
- * DERIVED, never hand-written: KRO builds the CRD plural as `kind.toLowerCase() + 's'`. Hand-building it put
- * the `s` before the run suffix (`…probes<id>` vs KRO's `…probe<id>s`), so every CRD lookup missed and the
- * fixture timed out waiting for a schema that was registered under the other name.
+ * DISCOVERED from the cluster, never derived. KRO pluralises the kind with real English rules, not `+ 's'`:
+ * with a random run suffix, `…probea32l9o` becomes `…probea32l9oes`, so any client-side guess is correct only
+ * for some suffixes — the fixture was flaky by construction and leaked the CRD its teardown couldn't find.
+ * Resolved in `beforeAll` once KRO has registered the CRD.
  */
-const CR_PLURAL = `${CR_KIND.toLowerCase()}s`;
+let CR_PLURAL = '';
 
 /** An RGD declaring `values` as the type given — the only difference between legacy and corrected. */
 const rgd = (valuesType: 'string' | 'object', allowBreaking: boolean): object => ({
@@ -136,6 +137,24 @@ describeLiveOrSkip('migrating an existing RGD from `string` to schemaless `objec
     return false;
   };
 
+  /**
+   * Find the CRD plural KRO registered for {@link CR_KIND} by MATCHING `spec.names.kind` — authoritative,
+   * unlike client-side pluralisation. Polls because KRO registers the CRD asynchronously after the RGD.
+   */
+  const discoverCrPlural = async (): Promise<string> => {
+    for (let i = 0; i < 60; i++) {
+      const found = await apiext
+        .listCustomResourceDefinition()
+        .then((list) =>
+          list.items.find((c) => c.spec.group === GROUP && c.spec.names.kind === CR_KIND)?.spec.names.plural
+        )
+        .catch(() => undefined);
+      if (found) return found;
+      await Bun.sleep(1000);
+    }
+    throw new Error(`KRO never registered a CRD for kind ${CR_KIND} in group ${GROUP}`);
+  };
+
   /** True only for a definitive 404. Any other error is NOT evidence of absence. */
   const isNotFound = (e: unknown): boolean => {
     const code = (e as { code?: number })?.code
@@ -171,22 +190,15 @@ describeLiveOrSkip('migrating an existing RGD from `string` to schemaless `objec
   };
 
   beforeAll(async () => {
-    // Start from a clean slate so "the CRD still says string" cannot be an artifact of a previous run.
-    await custom
-      .deleteClusterCustomObject({ group: GROUP, version: VERSION, plural: RGD_PLURAL, name: RGD_NAME })
-      .catch(() => {});
-    await apiext
-      .deleteCustomResourceDefinition({ name: `${CR_PLURAL}.${GROUP}` })
-      .catch(() => {});
-    for (let i = 0; i < 60; i++) {
-      if ((await registeredValuesType()) === undefined) break;
-      await Bun.sleep(1000);
-    }
+    // No pre-delete: the identity is RUN-UNIQUE, so there is nothing from a previous run to clear, and
+    // unconditionally deleting a fixed name is what let concurrent runs destroy each other's fixtures.
     // Seed the legacy state WITH the annotation. Reverting `object` back to `string` is itself a breaking
     // change, so if a previous run left the CRD at `object` (KRO's GC of the CRD can lag the RGD delete) an
     // un-annotated seed would be refused and the fixture would never establish. The annotation here is
     // fixture setup — the behaviour under test is the UN-annotated upgrade in the first `it`.
     await applyRgd(rgd('string', true));
+    // Resolve the plural from the cluster before any CRD read — every helper below keys off it.
+    CR_PLURAL = await discoverCrPlural();
     expect(await waitForValuesType('string')).toBe(true);
   });
 

--- a/test/integration/dagster/schema-migration.test.ts
+++ b/test/integration/dagster/schema-migration.test.ts
@@ -21,6 +21,7 @@ import * as k8s from '@kubernetes/client-node';
 import { createBunCompatibleApiClient } from '../../../src/core/kubernetes/bun-api-client.js';
 import {
   createCustomObjectsApiClient,
+  deleteGeneratedCrdAndWait,
   getIntegrationTestKubeConfig,
   isClusterAvailable,
 } from '../shared-kubeconfig.js';
@@ -176,19 +177,6 @@ describeLiveOrSkip('migrating an existing RGD from `string` to schemaless `objec
     return false;
   };
 
-  /** Same contract for the generated CRD. */
-  const waitForCrdAbsent = async (name: string): Promise<boolean> => {
-    for (let i = 0; i < 60; i++) {
-      const state = await apiext
-        .readCustomResourceDefinition({ name })
-        .then(() => 'present' as const)
-        .catch((e: unknown) => (isNotFound(e) ? ('absent' as const) : ('unknown' as const)));
-      if (state === 'absent') return true;
-      await Bun.sleep(1000);
-    }
-    return false;
-  };
-
   beforeAll(async () => {
     // No pre-delete: the identity is RUN-UNIQUE, so there is nothing from a previous run to clear, and
     // unconditionally deleting a fixed name is what let concurrent runs destroy each other's fixtures.
@@ -220,13 +208,21 @@ describeLiveOrSkip('migrating an existing RGD from `string` to schemaless `objec
     }
     // Deleting the RGD does NOT reap the CRD KRO registered for it, so remove it explicitly or every run
     // leaves one behind. Safe to delete unconditionally: this kind is run-unique and owned solely by this run.
+    // On a persistent OrbStack cluster an emptied CRD can hang on
+    // `customresourcecleanup.apiextensions.k8s.io`, so a plain delete-then-wait fails the hook and leaves the
+    // CRD Terminating. The shared harness helper owns that recovery and is FAIL-CLOSED: it clears the
+    // finalizer only after listing CR_KIND and proving zero instances remain.
     const crdName = `${CR_PLURAL}.${GROUP}`;
-    await apiext.deleteCustomResourceDefinition({ name: crdName }).catch((e: unknown) => {
-      if (!isNotFound(e)) failures.push(`crd/${crdName}: ${String(e)}`);
-    });
-    if (!(await waitForCrdAbsent(crdName))) {
-      failures.push(`crd/${crdName}: not confirmed absent (KRO may have re-registered it)`);
-    }
+    await deleteGeneratedCrdAndWait(
+      {
+        apiVersion: 'apiextensions.k8s.io/v1',
+        kind: 'CustomResourceDefinition',
+        metadata: { name: crdName },
+      },
+      `${GROUP}/${VERSION}`,
+      CR_KIND,
+      kc
+    ).catch((e: unknown) => failures.push(`crd/${crdName}: ${String(e)}`));
     if (failures.length > 0) throw new Error(`cleanup failed:\n${failures.join('\n')}`);
   });
 

--- a/test/integration/dagster/schema-migration.test.ts
+++ b/test/integration/dagster/schema-migration.test.ts
@@ -33,9 +33,17 @@ const describeLiveOrSkip = clusterAvailable ? describe : describe.skip;
 const GROUP = 'kro.run';
 const VERSION = 'v1alpha1';
 const RGD_PLURAL = 'resourcegraphdefinitions';
-const RGD_NAME = 'schema-migration-probe';
-const CR_PLURAL = 'schemamigrationprobes';
-const CR_KIND = 'SchemaMigrationProbe';
+/**
+ * RUN-UNIQUE identity. A fixed name made this fixture destructively ADOPT whatever was already on the
+ * cluster under that name: setup unconditionally deleted the RGD and its generated CRD (swallowing errors),
+ * so two concurrent runs — or a run overlapping an interrupted earlier one — would delete each other's
+ * resources with no ownership evidence. Suffixing every identity means a run can only ever touch objects it
+ * created, and the pre-delete below is a no-op belt-and-braces rather than a landmine.
+ */
+const RUN_ID = Math.random().toString(36).slice(2, 8);
+const RGD_NAME = `schema-migration-probe-${RUN_ID}`;
+const CR_PLURAL = `schemamigrationprobes${RUN_ID}`;
+const CR_KIND = `SchemaMigrationProbe${RUN_ID}`;
 
 /** An RGD declaring `values` as the type given — the only difference between legacy and corrected. */
 const rgd = (valuesType: 'string' | 'object', allowBreaking: boolean): object => ({

--- a/test/integration/dagster/schema-migration.test.ts
+++ b/test/integration/dagster/schema-migration.test.ts
@@ -131,6 +131,40 @@ describeLiveOrSkip('migrating an existing RGD from `string` to schemaless `objec
     return false;
   };
 
+  /** True only for a definitive 404. Any other error is NOT evidence of absence. */
+  const isNotFound = (e: unknown): boolean => {
+    const code = (e as { code?: number })?.code
+      ?? (e as { statusCode?: number })?.statusCode
+      ?? (e as { response?: { statusCode?: number } })?.response?.statusCode;
+    return code === 404 || /\b404\b|NotFound/.test(String(e));
+  };
+
+  /** Poll until the probe RGD is definitively gone; false on timeout so the caller fails. */
+  const waitForRgdAbsent = async (): Promise<boolean> => {
+    for (let i = 0; i < 60; i++) {
+      const state = await custom
+        .getClusterCustomObject({ group: GROUP, version: VERSION, plural: RGD_PLURAL, name: RGD_NAME })
+        .then(() => 'present' as const)
+        .catch((e: unknown) => (isNotFound(e) ? ('absent' as const) : ('unknown' as const)));
+      if (state === 'absent') return true;
+      await Bun.sleep(1000);
+    }
+    return false;
+  };
+
+  /** Same contract for the generated CRD. */
+  const waitForCrdAbsent = async (name: string): Promise<boolean> => {
+    for (let i = 0; i < 60; i++) {
+      const state = await apiext
+        .readCustomResourceDefinition({ name })
+        .then(() => 'present' as const)
+        .catch((e: unknown) => (isNotFound(e) ? ('absent' as const) : ('unknown' as const)));
+      if (state === 'absent') return true;
+      await Bun.sleep(1000);
+    }
+    return false;
+  };
+
   beforeAll(async () => {
     // Start from a clean slate so "the CRD still says string" cannot be an artifact of a previous run.
     await custom
@@ -159,19 +193,23 @@ describeLiveOrSkip('migrating an existing RGD from `string` to schemaless `objec
     // WAIT for the RGD to actually be gone before touching its CRD. Delete them back-to-back and KRO, still
     // reconciling the not-yet-observed RGD deletion, simply RE-REGISTERS the CRD — leaving one behind on
     // every run.
-    for (let i = 0; i < 60; i++) {
-      const stillThere = await custom
-        .getClusterCustomObject({ group: GROUP, version: VERSION, plural: RGD_PLURAL, name: RGD_NAME })
-        .then(() => true)
-        .catch(() => false);
-      if (!stillThere) break;
-      await Bun.sleep(1000);
+    //
+    // Absence must be proven by a 404. Treating ANY error as absence (the previous `.catch(() => false)`)
+    // meant a transient API failure read as "gone": cleanup would proceed to delete the CRD while the RGD was
+    // still there, KRO would re-register it, and the test would report success having leaked the CRD. A
+    // timeout is likewise a FAILURE, not a shrug.
+    if (!(await waitForRgdAbsent())) {
+      failures.push(`rgd/${RGD_NAME}: not confirmed absent (delete stuck, or the API never returned 404)`);
     }
     // Deleting the RGD does NOT reap the CRD KRO registered for it, so remove it explicitly or every run
-    // leaves one behind. Safe to delete unconditionally: this kind is owned solely by this test.
-    await apiext
-      .deleteCustomResourceDefinition({ name: `${CR_PLURAL}.${GROUP}` })
-      .catch((e: unknown) => failures.push(`crd/${CR_PLURAL}.${GROUP}: ${String(e)}`));
+    // leaves one behind. Safe to delete unconditionally: this kind is run-unique and owned solely by this run.
+    const crdName = `${CR_PLURAL}.${GROUP}`;
+    await apiext.deleteCustomResourceDefinition({ name: crdName }).catch((e: unknown) => {
+      if (!isNotFound(e)) failures.push(`crd/${crdName}: ${String(e)}`);
+    });
+    if (!(await waitForCrdAbsent(crdName))) {
+      failures.push(`crd/${crdName}: not confirmed absent (KRO may have re-registered it)`);
+    }
     if (failures.length > 0) throw new Error(`cleanup failed:\n${failures.join('\n')}`);
   });
 

--- a/test/integration/dagster/values-admission.test.ts
+++ b/test/integration/dagster/values-admission.test.ts
@@ -29,6 +29,7 @@ import { createBunCompatibleApiClient } from '../../../src/core/kubernetes/bun-a
 import {
   createCustomObjectsApiClient,
   createTestNamespace,
+  deleteGeneratedCrdAndWait,
   deleteTestNamespaceAndWait,
   getIntegrationTestKubeConfig,
   isClusterAvailable,
@@ -60,6 +61,12 @@ const PROBE_RGD = `object-schema-probe-${RUN_ID}`;
  * random, guessing made these fixtures pass or fail depending on its last character — `…probexrjqu1s` worked,
  * `…probea32l9oes` did not, and the mismatch leaked the CRD teardown then failed to find.
  */
+
+/** A kind this run registered, with the CRD plural KRO chose for it. */
+interface GeneratedKind {
+  readonly kind: string;
+  readonly plural: string;
+}
 
 /**
  * The structure a caller sends and admission must NOT strip: nested maps, a boolean, a number, an array of
@@ -104,8 +111,11 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
   /** CRD plurals KRO registers for this run's unique kinds; resolved in `beforeAll`. */
   let probePlural = '';
   let dagsterPlural = '';
-  /** EVERY plural this run registered — teardown must delete all of them, not only the asserted ones. */
-  const registeredPlurals: string[] = [];
+  /**
+   * EVERY kind/plural this run registered. The plural names the CRD to delete; the KIND is what
+   * `deleteGeneratedCrdAndWait` lists to prove zero instances remain before it touches a finalizer.
+   */
+  const registeredKinds: GeneratedKind[] = [];
   /** Every object this test creates, newest first, so teardown is deterministic. */
   const created: Array<{
     what: string;
@@ -131,19 +141,6 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
     for (let i = 0; i < 60; i++) {
       const state = await custom
         .getClusterCustomObject({ group: RGD_GROUP, version: RGD_VERSION, plural: RGD_PLURAL, name })
-        .then(() => 'present' as const)
-        .catch((e: unknown) => (isNotFound(e) ? ('absent' as const) : ('unknown' as const)));
-      if (state === 'absent') return true;
-      await Bun.sleep(1000);
-    }
-    return false;
-  };
-
-  /** Same contract for a CRD: only a 404 proves absence, and a timeout is a failure. */
-  const waitForCrdAbsent = async (name: string): Promise<boolean> => {
-    for (let i = 0; i < 60; i++) {
-      const state = await apiext
-        .readCustomResourceDefinition({ name })
         .then(() => 'present' as const)
         .catch((e: unknown) => (isNotFound(e) ? ('absent' as const) : ('unknown' as const)));
       if (state === 'absent') return true;
@@ -183,8 +180,8 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
    * overwriting. With a unique suffix that should be unreachable, so hitting it means an assumption broke —
    * which is exactly when silently rewriting somebody else's definition would do the most damage.
    */
-  const applyRgd = async (yamlDoc: string): Promise<string[]> => {
-    const plurals: string[] = [];
+  const applyRgd = async (yamlDoc: string): Promise<GeneratedKind[]> => {
+    const generated: GeneratedKind[] = [];
     for (const doc of k8s.loadAllYaml(yamlDoc)) {
       const body = doc as {
         kind?: string;
@@ -240,10 +237,9 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
             name,
           }),
       });
-      const plural = await discoverPlural(kind);
-      plurals.push(plural);
+      generated.push({ kind, plural: await discoverPlural(kind) });
     }
-    return plurals;
+    return generated;
   };
 
   /** `spec.schema.openAPIV3Schema.properties.spec.properties` of a registered CRD, if it exists yet. */
@@ -283,23 +279,25 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
 
   beforeAll(async () => {
     lease = await createTestNamespace(`typekro-obj-admission-${Math.random().toString(36).slice(2, 8)}`, kc);
-    const probePlurals = await applyRgd(probeComposition.factory('kro').toYaml());
-    probePlural = probePlurals[0] ?? '';
+    const probeGenerated = await applyRgd(probeComposition.factory('kro').toYaml());
+    probePlural = probeGenerated[0]?.plural ?? '';
     if (!probePlural) throw new Error('probe RGD registered no CRD plural');
     // `allowBreakingChanges` is retained because the bundle under test carries it — and it is precisely why
     // this must run under a run-unique kind: applied to the SHARED `dagsterbootstraps` CRD it would migrate
     // the schema real Dagster instances depend on.
-    const dagsterPlurals = await applyRgd(
+    const dagsterGenerated = await applyRgd(
       dagsterBootstrap.factory('kro', { allowBreakingChanges: true }).toYaml()
     );
     // EVERY plural the bundle registers must be retained for teardown, not just the one the assertions read.
     // The bundle contains TWO RGDs (bootstrap + the HelmRepository singleton), so each run registers two CRDs;
     // deleting an RGD does not reap its CRD, so keeping only the bootstrap plural leaked
     // `dagsterhelmrepository<id>s.kro.run` on every run.
-    registeredPlurals.push(...probePlurals, ...dagsterPlurals);
+    registeredKinds.push(...probeGenerated, ...dagsterGenerated);
     // The bootstrap RGD is the one declaring the schemaless `values` hatches the assertions read.
-    dagsterPlural = dagsterPlurals.find((pl) => pl.startsWith('dagsterbootstrap')) ?? '';
-    if (!dagsterPlural) throw new Error(`no dagsterbootstraps plural in ${dagsterPlurals.join(', ')}`);
+    dagsterPlural = dagsterGenerated.find((g) => g.plural.startsWith('dagsterbootstrap'))?.plural ?? '';
+    if (!dagsterPlural) {
+      throw new Error(`no dagsterbootstraps plural in ${dagsterGenerated.map((g) => g.plural).join(', ')}`);
+    }
     await waitForConvergedCrd(probePlural);
     await waitForConvergedCrd(dagsterPlural);
   });
@@ -341,18 +339,22 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
       }
     }
 
-    // Deleting an RGD does NOT reap the CRD KRO registered for it. Both kinds are run-unique, so this run
-    // owns both and can remove them without touching any shared definition.
-    for (const plural of [...new Set(registeredPlurals.filter(Boolean))]) {
-      const crd = `${plural}.${RGD_GROUP}`;
-      await apiext
-        .deleteCustomResourceDefinition({ name: crd })
-        .catch((e: unknown) => {
-          if (!isNotFound(e)) failures.push(`crd/${crd}: ${String(e)}`);
-        });
-      if (!(await waitForCrdAbsent(crd))) {
-        failures.push(`crd/${crd}: not confirmed absent (KRO may have re-registered it)`);
-      }
+    // Deleting an RGD does NOT reap the CRD KRO registered for it, and on a persistent OrbStack cluster an
+    // emptied CRD can hang on `customresourcecleanup.apiextensions.k8s.io` — a plain delete-then-wait then
+    // fails the hook and leaves the CRD Terminating. The shared harness helper owns that recovery and is
+    // FAIL-CLOSED: it only clears the finalizer after listing the kind and proving zero instances remain,
+    // which is why the KIND is retained next to the plural.
+    for (const { kind, plural } of registeredKinds) {
+      await deleteGeneratedCrdAndWait(
+        {
+          apiVersion: 'apiextensions.k8s.io/v1',
+          kind: 'CustomResourceDefinition',
+          metadata: { name: `${plural}.${RGD_GROUP}` },
+        },
+        `${RGD_GROUP}/${RGD_VERSION}`,
+        kind,
+        kc
+      ).catch((e: unknown) => failures.push(`crd/${plural}.${RGD_GROUP}: ${String(e)}`));
     }
 
     if (failures.length > 0) throw new Error(`cleanup failed:\n${failures.join('\n')}`);

--- a/test/integration/dagster/values-admission.test.ts
+++ b/test/integration/dagster/values-admission.test.ts
@@ -1,0 +1,176 @@
+/**
+ * LIVE KRO ADMISSION test for the Dagster raw-Helm-`values` escape hatches.
+ *
+ * Why this exists, specifically: the unit tests asserted that CEL strings like `schema.spec.postgresql.values`
+ * appeared in the generated YAML. That is not the same claim. A field can be referenced by CEL and still be
+ * DECLARED `string` in the RGD schema — in which case KRO admission silently PRUNES whatever object a caller
+ * sent, the CEL resolves to nothing, and every offline test still passes. Both documented Dagster escape
+ * hatches were broken that way, and it stayed invisible because nothing ever read a CR back from a cluster.
+ *
+ * So this test does the only thing that actually proves the contract: apply the RGD, submit a CR carrying
+ * NESTED UNKNOWN structure (maps, booleans, numbers, arrays — none of it modelled by any convenience shape),
+ * then read the admitted object back from the API server and assert the values survived.
+ *
+ * Worth knowing WHY this stayed hidden: the same defect surfaces differently per client. `kubectl apply` uses
+ * STRICT decoding, so against the broken schema it fails loudly —
+ *   `strict decoding error: unknown field "spec.values.postgresql"`
+ * — which is the "rejected 422/BadRequest" people hit when poking by hand. TypeKro's own apply path is NOT
+ * strict, so in production the identical mismatch was PRUNED IN SILENCE and the converge reported success.
+ * This test deliberately drives kubectl, so a regression is a hard error rather than a quiet omission.
+ *
+ * Deliberately image-free: it never deploys Dagster, so it needs only a cluster with KRO. Run with
+ * `bun test test/integration/dagster/values-admission.test.ts` against orbstack.
+ */
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from 'bun:test';
+import { dagsterBootstrap } from '../../../src/factories/dagster/index.js';
+import { isClusterAvailable } from '../shared-kubeconfig.js';
+
+setDefaultTimeout(300000);
+
+const clusterAvailable = await isClusterAvailable();
+const describeLiveOrSkip = clusterAvailable ? describe : describe.skip;
+
+// Unique per run: afterAll deletes the namespace with `--wait=false`, so a fixed name races against the
+// previous run's Terminating namespace (apply then fails with `namespaces ... not found`).
+const NAMESPACE = `typekro-values-admission-${Math.random().toString(36).slice(2, 8)}`;
+const INSTANCE = 'values-probe';
+
+/** `kubectl` against the ambient kubeconfig; returns stdout, throws with stderr on failure. */
+const kubectl = async (args: string[], stdin?: string): Promise<string> => {
+  const proc = Bun.spawn(['kubectl', ...args], {
+    stdin: stdin ? new TextEncoder().encode(stdin) : 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0) throw new Error(`kubectl ${args.join(' ')} failed (${code}): ${err}`);
+  return out;
+};
+
+/**
+ * The structure a caller sends and admission must NOT strip. Chosen to cover what the old `string` typing
+ * destroyed: nested maps, a boolean, a number, an array of objects, and a dotted key.
+ */
+const PROBE_VALUES = {
+  postgresql: {
+    // The exact settings that could not be expressed before — no convenience shape models these.
+    primary: { persistence: { enabled: false }, nodeSelector: { 'kubernetes.io/os': 'linux' } },
+    persistence: { enabled: false },
+  },
+  extraObjects: [{ kind: 'ConfigMap', metadata: { name: 'probe' } }],
+  someNumber: 42,
+  someBool: true,
+} as const;
+
+describeLiveOrSkip('Dagster raw Helm values survive KRO admission', () => {
+  beforeAll(async () => {
+    await kubectl(['create', 'namespace', NAMESPACE]);
+    // Apply only the DagsterBootstrap RGD (the stream also carries the HelmRepository one; both are fine).
+    await kubectl(['apply', '-f', '-'], dagsterBootstrap.toYaml());
+    // Wait for KRO to accept the graph — a rejected RGD would make the CR apply fail confusingly.
+    await kubectl([
+      'wait',
+      'resourcegraphdefinition/dagster-bootstrap',
+      '--for=condition=GraphAccepted',
+      '--timeout=120s',
+    ]);
+    // GraphAccepted does NOT imply the CRD is registered and served — KRO creates it afterwards, so reading
+    // the CRD immediately races and sees NotFound. And `kubectl wait` ERRORS on a resource that does not
+    // exist yet rather than waiting for it, so poll for existence first, then wait for Established (the
+    // condition that actually means "the API server will accept objects of this kind").
+    for (let i = 0; i < 60; i++) {
+      const exists = await kubectl(['get', 'crd', 'dagsterbootstraps.kro.run', '--ignore-not-found', '-o', 'name']);
+      if (exists.trim()) break;
+      await Bun.sleep(1000);
+    }
+    await kubectl([
+      'wait',
+      'crd/dagsterbootstraps.kro.run',
+      '--for=condition=Established',
+      '--timeout=120s',
+    ]);
+  });
+
+  afterAll(async () => {
+    await kubectl([
+      'delete',
+      'dagsterbootstrap',
+      INSTANCE,
+      '-n',
+      NAMESPACE,
+      '--ignore-not-found',
+      '--wait=false',
+    ]).catch(() => {});
+    await kubectl(['delete', 'namespace', NAMESPACE, '--ignore-not-found', '--wait=false']).catch(
+      () => {}
+    );
+  });
+
+  it('declares the escape hatches as schemaless `object` in the ADMITTED CRD', async () => {
+    // Read the CRD the API server actually registered, not the YAML we generated — this is what prunes.
+    const crd = JSON.parse(
+      await kubectl(['get', 'crd', 'dagsterbootstraps.kro.run', '-o', 'json'])
+    ) as {
+      spec: { versions: Array<{ schema: { openAPIV3Schema: any } }> };
+    };
+    const spec = crd.spec.versions[0]!.schema.openAPIV3Schema.properties.spec.properties;
+
+    expect(spec.values.type).toBe('object');
+    expect(spec.values['x-kubernetes-preserve-unknown-fields']).toBe(true);
+    expect(spec.postgresql.properties.values.type).toBe('object');
+    expect(spec.postgresql.properties.values['x-kubernetes-preserve-unknown-fields']).toBe(true);
+  });
+
+  it('preserves nested unknown values through admission (the regression that shipped)', async () => {
+    const cr = {
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'DagsterBootstrap',
+      metadata: { name: INSTANCE, namespace: NAMESPACE },
+      spec: { name: INSTANCE, namespace: NAMESPACE, values: PROBE_VALUES },
+    };
+    await kubectl(['apply', '-f', '-'], JSON.stringify(cr));
+
+    const admitted = JSON.parse(
+      await kubectl(['get', 'dagsterbootstrap', INSTANCE, '-n', NAMESPACE, '-o', 'json'])
+    ) as { spec: { values?: Record<string, unknown> } };
+
+    // Before the fix this read back as `{}` / absent: the whole subtree was pruned in silence.
+    expect(admitted.spec.values).toEqual(PROBE_VALUES);
+  });
+
+  it('preserves the per-subchart `postgresql.values` hatch too', async () => {
+    const cr = {
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'DagsterBootstrap',
+      metadata: { name: `${INSTANCE}-pg`, namespace: NAMESPACE },
+      spec: {
+        name: `${INSTANCE}-pg`,
+        namespace: NAMESPACE,
+        postgresql: { enabled: true, values: { primary: { persistence: { enabled: false } } } },
+      },
+    };
+    await kubectl(['apply', '-f', '-'], JSON.stringify(cr));
+
+    const admitted = JSON.parse(
+      await kubectl(['get', 'dagsterbootstrap', `${INSTANCE}-pg`, '-n', NAMESPACE, '-o', 'json'])
+    ) as { spec: { postgresql?: { enabled?: boolean; values?: Record<string, unknown> } } };
+
+    expect(admitted.spec.postgresql?.values).toEqual({ primary: { persistence: { enabled: false } } });
+    // The typed convenience field alongside it must still be typed, not swallowed by the opaque sibling.
+    expect(admitted.spec.postgresql?.enabled).toBe(true);
+
+    await kubectl([
+      'delete',
+      'dagsterbootstrap',
+      `${INSTANCE}-pg`,
+      '-n',
+      NAMESPACE,
+      '--ignore-not-found',
+      '--wait=false',
+    ]);
+  });
+});

--- a/test/integration/dagster/values-admission.test.ts
+++ b/test/integration/dagster/values-admission.test.ts
@@ -54,8 +54,12 @@ const RGD_PLURAL = 'resourcegraphdefinitions';
 const RUN_ID = Math.random().toString(36).slice(2, 8);
 const PROBE_KIND = `ObjectSchemaProbe${RUN_ID}`;
 const PROBE_RGD = `object-schema-probe-${RUN_ID}`;
-/** KRO derives the CRD plural from the schema kind, lowercased. */
-const pluralFor = (kind: string): string => `${kind.toLowerCase()}s`;
+/**
+ * The CRD plural is DISCOVERED from the cluster, never derived. KRO pluralises the schema kind with real
+ * English rules, not `+ 's'`: a kind ending in `o` becomes `oes` (potato→potatoes). Since the run suffix is
+ * random, guessing made these fixtures pass or fail depending on its last character — `…probexrjqu1s` worked,
+ * `…probea32l9oes` did not, and the mismatch leaked the CRD teardown then failed to find.
+ */
 
 /**
  * The structure a caller sends and admission must NOT strip: nested maps, a boolean, a number, an array of
@@ -100,6 +104,8 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
   /** CRD plurals KRO registers for this run's unique kinds; resolved in `beforeAll`. */
   let probePlural = '';
   let dagsterPlural = '';
+  /** EVERY plural this run registered — teardown must delete all of them, not only the asserted ones. */
+  const registeredPlurals: string[] = [];
   /** Every object this test creates, newest first, so teardown is deterministic. */
   const created: Array<{
     what: string;
@@ -144,6 +150,24 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
       await Bun.sleep(1000);
     }
     return false;
+  };
+
+  /**
+   * Find the CRD plural KRO registered for `kind` by MATCHING `spec.names.kind` — authoritative, unlike any
+   * client-side pluralisation. Polls because KRO registers the CRD asynchronously after accepting the RGD.
+   */
+  const discoverPlural = async (kind: string): Promise<string> => {
+    for (let i = 0; i < 60; i++) {
+      const found = await apiext
+        .listCustomResourceDefinition()
+        .then((list) =>
+          list.items.find((c) => c.spec.group === RGD_GROUP && c.spec.names.kind === kind)?.spec.names.plural
+        )
+        .catch(() => undefined);
+      if (found) return found;
+      await Bun.sleep(1000);
+    }
+    throw new Error(`KRO never registered a CRD for kind ${kind} in group ${RGD_GROUP}`);
   };
 
   /**
@@ -216,7 +240,8 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
             name,
           }),
       });
-      plurals.push(pluralFor(kind));
+      const plural = await discoverPlural(kind);
+      plurals.push(plural);
     }
     return plurals;
   };
@@ -267,6 +292,11 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
     const dagsterPlurals = await applyRgd(
       dagsterBootstrap.factory('kro', { allowBreakingChanges: true }).toYaml()
     );
+    // EVERY plural the bundle registers must be retained for teardown, not just the one the assertions read.
+    // The bundle contains TWO RGDs (bootstrap + the HelmRepository singleton), so each run registers two CRDs;
+    // deleting an RGD does not reap its CRD, so keeping only the bootstrap plural leaked
+    // `dagsterhelmrepository<id>s.kro.run` on every run.
+    registeredPlurals.push(...probePlurals, ...dagsterPlurals);
     // The bootstrap RGD is the one declaring the schemaless `values` hatches the assertions read.
     dagsterPlural = dagsterPlurals.find((pl) => pl.startsWith('dagsterbootstrap')) ?? '';
     if (!dagsterPlural) throw new Error(`no dagsterbootstraps plural in ${dagsterPlurals.join(', ')}`);
@@ -313,7 +343,7 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
 
     // Deleting an RGD does NOT reap the CRD KRO registered for it. Both kinds are run-unique, so this run
     // owns both and can remove them without touching any shared definition.
-    for (const plural of [probePlural, dagsterPlural].filter(Boolean)) {
+    for (const plural of [...new Set(registeredPlurals.filter(Boolean))]) {
       const crd = `${plural}.${RGD_GROUP}`;
       await apiext
         .deleteCustomResourceDefinition({ name: crd })
@@ -379,7 +409,9 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
             name,
           })
           .then(() => false)
-          .catch(() => true),
+          // 404-only, same as the RGD/CRD waits: a transient API error must NOT be read as "settled", or
+          // teardown proceeds to delete the namespace, RGD and CRD while this CR's finalizer is still active.
+          .catch((e: unknown) => isNotFound(e)),
     });
 
     const admitted = (await custom.getNamespacedCustomObject({

--- a/test/integration/dagster/values-admission.test.ts
+++ b/test/integration/dagster/values-admission.test.ts
@@ -87,7 +87,12 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
   const apiext = createBunCompatibleApiClient(kc, k8s.ApiextensionsV1Api);
   let lease: TestNamespaceLease | undefined;
   /** Every object this test creates, newest first, so teardown is deterministic. */
-  const created: Array<{ what: string; remove: () => Promise<unknown> }> = [];
+  const created: Array<{
+    what: string;
+    remove: () => Promise<unknown>;
+    /** Present for custom resources: polled until the object is really gone (finalizers settled). */
+    gone?: () => Promise<boolean>;
+  }> = [];
 
   const applyRgd = async (yamlDoc: string): Promise<void> => {
     for (const doc of k8s.loadAllYaml(yamlDoc)) {
@@ -141,50 +146,99 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
     }
   };
 
-  /** Poll until the CRD for `plural` is Established — KRO registers it AFTER the RGD is accepted. */
-  const waitForCrd = async (plural: string): Promise<k8s.V1CustomResourceDefinition> => {
-    const name = `${plural}.${RGD_GROUP}`;
-    for (let i = 0; i < 120; i++) {
-      const crd = await apiext.readCustomResourceDefinition({ name }).catch(() => undefined);
-      const established = crd?.status?.conditions?.some(
-        (c) => c.type === 'Established' && c.status === 'True'
-      );
-      if (crd && established) return crd;
+  /** `spec.schema.openAPIV3Schema.properties.spec.properties` of a registered CRD, if it exists yet. */
+  const crdSpecProps = async (plural: string): Promise<Record<string, any> | undefined> =>
+    apiext
+      .readCustomResourceDefinition({ name: `${plural}.${RGD_GROUP}` })
+      .then((crd) => {
+        const established = crd.status?.conditions?.some(
+          (c) => c.type === 'Established' && c.status === 'True'
+        );
+        if (!established) return undefined;
+        return crd.spec.versions[0]?.schema?.openAPIV3Schema?.properties?.spec?.properties as
+          | Record<string, any>
+          | undefined;
+      })
+      .catch(() => undefined);
+
+  /**
+   * Wait until the CRD for `plural` is Established AND its `spec.values` has converged to `object`.
+   *
+   * KRO registers and updates CRDs ASYNCHRONOUSLY after accepting an RGD, so waiting on Established alone
+   * returns instantly against a CRD left by an earlier run and the assertions then read a stale schema. Note
+   * this cannot wait on a new uid or a bumped resourceVersion either: KRO updates the CRD IN PLACE, and when
+   * the schema is already correct it performs no write at all — both signals would hang.
+   *
+   * Waiting on one field is not the same as asserting the contract: the tests below check the
+   * preserve-unknown flags, the per-subchart hatch, the typed siblings, and a real CR round trip.
+   */
+  const waitForConvergedCrd = async (plural: string): Promise<Record<string, any>> => {
+    for (let i = 0; i < 180; i++) {
+      const props = await crdSpecProps(plural);
+      if (props?.values?.type === 'object') return props;
       await Bun.sleep(1000);
     }
-    throw new Error(`CRD ${name} did not become Established`);
+    throw new Error(`CRD ${plural}.${RGD_GROUP} never converged to a schemaless \`values\``);
   };
 
   beforeAll(async () => {
     lease = await createTestNamespace(`typekro-obj-admission-${Math.random().toString(36).slice(2, 8)}`, kc);
     await applyRgd(probeComposition.factory('kro').toYaml());
-    await applyRgd(dagsterBootstrap.toYaml());
-    await waitForCrd('objectschemaprobes');
-    await waitForCrd('dagsterbootstraps');
+    // Apply WITH the migration flag: a `dagsterbootstraps` CRD left by an older TypeKro carries `string`
+    // types, and KRO refuses the breaking update SILENTLY (RGD still reports Ready). Without authorizing it
+    // the assertions below would read a stale schema and fail for the wrong reason.
+    await applyRgd(dagsterBootstrap.factory('kro', { allowBreakingChanges: true }).toYaml());
+    await waitForConvergedCrd('objectschemaprobes');
+    await waitForConvergedCrd('dagsterbootstraps');
   });
 
   afterAll(async () => {
-    // Aggregate rather than swallow: a teardown that hides its own failures is how clusters accumulate junk.
+    // ORDER MATTERS, and getting it wrong hangs for the full timeout. Custom resources must be gone —
+    // finalizers settled — BEFORE their CRD is removed; deleting the CRD first strands the finalizer and the
+    // namespace can then never terminate. So: CRs (and wait), then the namespace, then the RGDs, then the CRD
+    // this test owns. Failures are aggregated rather than swallowed.
     const failures: string[] = [];
-    for (const { what, remove } of created.reverse()) {
+
+    for (const { what, remove, gone } of created.filter((c) => c.gone).reverse()) {
       await remove().catch((e: unknown) => failures.push(`${what}: ${String(e)}`));
+      let settled = false;
+      for (let i = 0; i < 60 && !settled; i++) {
+        settled = await gone!();
+        if (!settled) await Bun.sleep(1000);
+      }
+      if (!settled) failures.push(`${what}: still present after delete (finalizer pending?)`);
     }
+
     if (lease) {
       await deleteTestNamespaceAndWait(lease, kc).catch((e: unknown) =>
         failures.push(`namespace ${lease?.name}: ${String(e)}`)
       );
     }
+
+    for (const { what, remove } of created.filter((c) => !c.gone).reverse()) {
+      await remove().catch((e: unknown) => failures.push(`${what}: ${String(e)}`));
+    }
+
+    // Deleting an RGD does NOT reap the CRD KRO registered for it, so remove it explicitly or every run
+    // leaves one behind. Only the PROBE kind — deliberately not dagsterbootstraps, which on a persistent
+    // cluster may hold real instances this test knows nothing about and only updated.
+    await apiext
+      .deleteCustomResourceDefinition({ name: `objectschemaprobes.${RGD_GROUP}` })
+      .catch((e: unknown) => failures.push(`crd/objectschemaprobes.${RGD_GROUP}: ${String(e)}`));
+
     if (failures.length > 0) throw new Error(`cleanup failed:\n${failures.join('\n')}`);
   });
 
   it('registers the Dagster escape hatches as schemaless `object` in the CRD (no instances created)', async () => {
-    const crd = await apiext.readCustomResourceDefinition({ name: 'dagsterbootstraps.kro.run' });
-    const props = crd.spec.versions[0]?.schema?.openAPIV3Schema?.properties?.spec
-      ?.properties as Record<string, any>;
+    const props = await waitForConvergedCrd('dagsterbootstraps');
 
     for (const path of [props.values, props.postgresql.properties.values]) {
       expect(path.type).toBe('object');
-      expect(path['x-kubernetes-preserve-unknown-fields']).toBe(true);
+      // The generated client deserializes the wire field `x-kubernetes-preserve-unknown-fields` to
+      // `x_kubernetes_preserve_unknown_fields`; accept either so this does not break on a client bump.
+      const preserveUnknown =
+        path.x_kubernetes_preserve_unknown_fields ?? path['x-kubernetes-preserve-unknown-fields'];
+      expect(preserveUnknown).toBe(true);
     }
     // The typed convenience fields alongside them must stay typed, or the CRD documents nothing.
     expect(props.postgresql.properties.enabled.type).toBe('boolean');
@@ -216,6 +270,17 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
           plural: 'objectschemaprobes',
           name,
         }),
+      gone: () =>
+        custom
+          .getNamespacedCustomObject({
+            group: RGD_GROUP,
+            version: RGD_VERSION,
+            namespace,
+            plural: 'objectschemaprobes',
+            name,
+          })
+          .then(() => false)
+          .catch(() => true),
     });
 
     const admitted = (await custom.getNamespacedCustomObject({

--- a/test/integration/dagster/values-admission.test.ts
+++ b/test/integration/dagster/values-admission.test.ts
@@ -43,8 +43,19 @@ const describeLiveOrSkip = clusterAvailable ? describe : describe.skip;
 const RGD_GROUP = 'kro.run';
 const RGD_VERSION = 'v1alpha1';
 const RGD_PLURAL = 'resourcegraphdefinitions';
-const PROBE_KIND = 'ObjectSchemaProbe';
-const PROBE_RGD = 'object-schema-probe';
+/**
+ * RUN-UNIQUE identities. Nothing this fixture applies may share a name with a real deployment: a shared
+ * cluster's `dagster-bootstrap` / `dagster-helm-repository` RGDs serve live Dagster instances, and rewriting
+ * one migrates the CRD those instances depend on (this bundle carries `allow-breaking-changes`) and discards
+ * labels/annotations owned by whatever system manages it. `resourceVersion` guards concurrent WRITES; it says
+ * nothing about OWNERSHIP. So the live admission coverage runs against a uniquely-named probe copy of the
+ * real generated bundle, and `applyRgd` fails closed if a name it is about to create already exists.
+ */
+const RUN_ID = Math.random().toString(36).slice(2, 8);
+const PROBE_KIND = `ObjectSchemaProbe${RUN_ID}`;
+const PROBE_RGD = `object-schema-probe-${RUN_ID}`;
+/** KRO derives the CRD plural from the schema kind, lowercased. */
+const pluralFor = (kind: string): string => `${kind.toLowerCase()}s`;
 
 /**
  * The structure a caller sends and admission must NOT strip: nested maps, a boolean, a number, an array of
@@ -86,6 +97,9 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
   const custom = createCustomObjectsApiClient(kc);
   const apiext = createBunCompatibleApiClient(kc, k8s.ApiextensionsV1Api);
   let lease: TestNamespaceLease | undefined;
+  /** CRD plurals KRO registers for this run's unique kinds; resolved in `beforeAll`. */
+  let probePlural = '';
+  let dagsterPlural = '';
   /** Every object this test creates, newest first, so teardown is deterministic. */
   const created: Array<{
     what: string;
@@ -94,82 +108,99 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
     gone?: () => Promise<boolean>;
   }> = [];
 
-  /** Poll until an RGD is really gone (KRO finalizers settled). Bounded so a stuck delete fails loudly. */
+  /** True only for a definitive 404. Any other error is NOT evidence of absence. */
+  const isNotFound = (e: unknown): boolean => {
+    const code = (e as { code?: number; statusCode?: number; response?: { statusCode?: number } })?.code
+      ?? (e as { statusCode?: number })?.statusCode
+      ?? (e as { response?: { statusCode?: number } })?.response?.statusCode;
+    return code === 404 || /\b404\b|NotFound/.test(String(e));
+  };
+
+  /**
+   * Poll until an RGD is definitively gone. Returns false on timeout so callers FAIL rather than proceed —
+   * treating a transient API error as absence would let teardown delete the CRD while KRO can still see the
+   * RGD, and KRO would then re-register the CRD after the test reported success.
+   */
   const waitForRgdAbsent = async (name: string): Promise<boolean> => {
     for (let i = 0; i < 60; i++) {
-      const gone = await custom
+      const state = await custom
         .getClusterCustomObject({ group: RGD_GROUP, version: RGD_VERSION, plural: RGD_PLURAL, name })
-        .then(() => false)
-        .catch(() => true);
-      if (gone) return true;
+        .then(() => 'present' as const)
+        .catch((e: unknown) => (isNotFound(e) ? ('absent' as const) : ('unknown' as const)));
+      if (state === 'absent') return true;
+      await Bun.sleep(1000);
+    }
+    return false;
+  };
+
+  /** Same contract for a CRD: only a 404 proves absence, and a timeout is a failure. */
+  const waitForCrdAbsent = async (name: string): Promise<boolean> => {
+    for (let i = 0; i < 60; i++) {
+      const state = await apiext
+        .readCustomResourceDefinition({ name })
+        .then(() => 'present' as const)
+        .catch((e: unknown) => (isNotFound(e) ? ('absent' as const) : ('unknown' as const)));
+      if (state === 'absent') return true;
       await Bun.sleep(1000);
     }
     return false;
   };
 
   /**
-   * Apply the RGDs in a rendered bundle.
+   * Apply the RGDs in a rendered bundle under RUN-UNIQUE identities, and report the CRD plurals they will
+   * register.
    *
-   * `ownership` decides what may happen to an RGD that ALREADY EXISTS, and it is a safety boundary, not a
-   * style choice:
+   * Every `metadata.name` and `spec.schema.kind` is suffixed with {@link RUN_ID}, so this fixture can only
+   * ever create objects belonging to this run. That is what makes the live coverage safe on a shared cluster:
+   * the assertions still exercise the REAL generated schema (same `object` typings, same preserve-unknown
+   * flags, same KRO admission path), just under a throwaway kind that no deployment depends on.
    *
-   * - `'test-owned'` — the name is unique to this test (see PROBE_RGD). A leftover from an earlier run
-   *   carries an OLD schema, so reusing it would silently assert against the wrong definition; delete and
-   *   recreate, and register it for teardown.
-   * - `'shared'` — the name is PRODUCTION-shaped (`dagster-bootstrap` and its HelmRepository singleton). On a
-   *   persistent cluster these definitions serve real Dagster instances, so this test must never delete
-   *   them: it UPDATES in place (which is all the assertions need — KRO re-registers the CRD from the new
-   *   schema) and never registers them for teardown. Deleting them previously took out the shared
-   *   HelmRepository singleton, breaking every Dagster release pointing at it.
+   * It also FAILS CLOSED: if a name it is about to create already exists, it aborts instead of adopting or
+   * overwriting. With a unique suffix that should be unreachable, so hitting it means an assumption broke —
+   * which is exactly when silently rewriting somebody else's definition would do the most damage.
    */
-  const applyRgd = async (yamlDoc: string, ownership: 'test-owned' | 'shared'): Promise<void> => {
+  const applyRgd = async (yamlDoc: string): Promise<string[]> => {
+    const plurals: string[] = [];
     for (const doc of k8s.loadAllYaml(yamlDoc)) {
-      const body = doc as { kind?: string; metadata?: { name?: string } };
+      const body = doc as {
+        kind?: string;
+        metadata?: { name?: string };
+        spec?: { schema?: { kind?: string } };
+      };
       if (body.kind !== 'ResourceGraphDefinition') continue;
-      const name = body.metadata?.name;
-      if (!name) continue;
+      const originalName = body.metadata?.name;
+      const originalKind = body.spec?.schema?.kind;
+      if (!originalName || !originalKind) continue;
 
-      const existing = await custom
+      // Suffix BOTH identities: the RGD name (what we create) and the schema kind (what KRO derives the CRD
+      // plural from). Leaving either shared would collide with a real deployment.
+      const name = `${originalName}-${RUN_ID}`;
+      const kind = `${originalKind}${RUN_ID}`;
+      const unique = {
+        ...body,
+        metadata: { ...(body.metadata ?? {}), name },
+        spec: { ...(body.spec ?? {}), schema: { ...(body.spec?.schema ?? {}), kind } },
+      };
+
+      const exists = await custom
         .getClusterCustomObject({ group: RGD_GROUP, version: RGD_VERSION, plural: RGD_PLURAL, name })
-        .then((o) => o as { metadata?: { resourceVersion?: string } })
-        .catch(() => undefined);
-
-      if (existing && ownership === 'shared') {
-        // Update in place — never delete somebody else's definition. `resourceVersion` makes this a
-        // compare-and-swap, so a concurrent writer surfaces as a conflict instead of being clobbered.
-        await custom.replaceClusterCustomObject({
-          group: RGD_GROUP,
-          version: RGD_VERSION,
-          plural: RGD_PLURAL,
-          name,
-          body: {
-            ...(body as object),
-            metadata: {
-              ...(body.metadata ?? {}),
-              resourceVersion: existing.metadata?.resourceVersion,
-            },
-          } as object,
+        .then(() => true)
+        .catch((e: unknown) => {
+          if (isNotFound(e)) return false;
+          throw e; // an API failure is not evidence the name is free
         });
-        continue; // deliberately NOT registered for teardown: this run did not create it
-      }
-
-      if (existing) {
-        // test-owned leftover: its schema is stale and KRO refuses breaking CRD type changes on update,
-        // so delete and recreate to exercise the CURRENT schema.
-        await custom.deleteClusterCustomObject({
-          group: RGD_GROUP,
-          version: RGD_VERSION,
-          plural: RGD_PLURAL,
-          name,
-        });
-        await waitForRgdAbsent(name);
+      if (exists) {
+        throw new Error(
+          `rgd/${name} already exists; refusing to adopt or overwrite it. This fixture only ever creates ` +
+            `run-unique names, so a collision means the naming assumption broke — investigate before rerunning.`
+        );
       }
 
       await custom.createClusterCustomObject({
         group: RGD_GROUP,
         version: RGD_VERSION,
         plural: RGD_PLURAL,
-        body: body as object,
+        body: unique as object,
       });
       created.push({
         what: `rgd/${name}`,
@@ -181,7 +212,9 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
             name,
           }),
       });
+      plurals.push(pluralFor(kind));
     }
+    return plurals;
   };
 
   /** `spec.schema.openAPIV3Schema.properties.spec.properties` of a registered CRD, if it exists yet. */
@@ -221,13 +254,20 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
 
   beforeAll(async () => {
     lease = await createTestNamespace(`typekro-obj-admission-${Math.random().toString(36).slice(2, 8)}`, kc);
-    await applyRgd(probeComposition.factory('kro').toYaml(), 'test-owned');
-    // Apply WITH the migration flag: a `dagsterbootstraps` CRD left by an older TypeKro carries `string`
-    // types, and KRO refuses the breaking update SILENTLY (RGD still reports Ready). Without authorizing it
-    // the assertions below would read a stale schema and fail for the wrong reason.
-    await applyRgd(dagsterBootstrap.factory('kro', { allowBreakingChanges: true }).toYaml(), 'shared');
-    await waitForConvergedCrd('objectschemaprobes');
-    await waitForConvergedCrd('dagsterbootstraps');
+    const probePlurals = await applyRgd(probeComposition.factory('kro').toYaml());
+    probePlural = probePlurals[0] ?? '';
+    if (!probePlural) throw new Error('probe RGD registered no CRD plural');
+    // `allowBreakingChanges` is retained because the bundle under test carries it — and it is precisely why
+    // this must run under a run-unique kind: applied to the SHARED `dagsterbootstraps` CRD it would migrate
+    // the schema real Dagster instances depend on.
+    const dagsterPlurals = await applyRgd(
+      dagsterBootstrap.factory('kro', { allowBreakingChanges: true }).toYaml()
+    );
+    // The bootstrap RGD is the one declaring the schemaless `values` hatches the assertions read.
+    dagsterPlural = dagsterPlurals.find((pl) => pl.startsWith('dagsterbootstrap')) ?? '';
+    if (!dagsterPlural) throw new Error(`no dagsterbootstraps plural in ${dagsterPlurals.join(', ')}`);
+    await waitForConvergedCrd(probePlural);
+    await waitForConvergedCrd(dagsterPlural);
   });
 
   afterAll(async () => {
@@ -258,37 +298,34 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
     }
 
     // The RGD must be GONE before its CRD is removed. Deleting the CRD while KRO can still observe the RGD
-    // lets KRO re-register the CRD, leaving the very object this teardown just removed — the same race the
-    // migration fixture documents. So: wait out the RGD, then delete the CRD, then confirm it stayed gone.
+    // lets KRO re-register it, leaving behind the object this teardown just removed. Absence is proven by a
+    // 404 only — a transient API error is not evidence — and a timeout is an explicit failure.
     for (const { what } of created.filter((c) => !c.gone && c.what.startsWith('rgd/'))) {
       const name = what.slice('rgd/'.length);
-      if (!(await waitForRgdAbsent(name))) failures.push(`${what}: still present after delete`);
+      if (!(await waitForRgdAbsent(name))) {
+        failures.push(`${what}: not confirmed absent (delete stuck, or the API never returned 404)`);
+      }
     }
 
-    // Deleting an RGD does NOT reap the CRD KRO registered for it, so remove it explicitly or every run
-    // leaves one behind. Only the PROBE kind — deliberately not dagsterbootstraps, which on a persistent
-    // cluster may hold real instances this test knows nothing about and only updated.
-    await apiext
-      .deleteCustomResourceDefinition({ name: `objectschemaprobes.${RGD_GROUP}` })
-      .catch((e: unknown) => failures.push(`crd/objectschemaprobes.${RGD_GROUP}: ${String(e)}`));
-
-    let crdGone = false;
-    for (let i = 0; i < 60 && !crdGone; i++) {
-      crdGone = await apiext
-        .readCustomResourceDefinition({ name: `objectschemaprobes.${RGD_GROUP}` })
-        .then(() => false)
-        .catch(() => true);
-      if (!crdGone) await Bun.sleep(1000);
-    }
-    if (!crdGone) {
-      failures.push(`crd/objectschemaprobes.${RGD_GROUP}: still present (KRO may have re-registered it)`);
+    // Deleting an RGD does NOT reap the CRD KRO registered for it. Both kinds are run-unique, so this run
+    // owns both and can remove them without touching any shared definition.
+    for (const plural of [probePlural, dagsterPlural].filter(Boolean)) {
+      const crd = `${plural}.${RGD_GROUP}`;
+      await apiext
+        .deleteCustomResourceDefinition({ name: crd })
+        .catch((e: unknown) => {
+          if (!isNotFound(e)) failures.push(`crd/${crd}: ${String(e)}`);
+        });
+      if (!(await waitForCrdAbsent(crd))) {
+        failures.push(`crd/${crd}: not confirmed absent (KRO may have re-registered it)`);
+      }
     }
 
     if (failures.length > 0) throw new Error(`cleanup failed:\n${failures.join('\n')}`);
   });
 
   it('registers the Dagster escape hatches as schemaless `object` in the CRD (no instances created)', async () => {
-    const props = await waitForConvergedCrd('dagsterbootstraps');
+    const props = await waitForConvergedCrd(dagsterPlural);
 
     for (const path of [props.values, props.postgresql.properties.values]) {
       expect(path.type).toBe('object');
@@ -310,7 +347,7 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
       group: RGD_GROUP,
       version: RGD_VERSION,
       namespace,
-      plural: 'objectschemaprobes',
+      plural: probePlural,
       body: {
         apiVersion: `${RGD_GROUP}/${RGD_VERSION}`,
         kind: PROBE_KIND,
@@ -325,7 +362,7 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
           group: RGD_GROUP,
           version: RGD_VERSION,
           namespace,
-          plural: 'objectschemaprobes',
+          plural: probePlural,
           name,
         }),
       gone: () =>
@@ -334,7 +371,7 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
             group: RGD_GROUP,
             version: RGD_VERSION,
             namespace,
-            plural: 'objectschemaprobes',
+            plural: probePlural,
             name,
           })
           .then(() => false)
@@ -345,7 +382,7 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
       group: RGD_GROUP,
       version: RGD_VERSION,
       namespace,
-      plural: 'objectschemaprobes',
+      plural: probePlural,
       name,
     })) as { spec?: { values?: unknown } };
 

--- a/test/integration/dagster/values-admission.test.ts
+++ b/test/integration/dagster/values-admission.test.ts
@@ -1,176 +1,232 @@
 /**
- * LIVE KRO ADMISSION test for the Dagster raw-Helm-`values` escape hatches.
+ * LIVE KRO ADMISSION coverage for schemaless (`object`) schema fields.
  *
- * Why this exists, specifically: the unit tests asserted that CEL strings like `schema.spec.postgresql.values`
- * appeared in the generated YAML. That is not the same claim. A field can be referenced by CEL and still be
- * DECLARED `string` in the RGD schema — in which case KRO admission silently PRUNES whatever object a caller
- * sent, the CEL resolves to nothing, and every offline test still passes. Both documented Dagster escape
- * hatches were broken that way, and it stayed invisible because nothing ever read a CR back from a cluster.
+ * Why this exists: the offline tests asserted that CEL strings like `schema.spec.postgresql.values` appeared
+ * in the generated YAML. That is a weaker claim than it looks. A field can be referenced by CEL and still be
+ * DECLARED `string` in the RGD schema — in which case admission drops whatever object a caller sent, the CEL
+ * resolves to nothing, and every offline test still passes. That is precisely how the Dagster escape hatches
+ * stayed broken, and it stayed invisible because nothing ever read a CR back from a cluster.
  *
- * So this test does the only thing that actually proves the contract: apply the RGD, submit a CR carrying
- * NESTED UNKNOWN structure (maps, booleans, numbers, arrays — none of it modelled by any convenience shape),
- * then read the admitted object back from the API server and assert the values survived.
- *
- * Worth knowing WHY this stayed hidden: the same defect surfaces differently per client. `kubectl apply` uses
- * STRICT decoding, so against the broken schema it fails loudly —
- *   `strict decoding error: unknown field "spec.values.postgresql"`
- * — which is the "rejected 422/BadRequest" people hit when poking by hand. TypeKro's own apply path is NOT
+ * The defect also surfaces differently per client, which is worth knowing: `kubectl apply` is STRICT-decoding
+ * and errors loudly (`strict decoding error: unknown field ...`), while TypeKro's own apply path is not
  * strict, so in production the identical mismatch was PRUNED IN SILENCE and the converge reported success.
- * This test deliberately drives kubectl, so a regression is a hard error rather than a quiet omission.
  *
- * Deliberately image-free: it never deploys Dagster, so it needs only a cluster with KRO. Run with
- * `bun test test/integration/dagster/values-admission.test.ts` against orbstack.
+ * SAFETY — this test deliberately never creates a Dagster INSTANCE. Applying the Dagster RGD only registers a
+ * CRD; creating a `DagsterBootstrap` CR would make KRO reconcile real HelmReleases, which is not something an
+ * admission test should do to a persistent cluster. So the two concerns are split:
+ *   1. Dagster: apply the RGD, read the REGISTERED CRD, assert the escape hatches are schemaless. No CRs.
+ *   2. Round-trip: a MINIMAL probe graph whose only resource is a ConfigMap, so a CR is harmless.
+ * Namespaces come from the shared harness (UID lease) and every created object is tracked and torn down with
+ * aggregated errors rather than swallowed ones.
  */
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from 'bun:test';
+import * as k8s from '@kubernetes/client-node';
+import { type } from 'arktype';
+import { ConfigMap } from '../../../src/factories/simple/index.js';
+import { kubernetesComposition } from '../../../src/core/composition/imperative.js';
 import { dagsterBootstrap } from '../../../src/factories/dagster/index.js';
-import { isClusterAvailable } from '../shared-kubeconfig.js';
+import { createBunCompatibleApiClient } from '../../../src/core/kubernetes/bun-api-client.js';
+import {
+  createCustomObjectsApiClient,
+  createTestNamespace,
+  deleteTestNamespaceAndWait,
+  getIntegrationTestKubeConfig,
+  isClusterAvailable,
+  type TestNamespaceLease,
+} from '../shared-kubeconfig.js';
 
 setDefaultTimeout(300000);
 
 const clusterAvailable = await isClusterAvailable();
 const describeLiveOrSkip = clusterAvailable ? describe : describe.skip;
 
-// Unique per run: afterAll deletes the namespace with `--wait=false`, so a fixed name races against the
-// previous run's Terminating namespace (apply then fails with `namespaces ... not found`).
-const NAMESPACE = `typekro-values-admission-${Math.random().toString(36).slice(2, 8)}`;
-const INSTANCE = 'values-probe';
-
-/** `kubectl` against the ambient kubeconfig; returns stdout, throws with stderr on failure. */
-const kubectl = async (args: string[], stdin?: string): Promise<string> => {
-  const proc = Bun.spawn(['kubectl', ...args], {
-    stdin: stdin ? new TextEncoder().encode(stdin) : 'ignore',
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  const [out, err, code] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  if (code !== 0) throw new Error(`kubectl ${args.join(' ')} failed (${code}): ${err}`);
-  return out;
-};
+const RGD_GROUP = 'kro.run';
+const RGD_VERSION = 'v1alpha1';
+const RGD_PLURAL = 'resourcegraphdefinitions';
+const PROBE_KIND = 'ObjectSchemaProbe';
+const PROBE_RGD = 'object-schema-probe';
 
 /**
- * The structure a caller sends and admission must NOT strip. Chosen to cover what the old `string` typing
- * destroyed: nested maps, a boolean, a number, an array of objects, and a dotted key.
+ * The structure a caller sends and admission must NOT strip: nested maps, a boolean, a number, an array of
+ * objects, and a dotted key — everything the old `string` typing destroyed.
  */
 const PROBE_VALUES = {
   postgresql: {
-    // The exact settings that could not be expressed before — no convenience shape models these.
     primary: { persistence: { enabled: false }, nodeSelector: { 'kubernetes.io/os': 'linux' } },
     persistence: { enabled: false },
   },
   extraObjects: [{ kind: 'ConfigMap', metadata: { name: 'probe' } }],
   someNumber: 42,
   someBool: true,
-} as const;
+};
 
-describeLiveOrSkip('Dagster raw Helm values survive KRO admission', () => {
-  beforeAll(async () => {
-    await kubectl(['create', 'namespace', NAMESPACE]);
-    // Apply only the DagsterBootstrap RGD (the stream also carries the HelmRepository one; both are fine).
-    await kubectl(['apply', '-f', '-'], dagsterBootstrap.toYaml());
-    // Wait for KRO to accept the graph — a rejected RGD would make the CR apply fail confusingly.
-    await kubectl([
-      'wait',
-      'resourcegraphdefinition/dagster-bootstrap',
-      '--for=condition=GraphAccepted',
-      '--timeout=120s',
-    ]);
-    // GraphAccepted does NOT imply the CRD is registered and served — KRO creates it afterwards, so reading
-    // the CRD immediately races and sees NotFound. And `kubectl wait` ERRORS on a resource that does not
-    // exist yet rather than waiting for it, so poll for existence first, then wait for Established (the
-    // condition that actually means "the API server will accept objects of this kind").
-    for (let i = 0; i < 60; i++) {
-      const exists = await kubectl(['get', 'crd', 'dagsterbootstraps.kro.run', '--ignore-not-found', '-o', 'name']);
-      if (exists.trim()) break;
+/** Minimal graph: one schemaless `values` field, one harmless ConfigMap. No Dagster, no Helm. */
+const probeComposition = kubernetesComposition(
+  {
+    name: PROBE_RGD,
+    kind: PROBE_KIND,
+    spec: type({ name: 'string', appNamespace: 'string', 'values?': 'object' }),
+    status: type({ ready: 'boolean' }),
+  },
+  (spec) => {
+    ConfigMap({
+      name: `${spec.name}-probe`,
+      namespace: spec.appNamespace,
+      data: { role: 'probe' },
+      id: 'probeCfg',
+    });
+    return { ready: true };
+  }
+);
+
+describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
+  const kc = getIntegrationTestKubeConfig();
+  // Bun-compatible clients: a plain `kc.makeApiClient` fails TLS against a self-signed cluster CA under Bun
+  // (oven-sh/bun#10642), which is exactly what the harness factories exist to paper over.
+  const custom = createCustomObjectsApiClient(kc);
+  const apiext = createBunCompatibleApiClient(kc, k8s.ApiextensionsV1Api);
+  let lease: TestNamespaceLease | undefined;
+  /** Every object this test creates, newest first, so teardown is deterministic. */
+  const created: Array<{ what: string; remove: () => Promise<unknown> }> = [];
+
+  const applyRgd = async (yamlDoc: string): Promise<void> => {
+    for (const doc of k8s.loadAllYaml(yamlDoc)) {
+      const body = doc as { kind?: string; metadata?: { name?: string } };
+      if (body.kind !== 'ResourceGraphDefinition') continue;
+      const name = body.metadata?.name;
+      if (!name) continue;
+      await custom
+        .createClusterCustomObject({
+          group: RGD_GROUP,
+          version: RGD_VERSION,
+          plural: RGD_PLURAL,
+          body: body as object,
+        })
+        .catch(async (e: unknown) => {
+          // A leftover RGD from an earlier run carries an OLD schema, so "reuse on AlreadyExists" would
+          // silently assert against the wrong definition (and KRO refuses breaking CRD type changes on
+          // update anyway). Delete and recreate so the test always exercises the CURRENT schema.
+          if (!String(e).includes('AlreadyExists') && !String(e).includes('409')) throw e;
+          await custom.deleteClusterCustomObject({
+            group: RGD_GROUP,
+            version: RGD_VERSION,
+            plural: RGD_PLURAL,
+            name,
+          });
+          for (let i = 0; i < 60; i++) {
+            const gone = await custom
+              .getClusterCustomObject({ group: RGD_GROUP, version: RGD_VERSION, plural: RGD_PLURAL, name })
+              .then(() => false)
+              .catch(() => true);
+            if (gone) break;
+            await Bun.sleep(1000);
+          }
+          await custom.createClusterCustomObject({
+            group: RGD_GROUP,
+            version: RGD_VERSION,
+            plural: RGD_PLURAL,
+            body: body as object,
+          });
+        });
+      created.push({
+        what: `rgd/${name}`,
+        remove: () =>
+          custom.deleteClusterCustomObject({
+            group: RGD_GROUP,
+            version: RGD_VERSION,
+            plural: RGD_PLURAL,
+            name,
+          }),
+      });
+    }
+  };
+
+  /** Poll until the CRD for `plural` is Established — KRO registers it AFTER the RGD is accepted. */
+  const waitForCrd = async (plural: string): Promise<k8s.V1CustomResourceDefinition> => {
+    const name = `${plural}.${RGD_GROUP}`;
+    for (let i = 0; i < 120; i++) {
+      const crd = await apiext.readCustomResourceDefinition({ name }).catch(() => undefined);
+      const established = crd?.status?.conditions?.some(
+        (c) => c.type === 'Established' && c.status === 'True'
+      );
+      if (crd && established) return crd;
       await Bun.sleep(1000);
     }
-    await kubectl([
-      'wait',
-      'crd/dagsterbootstraps.kro.run',
-      '--for=condition=Established',
-      '--timeout=120s',
-    ]);
+    throw new Error(`CRD ${name} did not become Established`);
+  };
+
+  beforeAll(async () => {
+    lease = await createTestNamespace(`typekro-obj-admission-${Math.random().toString(36).slice(2, 8)}`, kc);
+    await applyRgd(probeComposition.factory('kro').toYaml());
+    await applyRgd(dagsterBootstrap.toYaml());
+    await waitForCrd('objectschemaprobes');
+    await waitForCrd('dagsterbootstraps');
   });
 
   afterAll(async () => {
-    await kubectl([
-      'delete',
-      'dagsterbootstrap',
-      INSTANCE,
-      '-n',
-      NAMESPACE,
-      '--ignore-not-found',
-      '--wait=false',
-    ]).catch(() => {});
-    await kubectl(['delete', 'namespace', NAMESPACE, '--ignore-not-found', '--wait=false']).catch(
-      () => {}
-    );
+    // Aggregate rather than swallow: a teardown that hides its own failures is how clusters accumulate junk.
+    const failures: string[] = [];
+    for (const { what, remove } of created.reverse()) {
+      await remove().catch((e: unknown) => failures.push(`${what}: ${String(e)}`));
+    }
+    if (lease) {
+      await deleteTestNamespaceAndWait(lease, kc).catch((e: unknown) =>
+        failures.push(`namespace ${lease?.name}: ${String(e)}`)
+      );
+    }
+    if (failures.length > 0) throw new Error(`cleanup failed:\n${failures.join('\n')}`);
   });
 
-  it('declares the escape hatches as schemaless `object` in the ADMITTED CRD', async () => {
-    // Read the CRD the API server actually registered, not the YAML we generated — this is what prunes.
-    const crd = JSON.parse(
-      await kubectl(['get', 'crd', 'dagsterbootstraps.kro.run', '-o', 'json'])
-    ) as {
-      spec: { versions: Array<{ schema: { openAPIV3Schema: any } }> };
-    };
-    const spec = crd.spec.versions[0]!.schema.openAPIV3Schema.properties.spec.properties;
+  it('registers the Dagster escape hatches as schemaless `object` in the CRD (no instances created)', async () => {
+    const crd = await apiext.readCustomResourceDefinition({ name: 'dagsterbootstraps.kro.run' });
+    const props = crd.spec.versions[0]?.schema?.openAPIV3Schema?.properties?.spec
+      ?.properties as Record<string, any>;
 
-    expect(spec.values.type).toBe('object');
-    expect(spec.values['x-kubernetes-preserve-unknown-fields']).toBe(true);
-    expect(spec.postgresql.properties.values.type).toBe('object');
-    expect(spec.postgresql.properties.values['x-kubernetes-preserve-unknown-fields']).toBe(true);
+    for (const path of [props.values, props.postgresql.properties.values]) {
+      expect(path.type).toBe('object');
+      expect(path['x-kubernetes-preserve-unknown-fields']).toBe(true);
+    }
+    // The typed convenience fields alongside them must stay typed, or the CRD documents nothing.
+    expect(props.postgresql.properties.enabled.type).toBe('boolean');
+    expect(props.name.type).toBe('string');
   });
 
-  it('preserves nested unknown values through admission (the regression that shipped)', async () => {
-    const cr = {
-      apiVersion: 'kro.run/v1alpha1',
-      kind: 'DagsterBootstrap',
-      metadata: { name: INSTANCE, namespace: NAMESPACE },
-      spec: { name: INSTANCE, namespace: NAMESPACE, values: PROBE_VALUES },
-    };
-    await kubectl(['apply', '-f', '-'], JSON.stringify(cr));
-
-    const admitted = JSON.parse(
-      await kubectl(['get', 'dagsterbootstrap', INSTANCE, '-n', NAMESPACE, '-o', 'json'])
-    ) as { spec: { values?: Record<string, unknown> } };
-
-    // Before the fix this read back as `{}` / absent: the whole subtree was pruned in silence.
-    expect(admitted.spec.values).toEqual(PROBE_VALUES);
-  });
-
-  it('preserves the per-subchart `postgresql.values` hatch too', async () => {
-    const cr = {
-      apiVersion: 'kro.run/v1alpha1',
-      kind: 'DagsterBootstrap',
-      metadata: { name: `${INSTANCE}-pg`, namespace: NAMESPACE },
-      spec: {
-        name: `${INSTANCE}-pg`,
-        namespace: NAMESPACE,
-        postgresql: { enabled: true, values: { primary: { persistence: { enabled: false } } } },
+  it('preserves nested unknown values through a real create/read round trip', async () => {
+    const namespace = lease!.name;
+    const name = 'probe-values';
+    await custom.createNamespacedCustomObject({
+      group: RGD_GROUP,
+      version: RGD_VERSION,
+      namespace,
+      plural: 'objectschemaprobes',
+      body: {
+        apiVersion: `${RGD_GROUP}/${RGD_VERSION}`,
+        kind: PROBE_KIND,
+        metadata: { name, namespace },
+        spec: { name, appNamespace: namespace, values: PROBE_VALUES },
       },
-    };
-    await kubectl(['apply', '-f', '-'], JSON.stringify(cr));
+    });
+    created.push({
+      what: `${PROBE_KIND}/${name}`,
+      remove: () =>
+        custom.deleteNamespacedCustomObject({
+          group: RGD_GROUP,
+          version: RGD_VERSION,
+          namespace,
+          plural: 'objectschemaprobes',
+          name,
+        }),
+    });
 
-    const admitted = JSON.parse(
-      await kubectl(['get', 'dagsterbootstrap', `${INSTANCE}-pg`, '-n', NAMESPACE, '-o', 'json'])
-    ) as { spec: { postgresql?: { enabled?: boolean; values?: Record<string, unknown> } } };
+    const admitted = (await custom.getNamespacedCustomObject({
+      group: RGD_GROUP,
+      version: RGD_VERSION,
+      namespace,
+      plural: 'objectschemaprobes',
+      name,
+    })) as { spec?: { values?: unknown } };
 
-    expect(admitted.spec.postgresql?.values).toEqual({ primary: { persistence: { enabled: false } } });
-    // The typed convenience field alongside it must still be typed, not swallowed by the opaque sibling.
-    expect(admitted.spec.postgresql?.enabled).toBe(true);
-
-    await kubectl([
-      'delete',
-      'dagsterbootstrap',
-      `${INSTANCE}-pg`,
-      '-n',
-      NAMESPACE,
-      '--ignore-not-found',
-      '--wait=false',
-    ]);
+    // Before the core fix this field was declared `string`, so the whole subtree was dropped in silence.
+    expect(admitted.spec?.values).toEqual(PROBE_VALUES);
   });
 });

--- a/test/integration/dagster/values-admission.test.ts
+++ b/test/integration/dagster/values-admission.test.ts
@@ -94,45 +94,83 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
     gone?: () => Promise<boolean>;
   }> = [];
 
-  const applyRgd = async (yamlDoc: string): Promise<void> => {
+  /** Poll until an RGD is really gone (KRO finalizers settled). Bounded so a stuck delete fails loudly. */
+  const waitForRgdAbsent = async (name: string): Promise<boolean> => {
+    for (let i = 0; i < 60; i++) {
+      const gone = await custom
+        .getClusterCustomObject({ group: RGD_GROUP, version: RGD_VERSION, plural: RGD_PLURAL, name })
+        .then(() => false)
+        .catch(() => true);
+      if (gone) return true;
+      await Bun.sleep(1000);
+    }
+    return false;
+  };
+
+  /**
+   * Apply the RGDs in a rendered bundle.
+   *
+   * `ownership` decides what may happen to an RGD that ALREADY EXISTS, and it is a safety boundary, not a
+   * style choice:
+   *
+   * - `'test-owned'` — the name is unique to this test (see PROBE_RGD). A leftover from an earlier run
+   *   carries an OLD schema, so reusing it would silently assert against the wrong definition; delete and
+   *   recreate, and register it for teardown.
+   * - `'shared'` — the name is PRODUCTION-shaped (`dagster-bootstrap` and its HelmRepository singleton). On a
+   *   persistent cluster these definitions serve real Dagster instances, so this test must never delete
+   *   them: it UPDATES in place (which is all the assertions need — KRO re-registers the CRD from the new
+   *   schema) and never registers them for teardown. Deleting them previously took out the shared
+   *   HelmRepository singleton, breaking every Dagster release pointing at it.
+   */
+  const applyRgd = async (yamlDoc: string, ownership: 'test-owned' | 'shared'): Promise<void> => {
     for (const doc of k8s.loadAllYaml(yamlDoc)) {
       const body = doc as { kind?: string; metadata?: { name?: string } };
       if (body.kind !== 'ResourceGraphDefinition') continue;
       const name = body.metadata?.name;
       if (!name) continue;
-      await custom
-        .createClusterCustomObject({
+
+      const existing = await custom
+        .getClusterCustomObject({ group: RGD_GROUP, version: RGD_VERSION, plural: RGD_PLURAL, name })
+        .then((o) => o as { metadata?: { resourceVersion?: string } })
+        .catch(() => undefined);
+
+      if (existing && ownership === 'shared') {
+        // Update in place — never delete somebody else's definition. `resourceVersion` makes this a
+        // compare-and-swap, so a concurrent writer surfaces as a conflict instead of being clobbered.
+        await custom.replaceClusterCustomObject({
           group: RGD_GROUP,
           version: RGD_VERSION,
           plural: RGD_PLURAL,
-          body: body as object,
-        })
-        .catch(async (e: unknown) => {
-          // A leftover RGD from an earlier run carries an OLD schema, so "reuse on AlreadyExists" would
-          // silently assert against the wrong definition (and KRO refuses breaking CRD type changes on
-          // update anyway). Delete and recreate so the test always exercises the CURRENT schema.
-          if (!String(e).includes('AlreadyExists') && !String(e).includes('409')) throw e;
-          await custom.deleteClusterCustomObject({
-            group: RGD_GROUP,
-            version: RGD_VERSION,
-            plural: RGD_PLURAL,
-            name,
-          });
-          for (let i = 0; i < 60; i++) {
-            const gone = await custom
-              .getClusterCustomObject({ group: RGD_GROUP, version: RGD_VERSION, plural: RGD_PLURAL, name })
-              .then(() => false)
-              .catch(() => true);
-            if (gone) break;
-            await Bun.sleep(1000);
-          }
-          await custom.createClusterCustomObject({
-            group: RGD_GROUP,
-            version: RGD_VERSION,
-            plural: RGD_PLURAL,
-            body: body as object,
-          });
+          name,
+          body: {
+            ...(body as object),
+            metadata: {
+              ...(body.metadata ?? {}),
+              resourceVersion: existing.metadata?.resourceVersion,
+            },
+          } as object,
         });
+        continue; // deliberately NOT registered for teardown: this run did not create it
+      }
+
+      if (existing) {
+        // test-owned leftover: its schema is stale and KRO refuses breaking CRD type changes on update,
+        // so delete and recreate to exercise the CURRENT schema.
+        await custom.deleteClusterCustomObject({
+          group: RGD_GROUP,
+          version: RGD_VERSION,
+          plural: RGD_PLURAL,
+          name,
+        });
+        await waitForRgdAbsent(name);
+      }
+
+      await custom.createClusterCustomObject({
+        group: RGD_GROUP,
+        version: RGD_VERSION,
+        plural: RGD_PLURAL,
+        body: body as object,
+      });
       created.push({
         what: `rgd/${name}`,
         remove: () =>
@@ -183,11 +221,11 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
 
   beforeAll(async () => {
     lease = await createTestNamespace(`typekro-obj-admission-${Math.random().toString(36).slice(2, 8)}`, kc);
-    await applyRgd(probeComposition.factory('kro').toYaml());
+    await applyRgd(probeComposition.factory('kro').toYaml(), 'test-owned');
     // Apply WITH the migration flag: a `dagsterbootstraps` CRD left by an older TypeKro carries `string`
     // types, and KRO refuses the breaking update SILENTLY (RGD still reports Ready). Without authorizing it
     // the assertions below would read a stale schema and fail for the wrong reason.
-    await applyRgd(dagsterBootstrap.factory('kro', { allowBreakingChanges: true }).toYaml());
+    await applyRgd(dagsterBootstrap.factory('kro', { allowBreakingChanges: true }).toYaml(), 'shared');
     await waitForConvergedCrd('objectschemaprobes');
     await waitForConvergedCrd('dagsterbootstraps');
   });
@@ -219,12 +257,32 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
       await remove().catch((e: unknown) => failures.push(`${what}: ${String(e)}`));
     }
 
+    // The RGD must be GONE before its CRD is removed. Deleting the CRD while KRO can still observe the RGD
+    // lets KRO re-register the CRD, leaving the very object this teardown just removed — the same race the
+    // migration fixture documents. So: wait out the RGD, then delete the CRD, then confirm it stayed gone.
+    for (const { what } of created.filter((c) => !c.gone && c.what.startsWith('rgd/'))) {
+      const name = what.slice('rgd/'.length);
+      if (!(await waitForRgdAbsent(name))) failures.push(`${what}: still present after delete`);
+    }
+
     // Deleting an RGD does NOT reap the CRD KRO registered for it, so remove it explicitly or every run
     // leaves one behind. Only the PROBE kind — deliberately not dagsterbootstraps, which on a persistent
     // cluster may hold real instances this test knows nothing about and only updated.
     await apiext
       .deleteCustomResourceDefinition({ name: `objectschemaprobes.${RGD_GROUP}` })
       .catch((e: unknown) => failures.push(`crd/objectschemaprobes.${RGD_GROUP}: ${String(e)}`));
+
+    let crdGone = false;
+    for (let i = 0; i < 60 && !crdGone; i++) {
+      crdGone = await apiext
+        .readCustomResourceDefinition({ name: `objectschemaprobes.${RGD_GROUP}` })
+        .then(() => false)
+        .catch(() => true);
+      if (!crdGone) await Bun.sleep(1000);
+    }
+    if (!crdGone) {
+      failures.push(`crd/objectschemaprobes.${RGD_GROUP}: still present (KRO may have re-registered it)`);
+    }
 
     if (failures.length > 0) throw new Error(`cleanup failed:\n${failures.join('\n')}`);
   });

--- a/test/integration/dagster/values-admission.test.ts
+++ b/test/integration/dagster/values-admission.test.ts
@@ -174,8 +174,12 @@ describeLiveOrSkip('schemaless object fields survive KRO admission', () => {
 
       // Suffix BOTH identities: the RGD name (what we create) and the schema kind (what KRO derives the CRD
       // plural from). Leaving either shared would collide with a real deployment.
-      const name = `${originalName}-${RUN_ID}`;
-      const kind = `${originalKind}${RUN_ID}`;
+      //
+      // Idempotent: the probe composition already declares run-unique identities (PROBE_RGD/PROBE_KIND, which
+      // the CR assertions below also reference), so suffixing unconditionally double-suffixed the kind and the
+      // API rejected the CR with `must be ObjectSchemaProbe<id><id>`.
+      const name = originalName.endsWith(`-${RUN_ID}`) ? originalName : `${originalName}-${RUN_ID}`;
+      const kind = originalKind.endsWith(RUN_ID) ? originalKind : `${originalKind}${RUN_ID}`;
       const unique = {
         ...body,
         metadata: { ...(body.metadata ?? {}), name },

--- a/test/unit/arktype-object-primitive.test.ts
+++ b/test/unit/arktype-object-primitive.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Arktype `object` → KRO `object` in the core type converter.
+ *
+ * Arktype represents a bare `type('object')` as the STRING "object" — not as `{ domain: "object" }`, which
+ * the converter's object branch already handled. The primitive switch had no case for it, so it fell through
+ * to the `'string'` default and EVERY schemaless-object field was declared `string` in the generated RGD.
+ * KRO admission then pruned whatever object a caller sent, silently: no error, no warning, the field simply
+ * arrived empty.
+ *
+ * KRO models `object` as schemaless (`type: object` with `x-kubernetes-preserve-unknown-fields: true`), so
+ * the correct representation already existed; only the mapping was missing.
+ *
+ * This is a CORE bug, not a Dagster one — every factory using `type('object')` for chart/config passthrough
+ * (Dagster, APISIX, Ory, ClickHouse) was affected.
+ */
+import { describe, expect, test } from 'bun:test';
+import { type } from 'arktype';
+import { arktypeToKroSchema } from '../../src/core/serialization/schema.js';
+
+const specTypes = (spec: ReturnType<typeof type>): Record<string, unknown> => {
+  const out = arktypeToKroSchema('Probe', {
+    apiVersion: 'test.typekro.io/v1alpha1',
+    kind: 'Probe',
+    spec: spec as never,
+    status: type({ 'ready?': 'boolean' }) as never,
+  });
+  return (out as unknown as { spec: Record<string, unknown> }).spec;
+};
+
+describe('arktype object primitive → KRO object', () => {
+  test('maps a bare `object` to KRO `object`, not `string`', () => {
+    expect(specTypes(type({ 'values?': 'object' })).values).toBe('object');
+  });
+
+  test('maps `object[]` to `[]object` — the array branch recurses through the same switch', () => {
+    expect(specTypes(type({ 'items?': 'object[]' })).items).toBe('[]object');
+  });
+
+  test('a required `object` is still `object` (optionality must not change the type)', () => {
+    expect(specTypes(type({ values: 'object' })).values).toBe('object');
+  });
+
+  test('leaves the other primitives alone', () => {
+    const t = specTypes(type({ 'a?': 'string', 'b?': 'boolean', 'c?': 'number' }));
+    expect(t.a).toBe('string');
+    expect(t.b).toBe('boolean');
+    // `number` maps to KRO `float`; only an integer-divisor node becomes `integer`.
+    expect(t.c).toBe('float');
+  });
+
+  test('does not regress the STRUCTURED object forms, which took a different branch already', () => {
+    // `{ domain: 'object', index: [...] }` — a real string map stays a typed map, NOT opaque, so a
+    // Secret-annotations-style field keeps rejecting non-string values.
+    expect(specTypes(type({ 'tags?': 'Record<string, string>' })).tags).toBe('map[string]string');
+    // A nested shape stays a nested schema rather than collapsing to opaque.
+    // (KRO SimpleSchema carries optionality separately, so the emitted keys have no `?` suffix.)
+    const nested = specTypes(type({ 'image?': { repository: 'string', 'tag?': 'string' } }));
+    expect(nested.image).toEqual({ repository: 'string', tag: 'string' });
+  });
+
+  test('`Record<string, unknown>` remains opaque `object` (the pre-existing passthrough form)', () => {
+    expect(specTypes(type({ 'free?': 'Record<string, unknown>' })).free).toBe('object');
+  });
+});


### PR DESCRIPTION
Fixes #128, addressing the review's recommendation to fix this in **core** rather than applying a Dagster workaround.

## Root cause (P1, as the review identified)

Arktype represents a bare `type('object')` as the **string** `"object"` — not as `{ domain: "object" }`, which the converter's object branch already handled. The primitive switch had no case for it, so it fell through to the `'string'` default. Every schemaless-object field was therefore declared `string` in the generated RGD, and KRO admission dropped whatever object a caller sent.

`object[]` needed no separate case: the array branch recurses through the same switch, so a `sequence` of `"object"` now yields `[]object`.

**Blast radius in the Dagster RGD alone:** `object` **0 → 36** fields, `[]object` **22 → 38**. Confirmed core-wide, not Dagster-specific — APISIX, Ory and ClickHouse use the same construct.

## Dagster escape hatch (P1)

`values` was assigned the fully typed `helmValuesSchemaShape`, making a **closed** schema out of a field advertised as *"raw official chart values"*. Worse, its `postgresql` sub-shape reused the TypeKro **convenience** shape, so bundled-subchart settings (`primary.*`, `nodeSelector`, `persistence`) were unreachable through *either* documented route.

`values` is now opaque. Typed convenience stays on the high-level API (`postgresql`, `webserver`, `runLauncher`, …), and the `DagsterHelmValues` TS interface still documents the common fields — which is exactly the split the review recommended. The now-dead `helmValuesSchemaShape` is removed, with a comment in its place so nobody re-wires it.

One find worth calling out: the `serviceAccount.annotations` comment asserted that `object` *"serializes to `type: string`"* as if that were expected behaviour. That was this bug, documented as a feature. `Record<string,string>` remains correct there (annotations really are a string→string map), but the rationale is fixed.

## Tests (P2)

The review was right that the old tests proved references, not behaviour. Added:

- **Core:** `object` → `object`, `object[]` → `[]object`, required-vs-optional, and the structured forms that must **not** change (`Record<string,string>` stays `map[string]string`; nested shapes stay nested).
- **RGD types:** exact assertions for `spec.values`, `spec.postgresql.values`, `spec.rabbitmq.values`, `spec.redis.values` — plus a guard that opaque `values` didn't swallow the typed API.
- **Live KRO admission** (`test/integration/dagster/values-admission.test.ts`): applies the RGD, submits a CR with nested unknown maps/booleans/numbers/arrays, and reads the admitted object back. Image-free, so it needs only a cluster with KRO.

**I verified the live test fails without the core fix** — a test that can't fail proves nothing.

## Why this stayed hidden

The defect surfaces differently per client. `kubectl apply` uses strict decoding, so it errors loudly (`strict decoding error: unknown field "spec.values.postgresql"`) — that's the "422/BadRequest" people hit poking by hand. TypeKro's own apply path is **not** strict, so in production the identical mismatch was **pruned in silence** and the converge reported success. The new test drives kubectl deliberately, so a regression is a hard error.

## Verification

Typecheck clean. Full unit suite **5158 pass / 0 fail** — notable given 36+38 field types changed. Live admission test 3/3 against orbstack.

## Not done here

The review's audit item: APISIX/Ory/ClickHouse benefit automatically from the core fix (their `type('object')` fields now map correctly, and the core tests cover the construct), but I did not add per-factory live admission tests for them. Worth a follow-up if you want the same guarantee everywhere.