### PR TITLE
Fix persisted Alchemy resources after live deletion

### DIFF
--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -15,6 +15,7 @@
  */
 
 import type { KubeConfig } from '@kubernetes/client-node';
+import * as Diff from 'alchemy/Diff';
 import type { Input } from 'alchemy/Input';
 import * as Output from 'alchemy/Output';
 import * as ProviderMod from 'alchemy/Provider';
@@ -25,6 +26,7 @@ import * as Redacted from 'effect/Redacted';
 import { DEFAULT_DEPLOYMENT_TIMEOUT } from '../core/config/defaults.js';
 import { CEL_EXPRESSION_BRAND } from '../core/constants/brands.js';
 import { migrateLegacyKroArtifactBindingCrd } from '../core/deployment/kro-artifact-binding-migration.js';
+import { isNotFoundError } from '../core/deployment/k8s-helpers.js';
 import {
   decideNamespaceOwnershipCreateFirst,
   deleteNamespaceIfEmpty,
@@ -148,6 +150,15 @@ export const kroProvider = ProviderMod.effect(
     // cluster-wide from props alone — TypeKro manages teardown through its own `delete` lifecycle —
     // so this reports nothing to nuke rather than guessing (required by alchemy beta.58's ProviderService).
     list: () => Effect.succeed([]),
+    diff: Effect.fn(function* ({ olds, news, output }) {
+      if (Diff.isResolved(news) && olds.namespace !== news.namespace) {
+        return { action: 'replace' as const };
+      }
+      return yield* Effect.tryPromise({
+        try: () => detectKroResourceIdentityDrift(olds, output),
+        catch: ensureError,
+      });
+    }),
     reconcile: Effect.fn(function* ({ news }) {
       return yield* Effect.tryPromise({
         try: (abortSignal) => deployKroResource(news, abortSignal),
@@ -442,6 +453,81 @@ async function deployKroResource<T extends Enhanced<unknown, unknown>>(
  * through the Effect provider above.
  */
 export const deployKroResourceForTest = deployKroResource;
+
+interface KroResourceIdentityReader {
+  read(resource: KubernetesResource): Promise<KubernetesResource>;
+}
+
+/**
+ * Check persisted Alchemy state against the Kubernetes API before Alchemy
+ * decides that an unchanged TypeKro resource is a no-op.
+ *
+ * Alchemy invokes provider.read() only when state is absent. This diff check
+ * closes the complementary persisted-state case: an out-of-band deletion,
+ * replacement, or in-progress deletion must drive the normal convergent
+ * reconcile path. Authored desired-property changes remain Alchemy's normal
+ * prop-diff responsibility; controller-owned status evolution stays a no-op.
+ * A non-404 read failure is never evidence of drift absence and fails closed.
+ */
+async function detectKroResourceIdentityDrift(
+  props: TypeKroResourceProps<Enhanced<unknown, unknown>>,
+  output: TypeKroResource<Enhanced<unknown, unknown>> | undefined,
+  reader?: KroResourceIdentityReader
+): Promise<{ readonly action: 'update' } | undefined> {
+  const prior = output?.deployedResource;
+  if (!prior) return { action: 'update' };
+  const identity: KubernetesResource = {
+    apiVersion: prior.apiVersion,
+    kind: prior.kind,
+    metadata: {
+      name: prior.metadata?.name ?? '',
+      ...(prior.metadata?.namespace
+        ? { namespace: prior.metadata.namespace }
+        : {}),
+    },
+  };
+  if (!identity.metadata.name) return { action: 'update' };
+
+  const liveReader = reader ?? (() => {
+    const provider = _createClientProvider(props, 'alchemy-drift-check');
+    const api = createBunCompatibleKubernetesObjectApi(provider);
+    return {
+      read: async (resource: KubernetesResource) =>
+        (await api.read(
+          resource as Parameters<typeof api.read>[0],
+        )) as KubernetesResource,
+    };
+  })();
+
+  let live: KubernetesResource;
+  try {
+    live = await liveReader.read(identity);
+  } catch (error: unknown) {
+    if (isNotFoundError(error)) return { action: 'update' };
+    throw new Error(
+      `Alchemy drift check could not read ${identity.apiVersion}/${identity.kind} `
+      + `${identity.metadata.namespace ? `${identity.metadata.namespace}/` : ''}`
+      + `${identity.metadata.name}: ${ensureError(error).message}`,
+    );
+  }
+
+  const priorUid = prior.metadata?.uid;
+  const liveUid = live.metadata?.uid;
+  if (
+    typeof priorUid === 'string'
+    && typeof liveUid === 'string'
+    && priorUid !== liveUid
+  ) {
+    return { action: 'update' };
+  }
+  if (live.metadata?.deletionTimestamp) return { action: 'update' };
+
+  return undefined;
+}
+
+/** Test hook for persisted-state Kubernetes drift decisions. */
+export const detectKroResourceIdentityDriftForTest =
+  detectKroResourceIdentityDrift;
 
 export { singletonDriftVerdict } from '../core/deployment/singleton-owner-drift.js';
 

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -137,34 +137,102 @@ export type KroResourceR = ResourceT<
  */
 export const KroResource = ResourceMod.Resource<KroResourceR>(KRO_RESOURCE_TYPE);
 
-function shouldReplaceKroResourceNamespace<T extends Enhanced<unknown, unknown>>(
-  olds: TypeKroResourceProps<T>,
+interface KroResourceIdentity {
+  readonly apiVersion: string;
+  readonly kind: string;
+  readonly name: string;
+  readonly namespace?: string;
+}
+
+function inputResourceIdentityField(
+  value: unknown
+): string | undefined | typeof UNRESOLVED_IDENTITY {
+  if (value === undefined) return undefined;
+  if (!Diff.isResolved(value)) return UNRESOLVED_IDENTITY;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+const UNRESOLVED_IDENTITY = Symbol('unresolved-kro-resource-identity');
+
+function desiredKroResourceIdentity<T extends Enhanced<unknown, unknown>>(
+  news: Input<TypeKroResourceProps<T>>,
+  output?: TypeKroResource<T>
+): KroResourceIdentity | undefined | typeof UNRESOLVED_IDENTITY {
+  if (typeof news !== 'object' || news === null || !('resource' in news)) {
+    return undefined;
+  }
+  const resource = Reflect.get(news, 'resource');
+  if (typeof resource !== 'object' || resource === null) return undefined;
+  const metadata = Reflect.get(resource, 'metadata');
+  if (typeof metadata !== 'object' || metadata === null) return undefined;
+  const apiVersion = inputResourceIdentityField(Reflect.get(resource, 'apiVersion'));
+  const kind = inputResourceIdentityField(Reflect.get(resource, 'kind'));
+  const name = inputResourceIdentityField(Reflect.get(metadata, 'name'));
+  if (
+    apiVersion === UNRESOLVED_IDENTITY ||
+    kind === UNRESOLVED_IDENTITY ||
+    name === UNRESOLVED_IDENTITY
+  ) {
+    return UNRESOLVED_IDENTITY;
+  }
+  if (!apiVersion || !kind || !name) return undefined;
+
+  const persisted = persistedKroResourceIdentity(output);
+  let namespace: string | undefined;
+  if (persisted && persisted.metadata.namespace === undefined) {
+    // The API server is authoritative for scope. A factory/deployment
+    // namespace is execution context only and must never become part of a
+    // cluster-scoped resource identity.
+    namespace = undefined;
+  } else {
+    const explicitNamespace = inputResourceIdentityField(
+      Reflect.get(metadata, 'namespace')
+    );
+    if (explicitNamespace === UNRESOLVED_IDENTITY) return UNRESOLVED_IDENTITY;
+    if (explicitNamespace) {
+      namespace = explicitNamespace;
+    } else if (persisted?.metadata.namespace !== undefined) {
+      const factoryNamespace =
+        typeof news === 'object' && news !== null && 'namespace' in news
+          ? inputResourceIdentityField(Reflect.get(news, 'namespace'))
+          : undefined;
+      if (factoryNamespace === UNRESOLVED_IDENTITY) return UNRESOLVED_IDENTITY;
+      namespace = factoryNamespace;
+    }
+  }
+  return { apiVersion, kind, name, ...(namespace ? { namespace } : {}) };
+}
+
+function sameKroResourceIdentity(
+  left: KubernetesResource,
+  right: KroResourceIdentity
+): boolean {
+  return (
+    left.apiVersion === right.apiVersion &&
+    left.kind === right.kind &&
+    left.metadata.name === right.name &&
+    left.metadata.namespace === right.namespace
+  );
+}
+
+function shouldReplaceKroResourceIdentity<T extends Enhanced<unknown, unknown>>(
+  _olds: TypeKroResourceProps<T>,
   news: Input<TypeKroResourceProps<T>>,
   output?: TypeKroResource<T>
 ): boolean {
-  if (typeof news !== 'object' || news === null || !('namespace' in news)) {
-    return false;
-  }
-  const namespace: unknown = Reflect.get(news, 'namespace');
-  // Namespace is part of a namespaced resource's Kubernetes identity. When it
-  // is unresolved at plan time, defer the identity decision until reconcile:
-  // the upstream output is concrete there and can be compared with the
-  // persisted live identity. Treating uncertainty as replacement is unsafe
-  // because create-before-delete replacement can delete a freshly updated
-  // same-identity resource.
-  if (!Diff.isResolved(namespace)) return false;
-  // Persisted live identity is stronger evidence than the previous input.
-  // Older direct-factory declarations stored the factory default here even
-  // when the manifest was explicitly namespaced elsewhere. Treating that
-  // corrected state as a namespace move would replace an unchanged
-  // Kubernetes identity and can strand a failed Flux release.
-  const persistedNamespace =
-    output?.deployedResource.metadata?.namespace ?? output?.namespace ?? olds.namespace;
-  return typeof namespace === 'string' && persistedNamespace !== namespace;
+  const persisted = persistedKroResourceIdentity(output);
+  if (!persisted) return false;
+  const desired = desiredKroResourceIdentity(news, output);
+  // Identity fields can contain Alchemy Outputs. Defer uncertain identity
+  // decisions until reconcile, where every input has been resolved. Treating
+  // uncertainty as replacement is unsafe because create-before-delete can
+  // delete a freshly updated same-identity object.
+  if (!desired || desired === UNRESOLVED_IDENTITY) return false;
+  return !sameKroResourceIdentity(persisted, desired);
 }
 
-/** Test hook for namespace-stable replacement decisions with unresolved sibling inputs. */
-export const shouldReplaceKroResourceNamespaceForTest = shouldReplaceKroResourceNamespace;
+/** Test hook for identity-stable replacement decisions with unresolved sibling inputs. */
+export const shouldReplaceKroResourceIdentityForTest = shouldReplaceKroResourceIdentity;
 
 /**
  * The provider `Layer` that backs {@link KroResource}. Merge into the runtime's providers
@@ -185,7 +253,7 @@ export const kroProvider = ProviderMod.effect(
     // so this reports nothing to nuke rather than guessing (required by alchemy beta.58's ProviderService).
     list: () => Effect.succeed([]),
     diff: Effect.fn(function* ({ olds, news, output }) {
-      if (shouldReplaceKroResourceNamespace(olds, news, output)) {
+      if (shouldReplaceKroResourceIdentity(olds, news, output)) {
         return { action: 'replace' as const };
       }
       return yield* Effect.tryPromise({
@@ -196,12 +264,20 @@ export const kroProvider = ProviderMod.effect(
     reconcile: Effect.fn(function* ({ news, output }) {
       return yield* Effect.tryPromise({
         try: async (abortSignal) => {
-          const persistedNamespace = persistedKroResourceNamespace(output);
-          if (persistedNamespace !== undefined && persistedNamespace !== news.namespace) {
+          const persistedIdentity = persistedKroResourceIdentity(output);
+          const desiredIdentity = desiredKroResourceIdentity(news, output);
+          if (
+            persistedIdentity &&
+            desiredIdentity &&
+            desiredIdentity !== UNRESOLVED_IDENTITY &&
+            !sameKroResourceIdentity(persistedIdentity, desiredIdentity)
+          ) {
             const previous = propsFromOutput(output);
             if (!previous) {
               throw new Error(
-                `Alchemy cannot replace the prior Kubernetes identity in namespace ${persistedNamespace}: persisted delete properties are unavailable`
+                `Alchemy cannot replace prior Kubernetes identity ${persistedIdentity.apiVersion}/${persistedIdentity.kind} ` +
+                  `${persistedIdentity.metadata.namespace ? `${persistedIdentity.metadata.namespace}/` : ''}` +
+                  `${persistedIdentity.metadata.name}: persisted delete properties are unavailable`
               );
             }
             await deleteKroResource(previous, abortSignal);
@@ -518,12 +594,6 @@ function persistedKroResourceIdentity(
       ...(prior.metadata?.namespace ? { namespace: prior.metadata.namespace } : {}),
     },
   };
-}
-
-function persistedKroResourceNamespace(
-  output: TypeKroResource<Enhanced<unknown, unknown>> | undefined
-): string | undefined {
-  return output?.deployedResource.metadata?.namespace ?? output?.namespace;
 }
 
 function identityReader(

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -27,6 +27,7 @@ import { DEFAULT_DEPLOYMENT_TIMEOUT } from '../core/config/defaults.js';
 import { CEL_EXPRESSION_BRAND } from '../core/constants/brands.js';
 import { migrateLegacyKroArtifactBindingCrd } from '../core/deployment/kro-artifact-binding-migration.js';
 import { isNotFoundError } from '../core/deployment/k8s-helpers.js';
+import { ResourceReplacementTimeoutError } from '../core/deployment/errors.js';
 import {
   decideNamespaceOwnershipCreateFirst,
   deleteNamespaceIfEmpty,
@@ -66,7 +67,11 @@ import {
   planValueSensitiveBindingNames,
 } from '../core/planning/index.js';
 import { resolvePortableReadinessStrategy } from '../core/readiness/portable-strategies.js';
-import type { DeployedResource, DeploymentOptions } from '../core/types/deployment.js';
+import type {
+  DeletionResourceIdentity,
+  DeployedResource,
+  DeploymentOptions,
+} from '../core/types/deployment.js';
 import type { Enhanced, KubernetesResource } from '../core/types/kubernetes.js';
 import {
   DirectTypeKroDeployer,
@@ -140,9 +145,12 @@ function shouldReplaceKroResourceNamespace<T extends Enhanced<unknown, unknown>>
     return false;
   }
   const namespace: unknown = Reflect.get(news, 'namespace');
-  return (
-    Diff.isResolved(namespace) && typeof namespace === 'string' && olds.namespace !== namespace
-  );
+  // Namespace is part of a namespaced resource's Kubernetes identity. Alchemy resolves
+  // Outputs only after diffing, so an upstream-provided namespace cannot be compared with
+  // persisted state here. Treat that uncertainty as replacement: an in-place update could
+  // create the new identity while orphaning the old object outside Alchemy state.
+  if (!Diff.isResolved(namespace)) return true;
+  return typeof namespace === 'string' && olds.namespace !== namespace;
 }
 
 /** Test hook for namespace-stable replacement decisions with unresolved sibling inputs. */
@@ -513,6 +521,43 @@ interface PersistedIdentityDeletionWaitDependencies {
   pollIntervalMs?: number;
 }
 
+function deletionIdentityFromLive(
+  identity: KubernetesResource,
+  live: KubernetesResource
+): DeletionResourceIdentity {
+  const metadata = live.metadata;
+  const deletionTimestamp = metadata?.deletionTimestamp;
+  return {
+    apiVersion: live.apiVersion || identity.apiVersion,
+    kind: live.kind || identity.kind,
+    name: metadata?.name || identity.metadata.name || '<unknown>',
+    ...(metadata?.namespace || identity.metadata.namespace
+      ? { namespace: metadata?.namespace || identity.metadata.namespace }
+      : {}),
+    ...(metadata?.uid ? { uid: metadata.uid } : {}),
+    ...(deletionTimestamp
+      ? {
+          deletionTimestamp:
+            deletionTimestamp instanceof Date
+              ? deletionTimestamp.toISOString()
+              : String(deletionTimestamp),
+        }
+      : {}),
+    ...(metadata?.finalizers?.length ? { finalizers: [...metadata.finalizers] } : {}),
+    ...(metadata?.ownerReferences?.length
+      ? {
+          owners: metadata.ownerReferences.map((owner) => ({
+            apiVersion: owner.apiVersion,
+            kind: owner.kind,
+            name: owner.name,
+            ...(owner.uid ? { uid: owner.uid } : {}),
+            ...(owner.controller !== undefined ? { controller: owner.controller } : {}),
+          })),
+        }
+      : {}),
+  };
+}
+
 async function waitForPersistedIdentityDeletion(
   props: TypeKroResourceProps<Enhanced<unknown, unknown>>,
   output: TypeKroResource<Enhanced<unknown, unknown>> | undefined,
@@ -525,12 +570,15 @@ async function waitForPersistedIdentityDeletion(
   const sleep = dependencies.sleep ?? Bun.sleep;
   const now = dependencies.now ?? Date.now;
   const pollIntervalMs = dependencies.pollIntervalMs ?? 500;
-  const deadline = now() + (props.options?.timeout ?? DEFAULT_DEPLOYMENT_TIMEOUT);
+  const timeout = props.options?.timeout ?? DEFAULT_DEPLOYMENT_TIMEOUT;
+  const deadline = now() + timeout;
+  let lastLive: KubernetesResource | undefined;
 
   while (true) {
     abortSignal?.throwIfAborted();
     try {
       const live = await reader.read(identity);
+      lastLive = live;
       if (!live.metadata?.deletionTimestamp) return;
     } catch (error: unknown) {
       if (isNotFoundError(error)) return;
@@ -542,10 +590,12 @@ async function waitForPersistedIdentityDeletion(
     }
 
     if (now() >= deadline) {
-      throw new Error(
-        `Timed out waiting for terminating ${identity.apiVersion}/${identity.kind} ` +
-          `${identity.metadata.namespace ? `${identity.metadata.namespace}/` : ''}` +
-          `${identity.metadata.name} to disappear before reconciliation`
+      const resource = deletionIdentityFromLive(identity, lastLive ?? identity);
+      throw new ResourceReplacementTimeoutError(
+        resource.name,
+        resource.kind,
+        timeout,
+        resource
       );
     }
     await sleep(pollIntervalMs);

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -139,7 +139,8 @@ export const KroResource = ResourceMod.Resource<KroResourceR>(KRO_RESOURCE_TYPE)
 
 function shouldReplaceKroResourceNamespace<T extends Enhanced<unknown, unknown>>(
   olds: TypeKroResourceProps<T>,
-  news: Input<TypeKroResourceProps<T>>
+  news: Input<TypeKroResourceProps<T>>,
+  output?: TypeKroResource<T>
 ): boolean {
   if (typeof news !== 'object' || news === null || !('namespace' in news)) {
     return false;
@@ -152,7 +153,14 @@ function shouldReplaceKroResourceNamespace<T extends Enhanced<unknown, unknown>>
   // because create-before-delete replacement can delete a freshly updated
   // same-identity resource.
   if (!Diff.isResolved(namespace)) return false;
-  return typeof namespace === 'string' && olds.namespace !== namespace;
+  // Persisted live identity is stronger evidence than the previous input.
+  // Older direct-factory declarations stored the factory default here even
+  // when the manifest was explicitly namespaced elsewhere. Treating that
+  // corrected state as a namespace move would replace an unchanged
+  // Kubernetes identity and can strand a failed Flux release.
+  const persistedNamespace =
+    output?.deployedResource.metadata?.namespace ?? output?.namespace ?? olds.namespace;
+  return typeof namespace === 'string' && persistedNamespace !== namespace;
 }
 
 /** Test hook for namespace-stable replacement decisions with unresolved sibling inputs. */
@@ -177,7 +185,7 @@ export const kroProvider = ProviderMod.effect(
     // so this reports nothing to nuke rather than guessing (required by alchemy beta.58's ProviderService).
     list: () => Effect.succeed([]),
     diff: Effect.fn(function* ({ olds, news, output }) {
-      if (shouldReplaceKroResourceNamespace(olds, news)) {
+      if (shouldReplaceKroResourceNamespace(olds, news, output)) {
         return { action: 'replace' as const };
       }
       return yield* Effect.tryPromise({

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -25,9 +25,9 @@ import { Effect } from 'effect';
 import * as Redacted from 'effect/Redacted';
 import { DEFAULT_DEPLOYMENT_TIMEOUT } from '../core/config/defaults.js';
 import { CEL_EXPRESSION_BRAND } from '../core/constants/brands.js';
-import { migrateLegacyKroArtifactBindingCrd } from '../core/deployment/kro-artifact-binding-migration.js';
-import { isNotFoundError } from '../core/deployment/k8s-helpers.js';
 import { ResourceReplacementTimeoutError } from '../core/deployment/errors.js';
+import { isNotFoundError } from '../core/deployment/k8s-helpers.js';
+import { migrateLegacyKroArtifactBindingCrd } from '../core/deployment/kro-artifact-binding-migration.js';
 import {
   decideNamespaceOwnershipCreateFirst,
   deleteNamespaceIfEmpty,
@@ -145,11 +145,13 @@ function shouldReplaceKroResourceNamespace<T extends Enhanced<unknown, unknown>>
     return false;
   }
   const namespace: unknown = Reflect.get(news, 'namespace');
-  // Namespace is part of a namespaced resource's Kubernetes identity. Alchemy resolves
-  // Outputs only after diffing, so an upstream-provided namespace cannot be compared with
-  // persisted state here. Treat that uncertainty as replacement: an in-place update could
-  // create the new identity while orphaning the old object outside Alchemy state.
-  if (!Diff.isResolved(namespace)) return true;
+  // Namespace is part of a namespaced resource's Kubernetes identity. When it
+  // is unresolved at plan time, defer the identity decision until reconcile:
+  // the upstream output is concrete there and can be compared with the
+  // persisted live identity. Treating uncertainty as replacement is unsafe
+  // because create-before-delete replacement can delete a freshly updated
+  // same-identity resource.
+  if (!Diff.isResolved(namespace)) return false;
   return typeof namespace === 'string' && olds.namespace !== namespace;
 }
 
@@ -186,6 +188,16 @@ export const kroProvider = ProviderMod.effect(
     reconcile: Effect.fn(function* ({ news, output }) {
       return yield* Effect.tryPromise({
         try: async (abortSignal) => {
+          const persistedNamespace = persistedKroResourceNamespace(output);
+          if (persistedNamespace !== undefined && persistedNamespace !== news.namespace) {
+            const previous = propsFromOutput(output);
+            if (!previous) {
+              throw new Error(
+                `Alchemy cannot replace the prior Kubernetes identity in namespace ${persistedNamespace}: persisted delete properties are unavailable`
+              );
+            }
+            await deleteKroResource(previous, abortSignal);
+          }
           await waitForPersistedIdentityDeletion(news, output, abortSignal);
           return deployKroResource(news, abortSignal);
         },
@@ -500,6 +512,12 @@ function persistedKroResourceIdentity(
   };
 }
 
+function persistedKroResourceNamespace(
+  output: TypeKroResource<Enhanced<unknown, unknown>> | undefined
+): string | undefined {
+  return output?.deployedResource.metadata?.namespace ?? output?.namespace;
+}
+
 function identityReader(
   props: TypeKroResourceProps<Enhanced<unknown, unknown>>,
   reader: KroResourceIdentityReader | undefined,
@@ -591,12 +609,7 @@ async function waitForPersistedIdentityDeletion(
 
     if (now() >= deadline) {
       const resource = deletionIdentityFromLive(identity, lastLive ?? identity);
-      throw new ResourceReplacementTimeoutError(
-        resource.name,
-        resource.kind,
-        timeout,
-        resource
-      );
+      throw new ResourceReplacementTimeoutError(resource.name, resource.kind, timeout, resource);
     }
     await sleep(pollIntervalMs);
   }

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -132,6 +132,22 @@ export type KroResourceR = ResourceT<
  */
 export const KroResource = ResourceMod.Resource<KroResourceR>(KRO_RESOURCE_TYPE);
 
+function shouldReplaceKroResourceNamespace<T extends Enhanced<unknown, unknown>>(
+  olds: TypeKroResourceProps<T>,
+  news: Input<TypeKroResourceProps<T>>
+): boolean {
+  if (typeof news !== 'object' || news === null || !('namespace' in news)) {
+    return false;
+  }
+  const namespace: unknown = Reflect.get(news, 'namespace');
+  return (
+    Diff.isResolved(namespace) && typeof namespace === 'string' && olds.namespace !== namespace
+  );
+}
+
+/** Test hook for namespace-stable replacement decisions with unresolved sibling inputs. */
+export const shouldReplaceKroResourceNamespaceForTest = shouldReplaceKroResourceNamespace;
+
 /**
  * The provider `Layer` that backs {@link KroResource}. Merge into the runtime's providers
  * (alongside the cloud providers) so reconcile/delete run. `reconcile` is the single
@@ -151,7 +167,7 @@ export const kroProvider = ProviderMod.effect(
     // so this reports nothing to nuke rather than guessing (required by alchemy beta.58's ProviderService).
     list: () => Effect.succeed([]),
     diff: Effect.fn(function* ({ olds, news, output }) {
-      if (Diff.isResolved(news) && olds.namespace !== news.namespace) {
+      if (shouldReplaceKroResourceNamespace(olds, news)) {
         return { action: 'replace' as const };
       }
       return yield* Effect.tryPromise({
@@ -159,9 +175,12 @@ export const kroProvider = ProviderMod.effect(
         catch: ensureError,
       });
     }),
-    reconcile: Effect.fn(function* ({ news }) {
+    reconcile: Effect.fn(function* ({ news, output }) {
       return yield* Effect.tryPromise({
-        try: (abortSignal) => deployKroResource(news, abortSignal),
+        try: async (abortSignal) => {
+          await waitForPersistedIdentityDeletion(news, output, abortSignal);
+          return deployKroResource(news, abortSignal);
+        },
         catch: ensureError,
       });
     }),
@@ -419,9 +438,7 @@ async function deployKroResource<T extends Enhanced<unknown, unknown>>(
       effectiveProps.deploymentStrategy === 'kro' &&
       (resourceForDeploy as { kind?: string }).kind === 'ResourceGraphDefinition'
     ) {
-      await (
-        dependencies.migrateLegacyArtifactBindings ?? migrateLegacyKroArtifactBindingCrd
-      )(
+      await (dependencies.migrateLegacyArtifactBindings ?? migrateLegacyKroArtifactBindingCrd)(
         dependencies.kubeConfigForMigration?.() ??
           _createClientProvider(effectiveProps, 'artifact-binding-migration'),
         resourceForDeploy as unknown as KubernetesResource
@@ -458,6 +475,83 @@ interface KroResourceIdentityReader {
   read(resource: KubernetesResource): Promise<KubernetesResource>;
 }
 
+function persistedKroResourceIdentity(
+  output: TypeKroResource<Enhanced<unknown, unknown>> | undefined
+): KubernetesResource | undefined {
+  const prior = output?.deployedResource;
+  if (!prior) return undefined;
+  const name = prior.metadata?.name;
+  if (typeof name !== 'string' || name.length === 0) return undefined;
+  return {
+    apiVersion: prior.apiVersion,
+    kind: prior.kind,
+    metadata: {
+      name,
+      ...(prior.metadata?.namespace ? { namespace: prior.metadata.namespace } : {}),
+    },
+  };
+}
+
+function identityReader(
+  props: TypeKroResourceProps<Enhanced<unknown, unknown>>,
+  reader: KroResourceIdentityReader | undefined,
+  phase: string
+): KroResourceIdentityReader {
+  if (reader) return reader;
+  const provider = _createClientProvider(props, phase);
+  const api = createBunCompatibleKubernetesObjectApi(provider);
+  return {
+    read: async (resource: KubernetesResource) =>
+      (await api.read(resource as Parameters<typeof api.read>[0])) as KubernetesResource,
+  };
+}
+
+interface PersistedIdentityDeletionWaitDependencies {
+  reader?: KroResourceIdentityReader;
+  sleep?: (milliseconds: number) => Promise<void>;
+  now?: () => number;
+  pollIntervalMs?: number;
+}
+
+async function waitForPersistedIdentityDeletion(
+  props: TypeKroResourceProps<Enhanced<unknown, unknown>>,
+  output: TypeKroResource<Enhanced<unknown, unknown>> | undefined,
+  abortSignal?: AbortSignal,
+  dependencies: PersistedIdentityDeletionWaitDependencies = {}
+): Promise<void> {
+  const identity = persistedKroResourceIdentity(output);
+  if (!identity) return;
+  const reader = identityReader(props, dependencies.reader, 'alchemy-terminating-identity');
+  const sleep = dependencies.sleep ?? Bun.sleep;
+  const now = dependencies.now ?? Date.now;
+  const pollIntervalMs = dependencies.pollIntervalMs ?? 500;
+  const deadline = now() + (props.options?.timeout ?? DEFAULT_DEPLOYMENT_TIMEOUT);
+
+  while (true) {
+    abortSignal?.throwIfAborted();
+    try {
+      const live = await reader.read(identity);
+      if (!live.metadata?.deletionTimestamp) return;
+    } catch (error: unknown) {
+      if (isNotFoundError(error)) return;
+      throw new Error(
+        `Alchemy terminating-identity check could not read ${identity.apiVersion}/${identity.kind} ` +
+          `${identity.metadata.namespace ? `${identity.metadata.namespace}/` : ''}` +
+          `${identity.metadata.name}: ${ensureError(error).message}`
+      );
+    }
+
+    if (now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for terminating ${identity.apiVersion}/${identity.kind} ` +
+          `${identity.metadata.namespace ? `${identity.metadata.namespace}/` : ''}` +
+          `${identity.metadata.name} to disappear before reconciliation`
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
 /**
  * Check persisted Alchemy state against the Kubernetes API before Alchemy
  * decides that an unchanged TypeKro resource is a no-op.
@@ -475,29 +569,9 @@ async function detectKroResourceIdentityDrift(
   reader?: KroResourceIdentityReader
 ): Promise<{ readonly action: 'update' } | undefined> {
   const prior = output?.deployedResource;
-  if (!prior) return { action: 'update' };
-  const identity: KubernetesResource = {
-    apiVersion: prior.apiVersion,
-    kind: prior.kind,
-    metadata: {
-      name: prior.metadata?.name ?? '',
-      ...(prior.metadata?.namespace
-        ? { namespace: prior.metadata.namespace }
-        : {}),
-    },
-  };
-  if (!identity.metadata.name) return { action: 'update' };
-
-  const liveReader = reader ?? (() => {
-    const provider = _createClientProvider(props, 'alchemy-drift-check');
-    const api = createBunCompatibleKubernetesObjectApi(provider);
-    return {
-      read: async (resource: KubernetesResource) =>
-        (await api.read(
-          resource as Parameters<typeof api.read>[0],
-        )) as KubernetesResource,
-    };
-  })();
+  const identity = persistedKroResourceIdentity(output);
+  if (!prior || !identity) return { action: 'update' };
+  const liveReader = identityReader(props, reader, 'alchemy-drift-check');
 
   let live: KubernetesResource;
   try {
@@ -505,19 +579,15 @@ async function detectKroResourceIdentityDrift(
   } catch (error: unknown) {
     if (isNotFoundError(error)) return { action: 'update' };
     throw new Error(
-      `Alchemy drift check could not read ${identity.apiVersion}/${identity.kind} `
-      + `${identity.metadata.namespace ? `${identity.metadata.namespace}/` : ''}`
-      + `${identity.metadata.name}: ${ensureError(error).message}`,
+      `Alchemy drift check could not read ${identity.apiVersion}/${identity.kind} ` +
+        `${identity.metadata.namespace ? `${identity.metadata.namespace}/` : ''}` +
+        `${identity.metadata.name}: ${ensureError(error).message}`
     );
   }
 
   const priorUid = prior.metadata?.uid;
   const liveUid = live.metadata?.uid;
-  if (
-    typeof priorUid === 'string'
-    && typeof liveUid === 'string'
-    && priorUid !== liveUid
-  ) {
+  if (typeof priorUid === 'string' && typeof liveUid === 'string' && priorUid !== liveUid) {
     return { action: 'update' };
   }
   if (live.metadata?.deletionTimestamp) return { action: 'update' };
@@ -526,8 +596,10 @@ async function detectKroResourceIdentityDrift(
 }
 
 /** Test hook for persisted-state Kubernetes drift decisions. */
-export const detectKroResourceIdentityDriftForTest =
-  detectKroResourceIdentityDrift;
+export const detectKroResourceIdentityDriftForTest = detectKroResourceIdentityDrift;
+
+/** Test hook for terminating persisted-identity reconciliation. */
+export const waitForPersistedIdentityDeletionForTest = waitForPersistedIdentityDeletion;
 
 export { singletonDriftVerdict } from '../core/deployment/singleton-owner-drift.js';
 

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -1566,13 +1566,33 @@ export class DirectResourceFactoryImpl<
       hasSensitiveBindings || hasSecretPayload ? await import('effect/Redacted') : undefined;
     const nodeCandidates = graph.resources.map(({ id: graphId, manifest }) => {
       const resource = ensureReadinessEvaluator(manifest as Enhanced<unknown, unknown>);
+      const identity = directAlchemyKubernetesIdentity(resource, this.namespace);
       return {
         graphId,
         resource,
+        identity,
         legacyAlchemyId: createAlchemyResourceId(resource, this.namespace),
         logicalId: getResourceId(manifest as Enhanced<unknown, unknown>) ?? graphId,
       };
     });
+    const candidateByKubernetesIdentity = new Map<
+      string,
+      (typeof nodeCandidates)[number]
+    >();
+    for (const candidate of nodeCandidates) {
+      const existing = candidateByKubernetesIdentity.get(candidate.identity.key);
+      if (existing) {
+        throw new ValidationError(
+          `Direct Alchemy materialization cannot assign two graph nodes to the same Kubernetes ` +
+            `object ${candidate.identity.display}: ${existing.logicalId} and ${candidate.logicalId}. ` +
+            `Each live Kubernetes identity must have exactly one Alchemy owner.`,
+          candidate.resource.kind,
+          candidate.logicalId,
+          'metadata'
+        );
+      }
+      candidateByKubernetesIdentity.set(candidate.identity.key, candidate);
+    }
     const legacyAlchemyIdCounts = new Map<string, number>();
     for (const candidate of nodeCandidates) {
       legacyAlchemyIdCounts.set(
@@ -1587,8 +1607,7 @@ export class DirectResourceFactoryImpl<
           ? candidate.legacyAlchemyId
           : disambiguatedAlchemyResourceId(
               candidate.legacyAlchemyId,
-              candidate.resource,
-              candidate.logicalId
+              candidate.identity.key
             );
       if (assignedAlchemyIds.has(alchemyId)) {
         throw new ValidationError(
@@ -2884,18 +2903,38 @@ function findUnresolvedReferences(
  */
 function disambiguatedAlchemyResourceId(
   legacyId: string,
-  resource: Enhanced<unknown, unknown>,
-  logicalId: string
+  canonicalKubernetesIdentity: string
 ): string {
-  const identity = JSON.stringify({
+  const suffix = createHash('sha256')
+    .update(canonicalKubernetesIdentity, 'utf8')
+    .digest('hex')
+    .slice(0, 12);
+  return `${legacyId}Identity${suffix}`;
+}
+
+function directAlchemyKubernetesIdentity(
+  resource: Enhanced<unknown, unknown>,
+  factoryNamespace: string
+): {
+  readonly key: string;
+  readonly display: string;
+} {
+  const namespace =
+    getMetadataField(resource, 'scope') === 'cluster'
+      ? undefined
+      : resource.metadata?.namespace ?? factoryNamespace;
+  const identity = {
     apiVersion: resource.apiVersion,
     kind: resource.kind,
     name: resource.metadata?.name,
-    namespace: resource.metadata?.namespace,
-    logicalId,
-  });
-  const suffix = createHash('sha256').update(identity, 'utf8').digest('hex').slice(0, 12);
-  return `${legacyId}Identity${suffix}`;
+    namespace,
+  };
+  return {
+    key: JSON.stringify(identity),
+    display:
+      `${identity.apiVersion}/${identity.kind} ` +
+      `${namespace ? `${namespace}/` : ''}${identity.name ?? '<unnamed>'}`,
+  };
 }
 
 /**

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -5,6 +5,7 @@
  * internal dependency resolution engine, without requiring the Kro controller.
  */
 
+import { createHash } from 'node:crypto';
 import * as yaml from 'js-yaml';
 import type { AlchemyResourceDeclaration } from '../../alchemy/types.js';
 import { createAlchemyResourceId } from '../../alchemy/utilities.js';
@@ -1563,12 +1564,48 @@ export class DirectResourceFactoryImpl<
     );
     const Redacted =
       hasSensitiveBindings || hasSecretPayload ? await import('effect/Redacted') : undefined;
-    for (const { id: graphId, manifest } of graph.resources) {
+    const nodeCandidates = graph.resources.map(({ id: graphId, manifest }) => {
       const resource = ensureReadinessEvaluator(manifest as Enhanced<unknown, unknown>);
-      byGraphId.set(graphId, {
+      return {
+        graphId,
         resource,
-        alchemyId: createAlchemyResourceId(resource, this.namespace),
+        legacyAlchemyId: createAlchemyResourceId(resource, this.namespace),
         logicalId: getResourceId(manifest as Enhanced<unknown, unknown>) ?? graphId,
+      };
+    });
+    const legacyAlchemyIdCounts = new Map<string, number>();
+    for (const candidate of nodeCandidates) {
+      legacyAlchemyIdCounts.set(
+        candidate.legacyAlchemyId,
+        (legacyAlchemyIdCounts.get(candidate.legacyAlchemyId) ?? 0) + 1
+      );
+    }
+    const assignedAlchemyIds = new Set<string>();
+    for (const candidate of nodeCandidates) {
+      const alchemyId =
+        legacyAlchemyIdCounts.get(candidate.legacyAlchemyId) === 1
+          ? candidate.legacyAlchemyId
+          : disambiguatedAlchemyResourceId(
+              candidate.legacyAlchemyId,
+              candidate.resource,
+              candidate.logicalId
+            );
+      if (assignedAlchemyIds.has(alchemyId)) {
+        throw new ValidationError(
+          `Direct Alchemy materialization could not derive a unique declaration ID for ` +
+            `${candidate.resource.apiVersion}/${candidate.resource.kind} ` +
+            `${candidate.resource.metadata?.namespace ? `${candidate.resource.metadata.namespace}/` : ''}` +
+            `${candidate.resource.metadata?.name ?? '<unnamed>'}. Give each graph resource a distinct explicit id.`,
+          candidate.resource.kind,
+          candidate.logicalId,
+          'id'
+        );
+      }
+      assignedAlchemyIds.add(alchemyId);
+      byGraphId.set(candidate.graphId, {
+        resource: candidate.resource,
+        alchemyId,
+        logicalId: candidate.logicalId,
       });
     }
 
@@ -2838,6 +2875,27 @@ function findUnresolvedReferences(
   }
 
   return refs;
+}
+
+/**
+ * Preserve the historical declaration ID for every non-colliding resource.
+ * A collision means no prior Alchemy stack could have materialized the set, so
+ * it is safe to add an identity suffix only at that boundary.
+ */
+function disambiguatedAlchemyResourceId(
+  legacyId: string,
+  resource: Enhanced<unknown, unknown>,
+  logicalId: string
+): string {
+  const identity = JSON.stringify({
+    apiVersion: resource.apiVersion,
+    kind: resource.kind,
+    name: resource.metadata?.name,
+    namespace: resource.metadata?.namespace,
+    logicalId,
+  });
+  const suffix = createHash('sha256').update(identity, 'utf8').digest('hex').slice(0, 12);
+  return `${legacyId}Identity${suffix}`;
 }
 
 /**

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -1689,7 +1689,13 @@ export class DirectResourceFactoryImpl<
                 ...(artifactOutputUses.length > 0 ? { artifactOutputUses } : {}),
               }
             : {}),
-          namespace: this.namespace,
+          // Alchemy persists this field as the deployed Kubernetes identity
+          // namespace. A direct composition may author resources outside the
+          // factory's default namespace, so carrying only `this.namespace`
+          // makes drift reconciliation compare against the wrong identity.
+          // Match the KRO artifact emitter: prefer the concrete manifest
+          // namespace and use the factory namespace only as its default.
+          namespace: declarationResource.metadata.namespace ?? this.namespace,
           deploymentStrategy: 'direct' as const,
           kubeConfigOptions,
           options: { waitForReady, ...(timeout !== undefined && { timeout }) },

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -2924,7 +2924,7 @@ function directAlchemyKubernetesIdentity(
       ? undefined
       : resource.metadata?.namespace ?? factoryNamespace;
   const identity = {
-    apiVersion: resource.apiVersion,
+    group: kubernetesApiGroup(resource.apiVersion),
     kind: resource.kind,
     name: resource.metadata?.name,
     namespace,
@@ -2932,9 +2932,14 @@ function directAlchemyKubernetesIdentity(
   return {
     key: JSON.stringify(identity),
     display:
-      `${identity.apiVersion}/${identity.kind} ` +
+      `${resource.apiVersion}/${identity.kind} ` +
       `${namespace ? `${namespace}/` : ''}${identity.name ?? '<unnamed>'}`,
   };
+}
+
+function kubernetesApiGroup(apiVersion: string): string {
+  const separator = apiVersion.indexOf('/');
+  return separator === -1 ? '' : apiVersion.slice(0, separator);
 }
 
 /**

--- a/src/core/deployment/errors.ts
+++ b/src/core/deployment/errors.ts
@@ -6,7 +6,11 @@
  */
 
 import { TypeKroError } from '../errors.js';
-import type { DeployedResource, ResourceDeletionResult } from '../types/deployment.js';
+import type {
+  DeletionResourceIdentity,
+  DeployedResource,
+  ResourceDeletionResult,
+} from '../types/deployment.js';
 
 // =============================================================================
 // DEPLOYMENT ERROR CLASSES
@@ -103,16 +107,39 @@ export class ServerSideApplyConflictError extends TypeKroError {
 
 /** Replacement cannot proceed until Kubernetes confirms that the old object is absent. */
 export class ResourceReplacementTimeoutError extends TypeKroError {
-  constructor(resourceName: string, resourceKind: string, timeout: number) {
+  constructor(
+    resourceName: string,
+    resourceKind: string,
+    timeout: number,
+    public readonly resource?: DeletionResourceIdentity
+  ) {
+    const namespacePrefix = resource?.namespace ? `${resource.namespace}/` : '';
+    const uid = resource?.uid ? ` UID ${resource.uid}` : '';
+    const deletionTimestamp = resource?.deletionTimestamp
+      ? ` deletion requested at ${resource.deletionTimestamp}`
+      : '';
+    const finalizers = resource?.finalizers?.length
+      ? ` blocking finalizers: ${resource.finalizers.join(', ')}`
+      : '';
+    const owners = resource?.owners?.length
+      ? ` owners: ${resource.owners
+          .map(
+            (owner) =>
+              `${owner.apiVersion}/${owner.kind} ${owner.name}${owner.uid ? ` (${owner.uid})` : ''}`
+          )
+          .join(', ')}`
+      : '';
     super(
-      `Timeout after ${timeout}ms waiting to replace ${resourceKind}/${resourceName}; the previous object still exists.`,
+      `Timeout after ${timeout}ms waiting to replace ${resourceKind}/${namespacePrefix}${resourceName}; ` +
+        `the previous object still exists.${uid}${deletionTimestamp}${finalizers}${owners}`,
       'RESOURCE_REPLACEMENT_TIMEOUT',
       {
         resourceName,
         resourceKind,
         timeoutMs: timeout,
+        ...(resource ? { resource } : {}),
         suggestions: [
-          `Inspect ${resourceKind}/${resourceName} for deletionTimestamp and blocking finalizers`,
+          `Inspect ${resourceKind}/${namespacePrefix}${resourceName} for deletionTimestamp and blocking finalizers`,
           'Increase DeploymentOptions.timeout if deletion is making legitimate progress',
         ],
       }

--- a/src/factories/nats/compositions/nats-bootstrap.ts
+++ b/src/factories/nats/compositions/nats-bootstrap.ts
@@ -132,8 +132,12 @@ export const natsBootstrap = kubernetesComposition(
       chart: 'nats',
       version: spec.version ?? DEFAULT_NATS_VERSION,
       values: serverValues,
-      repositoryName,
-      repositoryNamespace,
+      // Carry the repository proxy through sourceRef instead of repeating its
+      // concrete identity. TypeKro can then preserve the real dependency in
+      // direct Alchemy materialization: repository before releases on create,
+      // releases before repository on destroy.
+      repositoryName: _repository.metadata.name,
+      repositoryNamespace: _repository.metadata.namespace,
       repositoryUrl,
     });
     const controller = natsHelmRelease({
@@ -143,10 +147,12 @@ export const natsBootstrap = kubernetesComposition(
       chart: 'nack',
       version: spec.nackVersion ?? DEFAULT_NACK_VERSION,
       values: nackValues,
-      repositoryName,
-      repositoryNamespace,
+      repositoryName: _repository.metadata.name,
+      repositoryNamespace: _repository.metadata.namespace,
       repositoryUrl,
     });
+    server.dependsOn(_repository);
+    controller.dependsOn(_repository);
     return {
       ...helmReleaseConditionSummary(server, controller),
       serverVersion: spec.version ?? DEFAULT_NATS_VERSION,

--- a/src/factories/nats/compositions/nats-bootstrap.ts
+++ b/src/factories/nats/compositions/nats-bootstrap.ts
@@ -132,12 +132,8 @@ export const natsBootstrap = kubernetesComposition(
       chart: 'nats',
       version: spec.version ?? DEFAULT_NATS_VERSION,
       values: serverValues,
-      // Carry the repository proxy through sourceRef instead of repeating its
-      // concrete identity. TypeKro can then preserve the real dependency in
-      // direct Alchemy materialization: repository before releases on create,
-      // releases before repository on destroy.
-      repositoryName: _repository.metadata.name,
-      repositoryNamespace: _repository.metadata.namespace,
+      repositoryName,
+      repositoryNamespace,
       repositoryUrl,
     });
     const controller = natsHelmRelease({
@@ -147,10 +143,13 @@ export const natsBootstrap = kubernetesComposition(
       chart: 'nack',
       version: spec.nackVersion ?? DEFAULT_NACK_VERSION,
       values: nackValues,
-      repositoryName: _repository.metadata.name,
-      repositoryNamespace: _repository.metadata.namespace,
+      repositoryName,
+      repositoryNamespace,
       repositoryUrl,
     });
+    // The sourceRef values are Kubernetes identity, while these explicit
+    // graph edges are lifecycle authority: repository before releases on
+    // create, releases before repository on destroy.
     server.dependsOn(_repository);
     controller.dependsOn(_repository);
     return {

--- a/src/factories/nats/compositions/nats-bootstrap.ts
+++ b/src/factories/nats/compositions/nats-bootstrap.ts
@@ -83,9 +83,16 @@ export const natsBootstrap = kubernetesComposition(
       natsBox: { enabled: true },
       statefulSet: {
         merge: {
-          persistentVolumeClaimRetentionPolicy: {
-            whenDeleted: pvcWhenDeleted,
-            whenScaled: 'Retain',
+          // The official chart merges this object into the StatefulSet root,
+          // so Kubernetes spec fields must remain nested below `spec`.
+          // Emitting the retention policy directly below `merge` produces an
+          // invalid top-level StatefulSet field that Flux cannot server-side
+          // apply.
+          spec: {
+            persistentVolumeClaimRetentionPolicy: {
+              whenDeleted: pvcWhenDeleted,
+              whenScaled: 'Retain',
+            },
           },
         },
       },

--- a/test/core/direct-factory.test.ts
+++ b/test/core/direct-factory.test.ts
@@ -533,6 +533,44 @@ describe('DirectResourceFactory', () => {
       ).toEqual(['namespace-a', 'namespace-b']);
     });
 
+    it('rejects multiple graph nodes that target one canonical Kubernetes identity', async () => {
+      const duplicateIdentity = toResourceGraph(
+        {
+          name: 'duplicate-kubernetes-identity',
+          apiVersion: 'v1alpha1',
+          kind: 'DuplicateKubernetesIdentity',
+          spec: WebAppSpecSchema,
+          status: WebAppStatusSchema,
+        },
+        () => ({
+          first: simple.ConfigMap({
+            name: 'shared-name',
+            namespace: 'namespace-a',
+            data: { owner: 'first' },
+            id: 'firstSharedConfig',
+          }),
+          second: simple.ConfigMap({
+            name: 'shared-name',
+            namespace: 'namespace-a',
+            data: { owner: 'second' },
+            id: 'secondSharedConfig',
+          }),
+        }),
+        () => ({
+          phase: 'running' as const,
+          url: 'http://duplicate-kubernetes-identity',
+          readyReplicas: 1,
+        })
+      );
+      const factory = await duplicateIdentity.factory('direct', {
+        namespace: 'control-plane',
+      });
+
+      await expect(factory.toAlchemyResources(spec)).rejects.toThrow(
+        /same Kubernetes object.*firstSharedConfig.*secondSharedConfig.*exactly one Alchemy owner/
+      );
+    });
+
     it('topologically orders declarations and wires dependsOn from the dependency graph', async () => {
       const composition = makeGraph();
       const plan = composition.plan!(spec, { strict: true });

--- a/test/core/direct-factory.test.ts
+++ b/test/core/direct-factory.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
-import { Cel, simple, toResourceGraph } from '../../src/index.js';
+import { Cel, createResource, simple, toResourceGraph } from '../../src/index.js';
 import { decodeDirectArtifactExecutionRecord } from '../../src/experimental-planning.js';
 
 describe('DirectResourceFactory', () => {
@@ -568,6 +568,46 @@ describe('DirectResourceFactory', () => {
 
       await expect(factory.toAlchemyResources(spec)).rejects.toThrow(
         /same Kubernetes object.*firstSharedConfig.*secondSharedConfig.*exactly one Alchemy owner/
+      );
+    });
+
+    it('treats served versions in one API group as the same Kubernetes identity', async () => {
+      const versionSkew = toResourceGraph(
+        {
+          name: 'version-skew-kubernetes-identity',
+          apiVersion: 'v1alpha1',
+          kind: 'VersionSkewKubernetesIdentity',
+          spec: WebAppSpecSchema,
+          status: WebAppStatusSchema,
+        },
+        () => ({
+          alpha: createResource({
+            id: 'alphaWidget',
+            apiVersion: 'widgets.example.com/v1alpha1',
+            kind: 'Widget',
+            metadata: { name: 'shared-name', namespace: 'namespace-a' },
+            spec: { owner: 'alpha' },
+          }).withReadinessEvaluator(() => ({ ready: true })),
+          beta: createResource({
+            id: 'betaWidget',
+            apiVersion: 'widgets.example.com/v1beta1',
+            kind: 'Widget',
+            metadata: { name: 'shared-name', namespace: 'namespace-a' },
+            spec: { owner: 'beta' },
+          }).withReadinessEvaluator(() => ({ ready: true })),
+        }),
+        () => ({
+          phase: 'running' as const,
+          url: 'http://version-skew-kubernetes-identity',
+          readyReplicas: 1,
+        })
+      );
+      const factory = await versionSkew.factory('direct', {
+        namespace: 'control-plane',
+      });
+
+      await expect(factory.toAlchemyResources(spec)).rejects.toThrow(
+        /same Kubernetes object.*alphaWidget.*betaWidget.*exactly one Alchemy owner/
       );
     });
 

--- a/test/core/direct-factory.test.ts
+++ b/test/core/direct-factory.test.ts
@@ -454,6 +454,38 @@ describe('DirectResourceFactory', () => {
       expect(decls[0]!.id).not.toBe(decls[1]!.id);
     });
 
+    it('persists an explicitly authored resource namespace instead of the factory default', async () => {
+      const crossNamespace = toResourceGraph(
+        {
+          name: 'cross-namespace',
+          apiVersion: 'v1alpha1',
+          kind: 'CrossNamespace',
+          spec: WebAppSpecSchema,
+          status: WebAppStatusSchema,
+        },
+        (schema) => ({
+          config: simple.ConfigMap({
+            name: Cel.template('%s-config', schema.spec.name),
+            namespace: 'workloads',
+            data: { contract: 'manifest-namespace-is-the-deployed-identity' },
+            id: 'crossNamespaceConfig',
+          }),
+        }),
+        () => ({
+          phase: 'running' as const,
+          url: 'http://cross-namespace',
+          readyReplicas: 1,
+        })
+      );
+      const factory = await crossNamespace.factory('direct', {
+        namespace: 'control-plane',
+      });
+      const [declaration] = await factory.toAlchemyResources(spec);
+
+      expect(declaration?.props.resource.metadata.namespace).toBe('workloads');
+      expect(declaration?.props.namespace).toBe('workloads');
+    });
+
     it('topologically orders declarations and wires dependsOn from the dependency graph', async () => {
       const composition = makeGraph();
       const plan = composition.plan!(spec, { strict: true });

--- a/test/core/direct-factory.test.ts
+++ b/test/core/direct-factory.test.ts
@@ -484,6 +484,53 @@ describe('DirectResourceFactory', () => {
 
       expect(declaration?.props.resource.metadata.namespace).toBe('workloads');
       expect(declaration?.props.namespace).toBe('workloads');
+      expect(declaration?.id).not.toContain('Identity');
+    });
+
+    it('disambiguates only colliding legacy IDs with the authored Kubernetes identity', async () => {
+      const crossNamespace = toResourceGraph(
+        {
+          name: 'cross-namespace-collision',
+          apiVersion: 'v1alpha1',
+          kind: 'CrossNamespaceCollision',
+          spec: WebAppSpecSchema,
+          status: WebAppStatusSchema,
+        },
+        () => ({
+          first: simple.ConfigMap({
+            name: 'shared-name',
+            namespace: 'namespace-a',
+            data: { identity: 'namespace-a/shared-name' },
+            id: 'firstSharedConfig',
+          }),
+          second: simple.ConfigMap({
+            name: 'shared-name',
+            namespace: 'namespace-b',
+            data: { identity: 'namespace-b/shared-name' },
+            id: 'secondSharedConfig',
+          }),
+        }),
+        () => ({
+          phase: 'running' as const,
+          url: 'http://cross-namespace-collision',
+          readyReplicas: 1,
+        })
+      );
+      const factory = await crossNamespace.factory('direct', {
+        namespace: 'control-plane',
+      });
+      const first = await factory.toAlchemyResources(spec);
+      const second = await factory.toAlchemyResources(spec);
+
+      expect(first).toHaveLength(2);
+      expect(new Set(first.map((declaration) => declaration.id)).size).toBe(2);
+      expect(first.map((declaration) => declaration.id)).toEqual(
+        second.map((declaration) => declaration.id)
+      );
+      expect(first.every((declaration) => declaration.id.includes('Identity'))).toBe(true);
+      expect(
+        first.map((declaration) => declaration.props.resource.metadata.namespace).sort()
+      ).toEqual(['namespace-a', 'namespace-b']);
     });
 
     it('topologically orders declarations and wires dependsOn from the dependency graph', async () => {

--- a/test/factories/nats/factory-modes.test.ts
+++ b/test/factories/nats/factory-modes.test.ts
@@ -87,7 +87,7 @@ describe('NATS and JetStream factories', () => {
     expect(yaml).toContain('url: nats://nats.nats-system.svc:4222');
     expect(yaml).toContain('fullnameOverride: nats');
     expect(yaml).toMatch(
-      /persistentVolumeClaimRetentionPolicy:\s*\n\s+whenDeleted: Retain\s*\n\s+whenScaled: Retain/
+      /statefulSet:\s*\n\s+merge:\s*\n\s+spec:\s*\n\s+persistentVolumeClaimRetentionPolicy:\s*\n\s+whenDeleted: Retain\s*\n\s+whenScaled: Retain/
     );
 
     const ephemeral = natsBootstrap.factory('direct', { namespace: 'typekro-system' }).toYaml({
@@ -96,7 +96,7 @@ describe('NATS and JetStream factories', () => {
       pvcRetentionPolicy: 'delete',
     });
     expect(ephemeral).toMatch(
-      /persistentVolumeClaimRetentionPolicy:\s*\n\s+whenDeleted: Delete\s*\n\s+whenScaled: Retain/
+      /statefulSet:\s*\n\s+merge:\s*\n\s+spec:\s*\n\s+persistentVolumeClaimRetentionPolicy:\s*\n\s+whenDeleted: Delete\s*\n\s+whenScaled: Retain/
     );
 
     const externallyOwnedNamespace = natsBootstrap

--- a/test/factories/nats/factory-modes.test.ts
+++ b/test/factories/nats/factory-modes.test.ts
@@ -180,6 +180,28 @@ describe('NATS and JetStream factories', () => {
     expect(external).not.toContain('typekro.io/kro-instance-namespace');
   });
 
+  it('orders the repository before both releases in direct Alchemy materialization', async () => {
+    const declarations = await natsBootstrap
+      .factory('direct', { namespace: 'typekro-system', waitForReady: false })
+      .toAlchemyResources({
+        name: 'application-events',
+        namespace: 'application-system',
+        namespaceOwnership: 'external',
+      });
+    const byResourceId = new Map(
+      declarations.map((declaration) => [declaration.props.resourceId, declaration]),
+    );
+    const repository = byResourceId.get('natsHelmRepository');
+    const server = byResourceId.get('natsHelmRelease');
+    const controller = byResourceId.get('nackHelmRelease');
+
+    expect(repository).toBeDefined();
+    expect(server?.dependsOn).toContain(repository?.id);
+    expect(controller?.dependsOn).toContain(repository?.id);
+    expect(declarations.indexOf(repository!)).toBeLessThan(declarations.indexOf(server!));
+    expect(declarations.indexOf(repository!)).toBeLessThan(declarations.indexOf(controller!));
+  });
+
   it('rejects non-positive and fractional replica counts', () => {
     const factory = natsBootstrap.factory('direct', { namespace: 'typekro-system' });
     expect(() => factory.toYaml({ name: 'nats', replicas: 0 })).toThrow();

--- a/test/integration/alchemy/persisted-drift-e2e.test.ts
+++ b/test/integration/alchemy/persisted-drift-e2e.test.ts
@@ -431,4 +431,92 @@ describeOrSkip('Alchemy persisted-state live drift (e2e)', () => {
 
     await waitForResourceAbsent(identity, kubeConfig);
   });
+
+  it('preserves a cross-namespace resource when only its data changes', async () => {
+    const token = crypto.randomUUID().slice(0, 8);
+    const resourceNamespace = `tk-alchemy-cross-ns-${token}`;
+    const factoryNamespace = 'default';
+    const name = `tk-alchemy-cross-resource-${token}`;
+    const kubeConfig = getIntegrationTestKubeConfig();
+    const objectApi = createKubernetesObjectApiClient(kubeConfig);
+    const namespaceLease = await createTestNamespace(resourceNamespace, kubeConfig);
+    const options = { providers: kroProvider };
+    const scratch = Test.scratchStack(options, `tk-alchemy-cross-ns-${token}`);
+    const declarationFor = (revision: string) =>
+      Effect.gen(function* () {
+        return yield* KroResource('applicationContract', {
+          resource: simple.ConfigMap({
+            name,
+            namespace: resourceNamespace,
+            data: {
+              contract: 'factory-namespace-is-not-resource-identity',
+              revision,
+            },
+          }),
+          namespace: factoryNamespace,
+          deploymentStrategy: 'direct',
+          kubeConfigOptions: { loadFromDefault: true },
+        });
+      });
+    const run = <A>(effect: Effect.Effect<A, unknown, unknown>): Promise<A> =>
+      Test.run(effect as never, options as never) as Promise<A>;
+    const firstDeclaration = declarationFor('one');
+    const secondDeclaration = declarationFor('two');
+    const identity = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { namespace: resourceNamespace, name },
+    };
+    const cleanup = async (): Promise<void> => {
+      const cleanupErrors: unknown[] = [];
+      try {
+        await run(scratch.destroy());
+      } catch (error: unknown) {
+        cleanupErrors.push(error);
+      }
+      try {
+        await deleteTestNamespaceAndWait(namespaceLease, kubeConfig);
+      } catch (error: unknown) {
+        cleanupErrors.push(error);
+      }
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(
+          cleanupErrors,
+          'Failed to clean up cross-namespace identity test'
+        );
+      }
+    };
+
+    try {
+      await run(scratch.deploy(firstDeclaration));
+      const first = await objectApi.read(identity);
+      const firstUid = first.metadata?.uid;
+      expect(firstUid).toBeString();
+      if (!firstUid) {
+        throw new Error(
+          `ConfigMap ${resourceNamespace}/${name} did not receive a Kubernetes UID`
+        );
+      }
+      expect((first as { data?: Record<string, string> }).data?.revision).toBe('one');
+
+      const plan = await run(scratch.plan(secondDeclaration));
+      expect(Object.values(plan.resources).some((resource) => resource.action === 'update')).toBe(
+        true
+      );
+
+      await run(scratch.deploy(secondDeclaration));
+      const updated = await objectApi.read(identity);
+      expect(updated.metadata?.uid).toBe(firstUid);
+      expect((updated as { data?: Record<string, string> }).data?.revision).toBe('two');
+
+      const convergedPlan = await run(scratch.plan(secondDeclaration));
+      expect(
+        Object.values(convergedPlan.resources).every((resource) => resource.action === 'noop')
+      ).toBe(true);
+    } finally {
+      await cleanup();
+    }
+
+    await waitForResourceAbsent(identity, kubeConfig);
+  });
 });

--- a/test/integration/alchemy/persisted-drift-e2e.test.ts
+++ b/test/integration/alchemy/persisted-drift-e2e.test.ts
@@ -7,13 +7,18 @@
  * drive its ordinary convergent reconcile, then return to a real no-op.
  */
 import { describe, expect, it, setDefaultTimeout } from 'bun:test';
+import * as Provider from 'alchemy/Provider';
+import type { Resource as AlchemyResource } from 'alchemy/Resource';
+import { Resource as defineAlchemyResource } from 'alchemy/Resource';
 import * as Test from 'alchemy/Test/Core';
-import { Effect } from 'effect';
+import { Effect, Layer } from 'effect';
 import { KroResource, kroProvider } from '../../../src/alchemy/index.js';
 import { simple } from '../../../src/index.js';
 import {
   createCoreV1ApiClient,
   createKubernetesObjectApiClient,
+  createTestNamespace,
+  deleteTestNamespaceAndWait,
   getIntegrationTestKubeConfig,
   isClusterAvailable,
   isNotFoundError,
@@ -24,6 +29,22 @@ setDefaultTimeout(300_000);
 
 const clusterAvailable = await isClusterAvailable();
 const describeOrSkip = clusterAvailable ? describe : describe.skip;
+
+type NamespaceSourceResource = AlchemyResource<
+  'TypeKro.Test.NamespaceSource',
+  { namespace: string },
+  { namespace: string }
+>;
+
+const NamespaceSource = defineAlchemyResource<NamespaceSourceResource>(
+  'TypeKro.Test.NamespaceSource'
+);
+const namespaceSourceProvider = Provider.succeed(NamespaceSource, {
+  read: ({ output }) => Effect.succeed(output),
+  list: () => Effect.succeed([]),
+  reconcile: ({ news }) => Effect.succeed({ namespace: news.namespace }),
+  delete: () => Effect.void,
+});
 
 describeOrSkip('Alchemy persisted-state live drift (e2e)', () => {
   it('recreates an externally deleted direct resource and then plans noop', async () => {
@@ -236,5 +257,83 @@ describeOrSkip('Alchemy persisted-state live drift (e2e)', () => {
     }
 
     await waitForResourceAbsent(identity, kubeConfig);
+  });
+
+  it('replaces a namespaced identity when its namespace is supplied by an unresolved output', async () => {
+    const token = crypto.randomUUID().slice(0, 8);
+    const firstNamespace = `tk-alchemy-ns-old-${token}`;
+    const secondNamespace = `tk-alchemy-ns-new-${token}`;
+    const name = `tk-alchemy-output-ns-${token}`;
+    const kubeConfig = getIntegrationTestKubeConfig();
+    const objectApi = createKubernetesObjectApiClient(kubeConfig);
+    const firstLease = await createTestNamespace(firstNamespace, kubeConfig);
+    const secondLease = await createTestNamespace(secondNamespace, kubeConfig);
+    const providers = Layer.mergeAll(kroProvider, namespaceSourceProvider);
+    const options = { providers };
+    const scratch = Test.scratchStack(options, `tk-alchemy-output-ns-${token}`);
+    const declarationFor = (namespace: string) =>
+      Effect.gen(function* () {
+        const source = yield* NamespaceSource('targetNamespace', { namespace });
+        return yield* KroResource('applicationContract', {
+          resource: simple.ConfigMap({
+            name,
+            namespace: source.namespace as unknown as string,
+            data: { contract: 'namespace-output-must-replace-identity' },
+          }),
+          namespace: source.namespace,
+          deploymentStrategy: 'direct',
+          kubeConfigOptions: { loadFromDefault: true },
+        });
+      });
+    const run = <A>(effect: Effect.Effect<A, unknown, unknown>): Promise<A> =>
+      Test.run(effect as never, options as never) as Promise<A>;
+    const firstDeclaration = declarationFor(firstNamespace);
+    const secondDeclaration = declarationFor(secondNamespace);
+    const firstIdentity = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { namespace: firstNamespace, name },
+    };
+    const secondIdentity = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { namespace: secondNamespace, name },
+    };
+    const cleanup = async (): Promise<void> => {
+      const cleanupErrors: unknown[] = [];
+      try {
+        await run(scratch.destroy());
+      } catch (error: unknown) {
+        cleanupErrors.push(error);
+      }
+      for (const lease of [firstLease, secondLease]) {
+        try {
+          await deleteTestNamespaceAndWait(lease, kubeConfig);
+        } catch (error: unknown) {
+          cleanupErrors.push(error);
+        }
+      }
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(cleanupErrors, 'Failed to clean up namespace-output drift test');
+      }
+    };
+
+    try {
+      await run(scratch.deploy(firstDeclaration));
+      await expect(objectApi.read(firstIdentity)).resolves.toBeDefined();
+
+      const plan = await run(scratch.plan(secondDeclaration));
+      expect(Object.values(plan.resources).some((resource) => resource.action === 'replace')).toBe(
+        true
+      );
+
+      await run(scratch.deploy(secondDeclaration));
+      await waitForResourceAbsent(firstIdentity, kubeConfig);
+      await expect(objectApi.read(secondIdentity)).resolves.toBeDefined();
+    } finally {
+      await cleanup();
+    }
+
+    await waitForResourceAbsent(secondIdentity, kubeConfig);
   });
 });

--- a/test/integration/alchemy/persisted-drift-e2e.test.ts
+++ b/test/integration/alchemy/persisted-drift-e2e.test.ts
@@ -13,8 +13,10 @@ import { KroResource, kroProvider } from '../../../src/alchemy/index.js';
 import { simple } from '../../../src/index.js';
 import {
   createCoreV1ApiClient,
+  createKubernetesObjectApiClient,
   getIntegrationTestKubeConfig,
   isClusterAvailable,
+  isNotFoundError,
   waitForResourceAbsent,
 } from '../shared-kubeconfig';
 
@@ -56,6 +58,9 @@ describeOrSkip('Alchemy persisted-state live drift (e2e)', () => {
       const first = await coreApi.readNamespacedConfigMap({ namespace, name });
       const firstUid = first.metadata?.uid;
       expect(firstUid).toBeString();
+      if (!firstUid) {
+        throw new Error(`ConfigMap ${namespace}/${name} did not receive a Kubernetes UID`);
+      }
 
       // Simulate external loss while retaining Alchemy's successful state.
       await coreApi.deleteNamespacedConfigMap({ namespace, name });
@@ -65,7 +70,7 @@ describeOrSkip('Alchemy persisted-state live drift (e2e)', () => {
           kind: 'ConfigMap',
           metadata: { namespace, name },
         },
-        kubeConfig,
+        kubeConfig
       );
 
       const driftPlan = await run(scratch.plan(declaration));
@@ -90,7 +95,146 @@ describeOrSkip('Alchemy persisted-state live drift (e2e)', () => {
         kind: 'ConfigMap',
         metadata: { namespace, name },
       },
-      kubeConfig,
+      kubeConfig
     );
+  });
+
+  it('waits for a finalizer-held terminating identity before recreating it', async () => {
+    const namespace = 'default';
+    const name = `tk-alchemy-terminating-${crypto.randomUUID().slice(0, 8)}`;
+    const testFinalizer = 'tests.typekro.dev/hold-termination';
+    const resource = simple.ConfigMap({
+      name,
+      namespace,
+      data: {
+        contract: 'terminating-state-must-not-report-success',
+      },
+    });
+    const declaration = Effect.gen(function* () {
+      return yield* KroResource('terminatingContract', {
+        resource,
+        namespace,
+        deploymentStrategy: 'direct',
+        kubeConfigOptions: {
+          loadFromDefault: true,
+        },
+      });
+    });
+    const options = { providers: kroProvider };
+    const scratch = Test.scratchStack(options, `tk-alchemy-terminating-${name}`);
+    const run = <A>(effect: Effect.Effect<A, unknown, unknown>): Promise<A> =>
+      Test.run(effect as never, options as never) as Promise<A>;
+    const kubeConfig = getIntegrationTestKubeConfig();
+    const coreApi = createCoreV1ApiClient(kubeConfig);
+    const objectApi = createKubernetesObjectApiClient(kubeConfig);
+    const identity = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { namespace, name },
+    };
+    const cleanup = async (): Promise<void> => {
+      const cleanupErrors: unknown[] = [];
+      try {
+        const live = await objectApi.read(identity);
+        if (live.metadata?.finalizers?.includes(testFinalizer)) {
+          await objectApi.patch(
+            {
+              ...identity,
+              metadata: {
+                ...identity.metadata,
+                finalizers: [],
+              },
+            },
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            'application/merge-patch+json'
+          );
+        }
+      } catch (error: unknown) {
+        if (!isNotFoundError(error)) cleanupErrors.push(error);
+      }
+      try {
+        await run(scratch.destroy());
+      } catch (error: unknown) {
+        cleanupErrors.push(error);
+      }
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(
+          cleanupErrors,
+          `Failed to clean up finalizer-held drift test ${namespace}/${name}`
+        );
+      }
+    };
+
+    try {
+      await run(scratch.deploy(declaration));
+      const first = await coreApi.readNamespacedConfigMap({ namespace, name });
+      const firstUid = first.metadata?.uid;
+      expect(firstUid).toBeString();
+      if (!firstUid) {
+        throw new Error(`ConfigMap ${namespace}/${name} did not receive a Kubernetes UID`);
+      }
+
+      await objectApi.patch(
+        {
+          ...identity,
+          metadata: {
+            ...identity.metadata,
+            finalizers: [testFinalizer],
+          },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'application/merge-patch+json'
+      );
+      await coreApi.deleteNamespacedConfigMap({ namespace, name });
+      const terminating = await coreApi.readNamespacedConfigMap({ namespace, name });
+      expect(terminating.metadata?.uid).toBe(firstUid);
+      expect(terminating.metadata?.deletionTimestamp).toBeDefined();
+
+      const driftPlan = await run(scratch.plan(declaration));
+      expect(Object.values(driftPlan.resources)).toHaveLength(1);
+      expect(Object.values(driftPlan.resources)[0]?.action).toBe('update');
+
+      let deploymentSettled = false;
+      const deployment = run(scratch.deploy(declaration)).finally(() => {
+        deploymentSettled = true;
+      });
+      await Bun.sleep(1_000);
+      expect(deploymentSettled).toBe(false);
+
+      await objectApi.patch(
+        {
+          ...identity,
+          metadata: {
+            ...identity.metadata,
+            finalizers: [],
+          },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'application/merge-patch+json'
+      );
+      await deployment;
+
+      const replacement = await coreApi.readNamespacedConfigMap({ namespace, name });
+      expect(replacement.metadata?.uid).toBeString();
+      expect(replacement.metadata?.uid).not.toBe(firstUid);
+      expect(replacement.metadata?.deletionTimestamp).toBeUndefined();
+
+      const convergedPlan = await run(scratch.plan(declaration));
+      expect(Object.values(convergedPlan.resources)).toHaveLength(1);
+      expect(Object.values(convergedPlan.resources)[0]?.action).toBe('noop');
+    } finally {
+      await cleanup();
+    }
+
+    await waitForResourceAbsent(identity, kubeConfig);
   });
 });

--- a/test/integration/alchemy/persisted-drift-e2e.test.ts
+++ b/test/integration/alchemy/persisted-drift-e2e.test.ts
@@ -32,8 +32,8 @@ const describeOrSkip = clusterAvailable ? describe : describe.skip;
 
 type NamespaceSourceResource = AlchemyResource<
   'TypeKro.Test.NamespaceSource',
-  { namespace: string },
-  { namespace: string }
+  { namespace: string; revision?: string },
+  { namespace: string; revision?: string }
 >;
 
 const NamespaceSource = defineAlchemyResource<NamespaceSourceResource>(
@@ -42,7 +42,11 @@ const NamespaceSource = defineAlchemyResource<NamespaceSourceResource>(
 const namespaceSourceProvider = Provider.succeed(NamespaceSource, {
   read: ({ output }) => Effect.succeed(output),
   list: () => Effect.succeed([]),
-  reconcile: ({ news }) => Effect.succeed({ namespace: news.namespace }),
+  reconcile: ({ news }) =>
+    Effect.succeed({
+      namespace: news.namespace,
+      ...(news.revision ? { revision: news.revision } : {}),
+    }),
   delete: () => Effect.void,
 });
 
@@ -323,7 +327,7 @@ describeOrSkip('Alchemy persisted-state live drift (e2e)', () => {
       await expect(objectApi.read(firstIdentity)).resolves.toBeDefined();
 
       const plan = await run(scratch.plan(secondDeclaration));
-      expect(Object.values(plan.resources).some((resource) => resource.action === 'replace')).toBe(
+      expect(Object.values(plan.resources).some((resource) => resource.action === 'update')).toBe(
         true
       );
 
@@ -335,5 +339,96 @@ describeOrSkip('Alchemy persisted-state live drift (e2e)', () => {
     }
 
     await waitForResourceAbsent(secondIdentity, kubeConfig);
+  });
+
+  it('preserves an updated resource when an unresolved namespace resolves to the same identity', async () => {
+    const token = crypto.randomUUID().slice(0, 8);
+    const namespace = `tk-alchemy-ns-stable-${token}`;
+    const name = `tk-alchemy-output-stable-${token}`;
+    const kubeConfig = getIntegrationTestKubeConfig();
+    const objectApi = createKubernetesObjectApiClient(kubeConfig);
+    const namespaceLease = await createTestNamespace(namespace, kubeConfig);
+    const providers = Layer.mergeAll(kroProvider, namespaceSourceProvider);
+    const options = { providers };
+    const scratch = Test.scratchStack(options, `tk-alchemy-output-stable-${token}`);
+    const declarationFor = (revision: string) =>
+      Effect.gen(function* () {
+        const source = yield* NamespaceSource('targetNamespace', {
+          namespace,
+          revision,
+        });
+        return yield* KroResource('applicationContract', {
+          resource: simple.ConfigMap({
+            name,
+            namespace: source.namespace as unknown as string,
+            data: {
+              contract: 'same-output-namespace-must-preserve-updated-resource',
+              revision: source.revision as unknown as string,
+            },
+          }),
+          namespace: source.namespace,
+          deploymentStrategy: 'direct',
+          kubeConfigOptions: { loadFromDefault: true },
+        });
+      });
+    const run = <A>(effect: Effect.Effect<A, unknown, unknown>): Promise<A> =>
+      Test.run(effect as never, options as never) as Promise<A>;
+    const firstDeclaration = declarationFor('one');
+    const secondDeclaration = declarationFor('two');
+    const identity = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { namespace, name },
+    };
+    const cleanup = async (): Promise<void> => {
+      const cleanupErrors: unknown[] = [];
+      try {
+        await run(scratch.destroy());
+      } catch (error: unknown) {
+        cleanupErrors.push(error);
+      }
+      try {
+        await deleteTestNamespaceAndWait(namespaceLease, kubeConfig);
+      } catch (error: unknown) {
+        cleanupErrors.push(error);
+      }
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(
+          cleanupErrors,
+          'Failed to clean up stable namespace-output drift test'
+        );
+      }
+    };
+
+    try {
+      await run(scratch.deploy(firstDeclaration));
+      const first = await objectApi.read(identity);
+      const firstUid = first.metadata?.uid;
+      expect(firstUid).toBeString();
+      if (!firstUid) {
+        throw new Error(`ConfigMap ${namespace}/${name} did not receive a Kubernetes UID`);
+      }
+      expect((first as { data?: Record<string, string> }).data?.revision).toBe('one');
+
+      const plan = await run(scratch.plan(secondDeclaration));
+      expect(Object.values(plan.resources).some((resource) => resource.action === 'update')).toBe(
+        true
+      );
+
+      await run(scratch.deploy(secondDeclaration));
+      const updated = await objectApi.read(identity);
+      expect(updated.metadata?.uid).toBeString();
+      expect(updated.metadata?.uid).toBe(firstUid);
+      expect((updated as { data?: Record<string, string> }).data?.revision).toBe('two');
+
+      const convergedPlan = await run(scratch.plan(secondDeclaration));
+      expect(
+        Object.values(convergedPlan.resources).every((resource) => resource.action === 'noop')
+      ).toBe(true);
+    } finally {
+      await cleanup();
+    }
+
+    await waitForResourceAbsent(identity, kubeConfig);
   });
 });

--- a/test/integration/alchemy/persisted-drift-e2e.test.ts
+++ b/test/integration/alchemy/persisted-drift-e2e.test.ts
@@ -1,0 +1,96 @@
+/**
+ * E2E (live cluster): persisted Alchemy state must not turn an absent
+ * Kubernetes object into a false no-op.
+ *
+ * The out-of-band ConfigMap deletion is deliberate failure injection. The
+ * TypeKro provider must detect the missing live object during the next plan,
+ * drive its ordinary convergent reconcile, then return to a real no-op.
+ */
+import { describe, expect, it, setDefaultTimeout } from 'bun:test';
+import * as Test from 'alchemy/Test/Core';
+import { Effect } from 'effect';
+import { KroResource, kroProvider } from '../../../src/alchemy/index.js';
+import { simple } from '../../../src/index.js';
+import {
+  createCoreV1ApiClient,
+  getIntegrationTestKubeConfig,
+  isClusterAvailable,
+  waitForResourceAbsent,
+} from '../shared-kubeconfig';
+
+setDefaultTimeout(300_000);
+
+const clusterAvailable = await isClusterAvailable();
+const describeOrSkip = clusterAvailable ? describe : describe.skip;
+
+describeOrSkip('Alchemy persisted-state live drift (e2e)', () => {
+  it('recreates an externally deleted direct resource and then plans noop', async () => {
+    const namespace = 'default';
+    const name = `tk-alchemy-drift-${crypto.randomUUID().slice(0, 8)}`;
+    const resource = simple.ConfigMap({
+      name,
+      namespace,
+      data: {
+        contract: 'persisted-state-must-match-live-state',
+      },
+    });
+    const declaration = Effect.gen(function* () {
+      return yield* KroResource('applicationContract', {
+        resource,
+        namespace,
+        deploymentStrategy: 'direct',
+        kubeConfigOptions: {
+          loadFromDefault: true,
+        },
+      });
+    });
+    const options = { providers: kroProvider };
+    const scratch = Test.scratchStack(options, `tk-alchemy-drift-${namespace}`);
+    const run = <A>(effect: Effect.Effect<A, unknown, unknown>): Promise<A> =>
+      Test.run(effect as never, options as never) as Promise<A>;
+    const kubeConfig = getIntegrationTestKubeConfig();
+    const coreApi = createCoreV1ApiClient(kubeConfig);
+
+    try {
+      await run(scratch.deploy(declaration));
+      const first = await coreApi.readNamespacedConfigMap({ namespace, name });
+      const firstUid = first.metadata?.uid;
+      expect(firstUid).toBeString();
+
+      // Simulate external loss while retaining Alchemy's successful state.
+      await coreApi.deleteNamespacedConfigMap({ namespace, name });
+      await waitForResourceAbsent(
+        {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          metadata: { namespace, name },
+        },
+        kubeConfig,
+      );
+
+      const driftPlan = await run(scratch.plan(declaration));
+      expect(Object.values(driftPlan.resources)).toHaveLength(1);
+      expect(Object.values(driftPlan.resources)[0]?.action).toBe('update');
+
+      await run(scratch.deploy(declaration));
+      const replacement = await coreApi.readNamespacedConfigMap({ namespace, name });
+      expect(replacement.metadata?.uid).toBeString();
+      expect(replacement.metadata?.uid).not.toBe(firstUid);
+
+      const convergedPlan = await run(scratch.plan(declaration));
+      expect(Object.values(convergedPlan.resources)).toHaveLength(1);
+      expect(Object.values(convergedPlan.resources)[0]?.action).toBe('noop');
+    } finally {
+      await run(scratch.destroy());
+    }
+
+    await waitForResourceAbsent(
+      {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: { namespace, name },
+      },
+      kubeConfig,
+    );
+  });
+});

--- a/test/unit/alchemy/live-drift.test.ts
+++ b/test/unit/alchemy/live-drift.test.ts
@@ -183,13 +183,13 @@ describe('Alchemy persisted TypeKro resource drift', () => {
     expect(shouldReplaceKroResourceNamespaceForTest(props, news)).toBe(true);
   });
 
-  it('conservatively replaces when the namespace itself is an unresolved output', () => {
+  it('defers an unresolved namespace identity decision until reconciliation', () => {
     const news: Input<TypeKroResourceProps<Resource>> = {
       ...props,
       namespace: Output.asOutput('replacement-system'),
     };
     expect(Diff.isResolved(news.namespace)).toBe(false);
-    expect(shouldReplaceKroResourceNamespaceForTest(props, news)).toBe(true);
+    expect(shouldReplaceKroResourceNamespaceForTest(props, news)).toBe(false);
   });
 
   it('fails closed when Kubernetes cannot prove live state', async () => {

--- a/test/unit/alchemy/live-drift.test.ts
+++ b/test/unit/alchemy/live-drift.test.ts
@@ -192,6 +192,37 @@ describe('Alchemy persisted TypeKro resource drift', () => {
     expect(shouldReplaceKroResourceNamespaceForTest(props, news)).toBe(false);
   });
 
+  it('does not replace when corrected declaration state matches the persisted live namespace', () => {
+    const namespacedResource = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'application-contract',
+        namespace: 'application-system',
+        uid: 'uid-config',
+      },
+    } as Resource;
+    const legacyProps = {
+      resource: namespacedResource,
+      namespace: 'default',
+      deploymentStrategy: 'direct' as const,
+    };
+    const persistedOutput = {
+      ...legacyProps,
+      deployedResource: namespacedResource,
+      ready: true,
+      deployedAt: 1,
+    };
+    const corrected = {
+      ...legacyProps,
+      namespace: 'application-system',
+    };
+
+    expect(
+      shouldReplaceKroResourceNamespaceForTest(legacyProps, corrected, persistedOutput)
+    ).toBe(false);
+  });
+
   it('fails closed when Kubernetes cannot prove live state', async () => {
     await expect(
       detectKroResourceIdentityDriftForTest(props, output, {

--- a/test/unit/alchemy/live-drift.test.ts
+++ b/test/unit/alchemy/live-drift.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  detectKroResourceIdentityDriftForTest,
+} from '../../../src/alchemy/resource-registration.js';
+import type {
+  TypeKroResource,
+  TypeKroResourceProps,
+} from '../../../src/alchemy/types.js';
+import type {
+  Enhanced,
+  KubernetesResource,
+} from '../../../src/core/types/kubernetes.js';
+
+type Resource = Enhanced<unknown, unknown>;
+
+const deployed: KubernetesResource = {
+  apiVersion: 'v1',
+  kind: 'Namespace',
+  metadata: {
+    name: 'application-system',
+    uid: 'uid-1',
+    resourceVersion: '10',
+  },
+  status: { phase: 'Active' },
+};
+
+const props = {
+  resource: deployed,
+  namespace: 'default',
+  deploymentStrategy: 'direct',
+} as TypeKroResourceProps<Resource>;
+
+const output = {
+  ...props,
+  deployedResource: deployed,
+  ready: true,
+  deployedAt: 1,
+} as TypeKroResource<Resource>;
+
+describe('Alchemy persisted TypeKro resource drift', () => {
+  it('preserves a real no-op across server fields and controller status evolution', async () => {
+    await expect(
+      detectKroResourceIdentityDriftForTest(props, output, {
+        read: async () => ({
+          ...deployed,
+          metadata: {
+            ...deployed.metadata,
+            resourceVersion: '11',
+            labels: { 'server-owned': 'value' },
+          },
+          status: {
+            phase: 'Active',
+            controllerObservation: 'changed-after-readiness',
+          },
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('reconciles an object removed behind persisted Alchemy state', async () => {
+    await expect(
+      detectKroResourceIdentityDriftForTest(props, output, {
+        read: async () => {
+          throw Object.assign(new Error('not found'), { statusCode: 404 });
+        },
+      }),
+    ).resolves.toEqual({ action: 'update' });
+  });
+
+  it('reconciles replacement and deletion', async () => {
+    await expect(
+      detectKroResourceIdentityDriftForTest(props, output, {
+        read: async () => ({
+          ...deployed,
+          metadata: { ...deployed.metadata, uid: 'uid-2' },
+        }),
+      }),
+    ).resolves.toEqual({ action: 'update' });
+
+    await expect(
+      detectKroResourceIdentityDriftForTest(props, output, {
+        read: async () => ({
+          ...deployed,
+          metadata: {
+            ...deployed.metadata,
+            deletionTimestamp: new Date('2026-08-02T00:00:00.000Z'),
+          },
+        }),
+      }),
+    ).resolves.toEqual({ action: 'update' });
+  });
+
+  it('fails closed when Kubernetes cannot prove live state', async () => {
+    await expect(
+      detectKroResourceIdentityDriftForTest(props, output, {
+        read: async () => {
+          throw Object.assign(new Error('forbidden'), { statusCode: 403 });
+        },
+      }),
+    ).rejects.toThrow(
+      'Alchemy drift check could not read v1/Namespace application-system: forbidden',
+    );
+  });
+});

--- a/test/unit/alchemy/live-drift.test.ts
+++ b/test/unit/alchemy/live-drift.test.ts
@@ -117,28 +117,55 @@ describe('Alchemy persisted TypeKro resource drift', () => {
   });
 
   it('fails rather than reporting success while a persisted identity remains terminating', async () => {
-    await expect(
-      waitForPersistedIdentityDeletionForTest(
-        {
-          ...props,
-          options: { timeout: 0 },
+    const owner = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      name: 'namespace-owner',
+      uid: 'owner-uid',
+      controller: true,
+    };
+    const promise = waitForPersistedIdentityDeletionForTest(
+      {
+        ...props,
+        options: { timeout: 0 },
+      },
+      output,
+      undefined,
+      {
+        reader: {
+          read: async () => ({
+            ...deployed,
+            metadata: {
+              ...deployed.metadata,
+              deletionTimestamp: new Date('2026-08-02T00:00:00.000Z'),
+              finalizers: ['tests.typekro.dev/hold-termination'],
+              ownerReferences: [owner],
+            },
+          }),
         },
-        output,
-        undefined,
-        {
-          reader: {
-            read: async () => ({
-              ...deployed,
-              metadata: {
-                ...deployed.metadata,
-                deletionTimestamp: new Date('2026-08-02T00:00:00.000Z'),
-              },
-            }),
-          },
-        }
-      )
-    ).rejects.toThrow(
-      'Timed out waiting for terminating v1/Namespace application-system to disappear before reconciliation'
+      }
+    );
+    await expect(promise).rejects.toMatchObject({
+      name: 'ResourceReplacementTimeoutError',
+      code: 'RESOURCE_REPLACEMENT_TIMEOUT',
+      resource: {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        name: 'application-system',
+        uid: 'uid-1',
+        deletionTimestamp: '2026-08-02T00:00:00.000Z',
+        finalizers: ['tests.typekro.dev/hold-termination'],
+        owners: [owner],
+      },
+      context: {
+        resource: {
+          uid: 'uid-1',
+          finalizers: ['tests.typekro.dev/hold-termination'],
+        },
+      },
+    });
+    await expect(promise).rejects.toThrow(
+      'blocking finalizers: tests.typekro.dev/hold-termination'
     );
   });
 
@@ -153,6 +180,15 @@ describe('Alchemy persisted TypeKro resource drift', () => {
       },
     };
     expect(Diff.isResolved(news)).toBe(false);
+    expect(shouldReplaceKroResourceNamespaceForTest(props, news)).toBe(true);
+  });
+
+  it('conservatively replaces when the namespace itself is an unresolved output', () => {
+    const news: Input<TypeKroResourceProps<Resource>> = {
+      ...props,
+      namespace: Output.asOutput('replacement-system'),
+    };
+    expect(Diff.isResolved(news.namespace)).toBe(false);
     expect(shouldReplaceKroResourceNamespaceForTest(props, news)).toBe(true);
   });
 

--- a/test/unit/alchemy/live-drift.test.ts
+++ b/test/unit/alchemy/live-drift.test.ts
@@ -4,7 +4,7 @@ import type { Input } from 'alchemy/Input';
 import * as Output from 'alchemy/Output';
 import {
   detectKroResourceIdentityDriftForTest,
-  shouldReplaceKroResourceNamespaceForTest,
+  shouldReplaceKroResourceIdentityForTest,
   waitForPersistedIdentityDeletionForTest,
 } from '../../../src/alchemy/resource-registration.js';
 import type { TypeKroResource, TypeKroResourceProps } from '../../../src/alchemy/types.js';
@@ -170,8 +170,32 @@ describe('Alchemy persisted TypeKro resource drift', () => {
   });
 
   it('replaces a changed namespace even when a sibling input is unresolved', () => {
+    const authored = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'application-contract' },
+    } as unknown as Resource;
+    const deployedConfigMap = {
+      ...authored,
+      metadata: {
+        ...authored.metadata,
+        namespace: 'default',
+        uid: 'uid-config-map',
+      },
+    } as unknown as Resource;
+    const oldProps = {
+      resource: authored,
+      namespace: 'default',
+      deploymentStrategy: 'direct' as const,
+    };
+    const oldOutput = {
+      ...oldProps,
+      deployedResource: deployedConfigMap,
+      ready: true,
+      deployedAt: 1,
+    };
     const news: Input<TypeKroResourceProps<Resource>> = {
-      ...props,
+      ...oldProps,
       namespace: 'replacement-system',
       artifactOutputs: {
         image: {
@@ -180,7 +204,9 @@ describe('Alchemy persisted TypeKro resource drift', () => {
       },
     };
     expect(Diff.isResolved(news)).toBe(false);
-    expect(shouldReplaceKroResourceNamespaceForTest(props, news)).toBe(true);
+    expect(
+      shouldReplaceKroResourceIdentityForTest(oldProps, news, oldOutput)
+    ).toBe(true);
   });
 
   it('defers an unresolved namespace identity decision until reconciliation', () => {
@@ -189,7 +215,7 @@ describe('Alchemy persisted TypeKro resource drift', () => {
       namespace: Output.asOutput('replacement-system'),
     };
     expect(Diff.isResolved(news.namespace)).toBe(false);
-    expect(shouldReplaceKroResourceNamespaceForTest(props, news)).toBe(false);
+    expect(shouldReplaceKroResourceIdentityForTest(props, news)).toBe(false);
   });
 
   it('does not replace when corrected declaration state matches the persisted live namespace', () => {
@@ -219,7 +245,76 @@ describe('Alchemy persisted TypeKro resource drift', () => {
     };
 
     expect(
-      shouldReplaceKroResourceNamespaceForTest(legacyProps, corrected, persistedOutput)
+      shouldReplaceKroResourceIdentityForTest(legacyProps, corrected, persistedOutput)
+    ).toBe(false);
+  });
+
+  it('does not mistake a factory namespace for an explicitly namespaced resource identity', () => {
+    const namespacedResource = {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: 'cross-namespace-contract',
+        namespace: 'application-system',
+        uid: 'uid-cross-namespace',
+      },
+      data: { revision: 'one' },
+    } as unknown as Resource;
+    const crossNamespaceProps = {
+      resource: namespacedResource,
+      namespace: 'default',
+      deploymentStrategy: 'direct' as const,
+    };
+    const persistedOutput = {
+      ...crossNamespaceProps,
+      deployedResource: namespacedResource,
+      ready: true,
+      deployedAt: 1,
+    };
+    const updated = {
+      ...crossNamespaceProps,
+      resource: {
+        ...namespacedResource,
+        data: { revision: 'two' },
+      },
+    };
+
+    expect(
+      shouldReplaceKroResourceIdentityForTest(
+        crossNamespaceProps,
+        updated,
+        persistedOutput
+      )
+    ).toBe(false);
+  });
+
+  it('does not assign a factory namespace to a cluster-scoped identity', () => {
+    const clusterResource = {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: {
+        name: 'application-system',
+        uid: 'uid-cluster-scoped',
+      },
+    } as Resource;
+    const clusterProps = {
+      resource: clusterResource,
+      namespace: 'default',
+      deploymentStrategy: 'direct' as const,
+    };
+    const persistedOutput = {
+      ...clusterProps,
+      deployedResource: clusterResource,
+      ready: true,
+      deployedAt: 1,
+    };
+
+    expect(
+      shouldReplaceKroResourceIdentityForTest(
+        clusterProps,
+        { ...clusterProps, namespace: 'other-default' },
+        persistedOutput
+      )
     ).toBe(false);
   });
 

--- a/test/unit/alchemy/live-drift.test.ts
+++ b/test/unit/alchemy/live-drift.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it } from 'bun:test';
+import * as Diff from 'alchemy/Diff';
+import type { Input } from 'alchemy/Input';
+import * as Output from 'alchemy/Output';
 import {
   detectKroResourceIdentityDriftForTest,
+  shouldReplaceKroResourceNamespaceForTest,
+  waitForPersistedIdentityDeletionForTest,
 } from '../../../src/alchemy/resource-registration.js';
-import type {
-  TypeKroResource,
-  TypeKroResourceProps,
-} from '../../../src/alchemy/types.js';
-import type {
-  Enhanced,
-  KubernetesResource,
-} from '../../../src/core/types/kubernetes.js';
+import type { TypeKroResource, TypeKroResourceProps } from '../../../src/alchemy/types.js';
+import type { Enhanced, KubernetesResource } from '../../../src/core/types/kubernetes.js';
 
 type Resource = Enhanced<unknown, unknown>;
 
@@ -53,7 +52,7 @@ describe('Alchemy persisted TypeKro resource drift', () => {
             controllerObservation: 'changed-after-readiness',
           },
         }),
-      }),
+      })
     ).resolves.toBeUndefined();
   });
 
@@ -63,7 +62,7 @@ describe('Alchemy persisted TypeKro resource drift', () => {
         read: async () => {
           throw Object.assign(new Error('not found'), { statusCode: 404 });
         },
-      }),
+      })
     ).resolves.toEqual({ action: 'update' });
   });
 
@@ -74,7 +73,7 @@ describe('Alchemy persisted TypeKro resource drift', () => {
           ...deployed,
           metadata: { ...deployed.metadata, uid: 'uid-2' },
         }),
-      }),
+      })
     ).resolves.toEqual({ action: 'update' });
 
     await expect(
@@ -86,8 +85,75 @@ describe('Alchemy persisted TypeKro resource drift', () => {
             deletionTimestamp: new Date('2026-08-02T00:00:00.000Z'),
           },
         }),
-      }),
+      })
     ).resolves.toEqual({ action: 'update' });
+  });
+
+  it('waits for a terminating persisted identity to reach 404 before reconciliation', async () => {
+    let reads = 0;
+    let sleeps = 0;
+    await waitForPersistedIdentityDeletionForTest(props, output, undefined, {
+      reader: {
+        read: async () => {
+          reads += 1;
+          if (reads === 1) {
+            return {
+              ...deployed,
+              metadata: {
+                ...deployed.metadata,
+                deletionTimestamp: new Date('2026-08-02T00:00:00.000Z'),
+              },
+            };
+          }
+          throw Object.assign(new Error('not found'), { statusCode: 404 });
+        },
+      },
+      sleep: async () => {
+        sleeps += 1;
+      },
+    });
+    expect(reads).toBe(2);
+    expect(sleeps).toBe(1);
+  });
+
+  it('fails rather than reporting success while a persisted identity remains terminating', async () => {
+    await expect(
+      waitForPersistedIdentityDeletionForTest(
+        {
+          ...props,
+          options: { timeout: 0 },
+        },
+        output,
+        undefined,
+        {
+          reader: {
+            read: async () => ({
+              ...deployed,
+              metadata: {
+                ...deployed.metadata,
+                deletionTimestamp: new Date('2026-08-02T00:00:00.000Z'),
+              },
+            }),
+          },
+        }
+      )
+    ).rejects.toThrow(
+      'Timed out waiting for terminating v1/Namespace application-system to disappear before reconciliation'
+    );
+  });
+
+  it('replaces a changed namespace even when a sibling input is unresolved', () => {
+    const news: Input<TypeKroResourceProps<Resource>> = {
+      ...props,
+      namespace: 'replacement-system',
+      artifactOutputs: {
+        image: {
+          digest: Output.asOutput('sha256:pending'),
+        },
+      },
+    };
+    expect(Diff.isResolved(news)).toBe(false);
+    expect(shouldReplaceKroResourceNamespaceForTest(props, news)).toBe(true);
   });
 
   it('fails closed when Kubernetes cannot prove live state', async () => {
@@ -96,9 +162,9 @@ describe('Alchemy persisted TypeKro resource drift', () => {
         read: async () => {
           throw Object.assign(new Error('forbidden'), { statusCode: 403 });
         },
-      }),
+      })
     ).rejects.toThrow(
-      'Alchemy drift check could not read v1/Namespace application-system: forbidden',
+      'Alchemy drift check could not read v1/Namespace application-system: forbidden'
     );
   });
 });


### PR DESCRIPTION
## What changed

- add a TypeKro provider `diff` check that verifies the persisted Kubernetes identity before Alchemy accepts an unchanged resource as a no-op
- reconcile resources that are absent, replaced under a different UID, or already terminating
- fail closed on Kubernetes read/authentication failures
- preserve real no-op behavior across server-managed fields and ordinary controller status evolution
- make the existing namespace-stability contract produce a replacement when a resolved namespace changes

## Root cause

Alchemy calls a provider's `read` hook for cold adoption, but a resource with successful persisted state could plan `noop` without consulting Kubernetes. If that live object had been deleted out of band, downstream resources were deployed against infrastructure that no longer existed. This surfaced in Applik8s when a persisted direct Namespace was absent from OrbStack but Alchemy retained the old successful output.

## Validation

- `bun run typecheck`
- `bun run build`
- `bun run lint`
- `git diff --check`
- 277 focused Alchemy and KRO characterization tests passed
- live OrbStack regression passed: create direct ConfigMap through Alchemy, delete it out of band, assert the next plan is `update`, redeploy, assert a new UID, then assert the converged plan is `noop` and clean up through Alchemy