### PR TITLE
chore(release): v0.33.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Release

- publish the persisted Alchemy live-drift reconciliation fix
- preserve canonical Kubernetes ownership across namespaces and served API versions
- include NATS dependency ordering and JetStream retention corrections validated during the fix

## Validation

- PR #135 CI passed
- focused unit and characterization tests passed
- OrbStack persisted-drift integration suite passed (5/5)
- typecheck and lint passed