### PR TITLE
fix: plan open objects and managed Ory secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Semantic planning now represents ArkType's explicitly open `object` and
+  `object[]` nodes instead of rejecting chart-value passthrough fields as
+  unsupported. The Kubernetes Secret factory also records its exact
+  lowercase factory provenance, so managed Ory platform compositions produce
+  valid strict plans when both `Secret` registrations are loaded.
 - **Arktype `object` now maps to KRO `object` instead of `string`.** A bare `type('object')` is represented by
   arktype as the string `"object"`, which the KRO type mapper had no case for, so it fell through to the
   `string` default. Every schemaless-object field was therefore declared `string` in the generated RGD and KRO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   namespaces externally owned, allowing a parent Alchemy graph to establish a
   generated credential before the platform Helm releases without competing
   Namespace owners.
+- Ory identity and platform stacks can declare their target namespace
+  externally owned when a parent deployment graph is the lifecycle authority.
 - **Arktype `object` now maps to KRO `object` instead of `string`.** A bare `type('object')` is represented by
   arktype as the string `"object"`, which the KRO type mapper had no case for, so it fell through to the
   `string` default. Every schemaless-object field was therefore declared `string` in the generated RGD and KRO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Portable direct-plan materialization now evaluates KRO's `dyn()` type
   widening as runtime identity, matching the other direct CEL evaluators and
   preserving structured defaults inside recursively materialized owners.
+- Envoy AI Gateway platform installations can declare their controller
+  namespaces externally owned, allowing a parent Alchemy graph to establish a
+  generated credential before the platform Helm releases without competing
+  Namespace owners.
 - **Arktype `object` now maps to KRO `object` instead of `string`.** A bare `type('object')` is represented by
   arktype as the string `"object"`, which the KRO type mapper had no case for, so it fell through to the
   `string` default. Every schemaless-object field was therefore declared `string` in the generated RGD and KRO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Semantic planning now represents ArkType's explicitly open `object` and
-  `object[]` nodes instead of rejecting chart-value passthrough fields as
-  unsupported. The Kubernetes Secret factory also records its exact
+  `object[]` nodes—including root `type('object')` schemas and ordinary or
+  `ignore` undeclared-key policies—without falsely opening `reject`/`delete`
+  shapes. The Kubernetes Secret factory also records its exact
   lowercase factory provenance, so managed Ory platform compositions produce
   valid strict plans when both `Secret` registrations are loaded.
+- Direct Alchemy declarations now recursively materialize singleton-owner
+  compositions, preserve their spec fingerprints, order consumers after the
+  complete owner graph, and retain shared owner resources. Compositions whose
+  entire direct surface is a singleton reference, such as the shared
+  OpenSearch operator bootstrap, no longer report a successful empty plan.
+- Portable direct-plan materialization now evaluates KRO's `dyn()` type
+  widening as runtime identity, matching the other direct CEL evaluators and
+  preserving structured defaults inside recursively materialized owners.
 - **Arktype `object` now maps to KRO `object` instead of `string`.** A bare `type('object')` is represented by
   arktype as the string `"object"`, which the KRO type mapper had no case for, so it fell through to the
   `string` default. Every schemaless-object field was therefore declared `string` in the generated RGD and KRO

--- a/docs/api/flux/index.md
+++ b/docs/api/flux/index.md
@@ -74,6 +74,14 @@ const release = helmRelease({
     name: 'my-app-values',
     valuesKey: 'databaseUrl',
     targetPath: 'config.databaseUrl'
+  }],
+  postRenderers: [{
+    kustomize: {
+      patches: [{
+        target: { group: 'apps', version: 'v1', kind: 'Deployment', name: 'my-app' },
+        patch: '- op: remove\n  path: /metadata/annotations/legacy'
+      }]
+    }
   }]
 });
 ```
@@ -87,6 +95,12 @@ the managed Flux 2.7.5 baseline. TypeKro intentionally withholds Flux 2.9's
 `literal` field until the managed runtime and Kubernetes compatibility baseline
 can move together. Use chart-native `envFrom` or mounted files for arbitrary
 Secret bytes; do not route credentials with punctuation through `targetPath`.
+
+`postRenderers` exposes Flux's Kustomize post-rendering boundary for
+strategic-merge and JSON 6902 patches. Patch targets are graph-aware, so their
+names and namespaces may come from schema or resource references. Prefer
+chart-native values for ordinary configuration; use post-rendering when an
+upstream chart cannot express a required manifest transformation.
 
 ## helmRepository()
 

--- a/docs/api/ory/index.md
+++ b/docs/api/ory/index.md
@@ -122,6 +122,12 @@ await platform.deploy({
 });
 ```
 
+TypeKro currently pins Hydra Maester `v0.0.39` for the bounded
+single-namespace mode because upstream `v0.0.40+` watches `OAuth2Client`
+resources cluster-wide despite receiving `--namespace`. Callers may override
+the subchart image through `maester.hydraValues.image` after upstream publishes
+a compatible fix.
+
 On existing clusters, set `managed.databaseStorageClass` explicitly when managed databases are
 enabled. TypeKro applies it to all three CNPG clusters in both direct and KRO modes.
 

--- a/docs/api/ory/index.md
+++ b/docs/api/ory/index.md
@@ -91,6 +91,13 @@ await stack.deploy({
 
 Explicit literal value sources are supported for controlled environments, but TypeKro rejects unsafe literals supplied through unapproved chart escape hatches.
 
+`oryIdentityStack` owns the Hydra and Kratos workload names used by its
+external-secret post-renderers. It therefore protects `nameOverride` and
+`fullnameOverride` from raw chart-value overrides in both direct and KRO
+modes. Use the lower-level `hydraHelmRelease` or `kratosHelmRelease` wrappers
+when custom chart naming is required and the caller also owns the resulting
+secret-environment wiring.
+
 Use `kratos.identitySchema` to replace Kratos' default mounted identity schema in both direct and KRO modes. TypeKro mounts it as `identity.default.schema.json` and wires `kratos.config.identity.schemas` to the matching default ref, so custom schema content does not require duplicate filename/ref configuration.
 
 ## Managed Local Platform

--- a/docs/api/yaml-closures.md
+++ b/docs/api/yaml-closures.md
@@ -216,6 +216,8 @@ interface HelmReleaseConfig {
     version?: string;      // Chart version
   };
   values?: Record<string, any>;
+  valuesFrom?: HelmReleaseValuesFromSource[];
+  postRenderers?: HelmReleasePostRenderer[];
 }
 ```
 

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -663,7 +663,9 @@ async function waitForPersistedIdentityDeletion(
   const identity = persistedKroResourceIdentity(output);
   if (!identity) return;
   const reader = identityReader(props, dependencies.reader, 'alchemy-terminating-identity');
-  const sleep = dependencies.sleep ?? Bun.sleep;
+  const sleep =
+    dependencies.sleep ??
+    ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
   const now = dependencies.now ?? Date.now;
   const pollIntervalMs = dependencies.pollIntervalMs ?? 500;
   const timeout = props.options?.timeout ?? DEFAULT_DEPLOYMENT_TIMEOUT;

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -116,6 +116,7 @@ import {
   assertNoDiscoveredSingletonSpecDrift,
   singletonSpecFingerprintAnnotationValue,
 } from './singleton-owner-drift.js';
+import { SINGLETON_SPEC_FINGERPRINT_ANNOTATION } from './resource-tagging.js';
 import { DirectDeploymentStrategy } from './strategies/index.js';
 
 interface DirectArtifactExecution {
@@ -1513,8 +1514,9 @@ export class DirectResourceFactoryImpl<
    */
   async toAlchemyResources(
     spec: TSpec,
-    opts?: { instanceNameOverride?: string }
+    opts?: { instanceNameOverride?: string; singletonSpecFingerprint?: string }
   ): Promise<AlchemyResourceDeclaration[]> {
+    const singletonDeclarations = await this.singletonAlchemyDeclarations(spec);
     const execution = this.createArtifactExecutionForInstance(spec, opts?.instanceNameOverride, {
       preserveArtifactOutputs: true,
     });
@@ -1636,7 +1638,7 @@ export class DirectResourceFactoryImpl<
     // authoritative ordering rather than reinterpreting serialized manifest strings.
     const ordered = graph.dependencyGraph.getTopologicalOrder();
 
-    return ordered.flatMap((graphId) => {
+    const applicationDeclarations = ordered.flatMap((graphId) => {
       const node = byGraphId.get(graphId);
       if (!node) return [];
       const artifact = artifactByLogicalId.get(node.logicalId);
@@ -1675,7 +1677,7 @@ export class DirectResourceFactoryImpl<
         strategy?.kind === 'runtime-binding' && evaluator
           ? { [strategy.binding]: evaluator }
           : undefined;
-      const declarationResource =
+      let declarationResource =
         materialization &&
         ((sensitiveBindings && Object.keys(sensitiveBindings).length > 0) ||
           artifactOutputUses.length > 0)
@@ -1721,6 +1723,18 @@ export class DirectResourceFactoryImpl<
       if (declarationResource !== node.resource) {
         copyResourceMetadata(node.resource, declarationResource);
       }
+      if (opts?.singletonSpecFingerprint) {
+        declarationResource = {
+          ...declarationResource,
+          metadata: {
+            ...declarationResource.metadata,
+            annotations: {
+              ...declarationResource.metadata.annotations,
+              [SINGLETON_SPEC_FINGERPRINT_ANNOTATION]: opts.singletonSpecFingerprint,
+            },
+          },
+        } as Enhanced<unknown, unknown>;
+      }
       const dependsOn = graph.dependencyGraph
         .getDependencies(graphId)
         .map((dependencyGraphId) => byGraphId.get(dependencyGraphId)?.alchemyId)
@@ -1758,6 +1772,83 @@ export class DirectResourceFactoryImpl<
         },
       };
     });
+    if (singletonDeclarations.length === 0) return applicationDeclarations;
+
+    const singletonIds = singletonDeclarations.map((declaration) => declaration.id);
+    const applicationIds = new Set(applicationDeclarations.map((declaration) => declaration.id));
+    const collision = singletonDeclarations.find((declaration) =>
+      applicationIds.has(declaration.id)
+    );
+    if (collision) {
+      throw new ValidationError(
+        `Direct Alchemy singleton declaration ${collision.id} collides with an application resource. ` +
+          `Singleton owners and consumers must have distinct declaration identities.`,
+        this.schemaDefinition.kind,
+        this.name,
+        'alchemy'
+      );
+    }
+    return [
+      ...singletonDeclarations,
+      ...applicationDeclarations.map((declaration) => ({
+        ...declaration,
+        dependsOn: [...new Set([...singletonIds, ...declaration.dependsOn])],
+      })),
+    ];
+  }
+
+  private async singletonAlchemyDeclarations(
+    spec: TSpec
+  ): Promise<AlchemyResourceDeclaration[]> {
+    const definitions = this.discoverSingletonDefinitions(spec);
+    if (definitions.length === 0) return [];
+
+    const declarations = new Map<string, AlchemyResourceDeclaration>();
+    for (const definition of definitions) {
+      const ownerFactory = definition.composition.factory('direct', {
+        namespace: definition.registryNamespace,
+        waitForReady: true,
+        ...(this.factoryOptions.timeout !== undefined
+          ? { timeout: this.factoryOptions.timeout }
+          : {}),
+        ...(this.factoryOptions.kubeConfig !== undefined
+          ? { kubeConfig: this.factoryOptions.kubeConfig }
+          : {}),
+        ...(this.factoryOptions.alchemyKubeConfig !== undefined
+          ? { alchemyKubeConfig: this.factoryOptions.alchemyKubeConfig }
+          : {}),
+        ...(this.factoryOptions.skipTLSVerify !== undefined
+          ? { skipTLSVerify: this.factoryOptions.skipTLSVerify }
+          : {}),
+        ...(this.factoryOptions.applyPolicy !== undefined
+          ? { applyPolicy: this.factoryOptions.applyPolicy }
+          : {}),
+      }) as DirectResourceFactory<KroCompatibleType, KroCompatibleType>;
+      const ownerDeclarations = await ownerFactory.toAlchemyResources(definition.spec, {
+        instanceNameOverride: getSingletonInstanceName(definition.id),
+        singletonSpecFingerprint: singletonSpecFingerprintAnnotationValue(
+          definition.specFingerprint
+        ),
+      });
+      for (const declaration of ownerDeclarations) {
+        const retained = {
+          ...declaration,
+          props: { ...declaration.props, retain: true },
+        };
+        const existing = declarations.get(retained.id);
+        if (existing && JSON.stringify(existing) !== JSON.stringify(retained)) {
+          throw new ValidationError(
+            `Direct Alchemy singleton declarations disagree on ${retained.id}. ` +
+              `A shared singleton identity must resolve to one canonical resource graph.`,
+            this.schemaDefinition.kind,
+            definition.id,
+            'alchemy'
+          );
+        }
+        declarations.set(retained.id, retained);
+      }
+    }
+    return [...declarations.values()];
   }
 
   /**
@@ -2514,7 +2605,7 @@ export class DirectResourceFactoryImpl<
     }
   }
 
-  private async ensureSingletonOwners(spec: TSpec, operationSignal?: AbortSignal): Promise<void> {
+  private discoverSingletonDefinitions(spec: TSpec): SingletonDefinitionRecord[] {
     const discoveredSingletons = new Map<string, SingletonDefinitionRecord>();
 
     if (this.factoryOptions.compositionFn) {
@@ -2534,9 +2625,16 @@ export class DirectResourceFactoryImpl<
       }
     }
 
-    if (discoveredSingletons.size === 0) return;
+    return [...discoveredSingletons.values()].sort((left, right) =>
+      left.key.localeCompare(right.key)
+    );
+  }
 
-    for (const definition of discoveredSingletons.values()) {
+  private async ensureSingletonOwners(spec: TSpec, operationSignal?: AbortSignal): Promise<void> {
+    const discoveredSingletons = this.discoverSingletonDefinitions(spec);
+    if (discoveredSingletons.length === 0) return;
+
+    for (const definition of discoveredSingletons) {
       await this.ensureTargetNamespace(definition.registryNamespace, operationSignal);
 
       const singletonInstanceName = getSingletonInstanceName(definition.id);

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -1240,9 +1240,36 @@ export class DirectResourceFactoryImpl<
       readonly sensitiveBindings?: Readonly<Record<string, unknown>>;
       readonly staticYamlOptions?: StaticYamlMaterializationOptions;
       readonly preserveArtifactOutputs?: boolean;
+      /**
+       * Singleton ownership is part of the desired Kubernetes object, not
+       * provider-only decoration. Include it before semantic compilation so
+       * the canonical execution record and every rehydrated apply preserve
+       * the same drift identity.
+       */
+      readonly singletonSpecFingerprint?: string;
     } = {}
   ): DirectArtifactExecution {
-    const legacyGraph = this.createLegacyResourceGraphForInstance(spec, instanceNameOverride);
+    const capturedGraph = this.createLegacyResourceGraphForInstance(spec, instanceNameOverride);
+    const legacyGraph = options.singletonSpecFingerprint
+      ? {
+          ...capturedGraph,
+          resources: capturedGraph.resources.map(({ id, manifest }) => {
+            const decorated = {
+              ...manifest,
+              metadata: {
+                ...manifest.metadata,
+                annotations: {
+                  ...manifest.metadata.annotations,
+                  [SINGLETON_SPEC_FINGERPRINT_ANNOTATION]:
+                    options.singletonSpecFingerprint as string,
+                },
+              },
+            } as typeof manifest;
+            copyResourceMetadata(manifest, decorated);
+            return { id, manifest: decorated };
+          }),
+        }
+      : capturedGraph;
     const capture = this.factoryOptions.semanticCapture;
     if (!capture) return { graph: legacyGraph };
 
@@ -1519,6 +1546,9 @@ export class DirectResourceFactoryImpl<
     const singletonDeclarations = await this.singletonAlchemyDeclarations(spec);
     const execution = this.createArtifactExecutionForInstance(spec, opts?.instanceNameOverride, {
       preserveArtifactOutputs: true,
+      ...(opts?.singletonSpecFingerprint
+        ? { singletonSpecFingerprint: opts.singletonSpecFingerprint }
+        : {}),
     });
     this.assertExecutionCapabilities(execution, { host: 'alchemy', output: 'live' });
     const graph = execution.graph;
@@ -1677,7 +1707,7 @@ export class DirectResourceFactoryImpl<
         strategy?.kind === 'runtime-binding' && evaluator
           ? { [strategy.binding]: evaluator }
           : undefined;
-      let declarationResource =
+      const declarationResource =
         materialization &&
         ((sensitiveBindings && Object.keys(sensitiveBindings).length > 0) ||
           artifactOutputUses.length > 0)
@@ -1722,18 +1752,6 @@ export class DirectResourceFactoryImpl<
             : node.resource;
       if (declarationResource !== node.resource) {
         copyResourceMetadata(node.resource, declarationResource);
-      }
-      if (opts?.singletonSpecFingerprint) {
-        declarationResource = {
-          ...declarationResource,
-          metadata: {
-            ...declarationResource.metadata,
-            annotations: {
-              ...declarationResource.metadata.annotations,
-              [SINGLETON_SPEC_FINGERPRINT_ANNOTATION]: opts.singletonSpecFingerprint,
-            },
-          },
-        } as Enhanced<unknown, unknown>;
       }
       const dependsOn = graph.dependencyGraph
         .getDependencies(graphId)

--- a/src/core/planning/index.ts
+++ b/src/core/planning/index.ts
@@ -63,6 +63,7 @@ export {
 export {
   collectPlanValueSensitiveBindings,
   mapPlanValueSensitiveBindings,
+  materializePlanOutputs,
   materializePlanValue,
   materializePlanValueForKro,
   type PlanMaterializationBindings,

--- a/src/core/planning/materialization.ts
+++ b/src/core/planning/materialization.ts
@@ -12,6 +12,16 @@ import {
 /** Explicit bindings supplied after pure planning and before artifact execution. */
 export interface PlanMaterializationBindings {
   readonly spec?: unknown;
+  /**
+   * Live Kubernetes resources keyed by their canonical composition resource id.
+   *
+   * Ordinary direct artifact materialization omits this map and preserves
+   * resource references for the deployment engine. Composition-output
+   * materialization supplies it after Alchemy has reconciled the complete
+   * resource graph, allowing the exact same PlanValue to hydrate a concrete
+   * result without re-running the authoring closure.
+   */
+  readonly resources?: Readonly<Record<string, unknown>>;
   readonly sensitive?: Readonly<Record<string, unknown>>;
   readonly externalInputs?: Readonly<Record<string, unknown>>;
   readonly artifactOutputs?: Readonly<Record<string, Readonly<Record<string, unknown>>>>;
@@ -281,6 +291,7 @@ function evaluatePortableExpression(
       if (guarded) ensureEvaluationPath(specContext, reference.fieldPath);
     }
     const context: Record<string, unknown> = {
+      ...(bindings.resources ?? {}),
       schema: { spec: specContext },
       ...(bindings.locals ?? {}),
     };
@@ -446,6 +457,14 @@ function materialize(
       if (!value.resourceId) {
         throw new PlanMaterializationError(`Resource reference has no producer id.`, path);
       }
+      if (Object.hasOwn(bindings.resources ?? {}, value.resourceId)) {
+        return readPath(
+          bindings.resources?.[value.resourceId],
+          value.fieldPath,
+          path,
+          value.optional === true
+        );
+      }
       return runtimeReference(
         bindings.resourceIds?.[value.resourceId] ?? value.resourceId,
         value.fieldPath,
@@ -461,7 +480,10 @@ function materialize(
           { language: value.expression.language }
         );
       }
-      if (value.expression.references.some((reference) => reference.source === 'resource')) {
+      if (
+        value.expression.references.some((reference) => reference.source === 'resource') &&
+        bindings.resources === undefined
+      ) {
         return runtimeExpression(value.expression.expression);
       }
       if (
@@ -516,6 +538,21 @@ function materialize(
             path,
             segment.optional === true,
             bindings.iterationItems
+          );
+          if (resolved === OMIT) return OMIT;
+          renderedSegments.push(String(resolved));
+          continue;
+        }
+        if (
+          segment.source === 'resource' &&
+          segment.resourceId &&
+          Object.hasOwn(bindings.resources ?? {}, segment.resourceId)
+        ) {
+          const resolved = readPath(
+            bindings.resources?.[segment.resourceId],
+            segment.fieldPath,
+            path,
+            segment.optional === true
           );
           if (resolved === OMIT) return OMIT;
           renderedSegments.push(String(resolved));
@@ -576,6 +613,29 @@ export function materializePlanValue(
 ): unknown {
   const result = materialize(value, bindings, path);
   return result === OMIT ? undefined : result;
+}
+
+/**
+ * Hydrate a composition's canonical output map from concrete bindings.
+ *
+ * This is deliberately a planning/runtime seam rather than an Alchemy helper:
+ * TypeKro owns the meaning of PlanValue, while deployment backends own how
+ * live resources and provider outputs become available. Keeping the evaluator
+ * here guarantees direct factories, KRO status, and Alchemy composition
+ * outputs share one authored expression contract.
+ */
+export function materializePlanOutputs(
+  outputs: Readonly<Record<string, PlanValue>>,
+  bindings: PlanMaterializationBindings = {}
+): Readonly<Record<string, unknown>> {
+  return Object.fromEntries(
+    Object.keys(outputs)
+      .sort()
+      .map((name) => [
+        name,
+        materializePlanValue(outputs[name] as PlanValue, bindings, `$.outputs.${name}`),
+      ])
+  );
 }
 
 /**

--- a/src/core/planning/materialization.ts
+++ b/src/core/planning/materialization.ts
@@ -561,6 +561,13 @@ function materialize(
                 }
               );
             }
+            if (specReferences.length > 0 && bindings.spec === undefined) {
+              throw new PlanMaterializationError(
+                `Spec binding is required to evaluate ${segment.expression.expression}.`,
+                path,
+                { expression: segment.expression.expression }
+              );
+            }
           }
           const canEvaluate =
             segment.expression.language === 'portable-cel' &&
@@ -594,6 +601,14 @@ function materialize(
           if (resolved === OMIT) return OMIT;
           renderedSegments.push(String(resolved));
           continue;
+        }
+        if (segment.source === 'spec' && bindings.resources !== undefined) {
+          if (segment.optional === true) return OMIT;
+          throw new PlanMaterializationError(
+            `Spec binding is required to resolve ${segment.fieldPath}.`,
+            path,
+            { fieldPath: segment.fieldPath }
+          );
         }
         if (
           segment.source === 'resource' &&

--- a/src/core/planning/materialization.ts
+++ b/src/core/planning/materialization.ts
@@ -302,6 +302,10 @@ function evaluatePortableExpression(
             ? Object.keys(value).length
             : 0,
       has: (value: unknown) => value !== undefined && value !== null,
+      // KRO uses dyn() for static type widening. Portable direct execution
+      // preserves the same expression and therefore treats it as runtime
+      // identity, matching the direct/schema CEL evaluators.
+      dyn: (value: unknown) => value,
       concat: (...values: unknown[]) => values.join(''),
     });
   } catch (error: unknown) {

--- a/src/core/planning/materialization.ts
+++ b/src/core/planning/materialization.ts
@@ -465,6 +465,14 @@ function materialize(
           value.optional === true
         );
       }
+      if (bindings.resources !== undefined) {
+        if (value.optional === true) return OMIT;
+        throw new PlanMaterializationError(
+          `Required resource binding ${value.resourceId} is not present in materialization input.`,
+          path,
+          { resourceId: value.resourceId, fieldPath: value.fieldPath }
+        );
+      }
       return runtimeReference(
         bindings.resourceIds?.[value.resourceId] ?? value.resourceId,
         value.fieldPath,
@@ -479,6 +487,25 @@ function materialize(
           path,
           { language: value.expression.language }
         );
+      }
+      if (bindings.resources !== undefined) {
+        const missingResource = value.expression.references.find(
+          (reference) =>
+            reference.source === 'resource' &&
+            (!reference.resourceId ||
+              !Object.hasOwn(bindings.resources ?? {}, reference.resourceId))
+        );
+        if (missingResource) {
+          throw new PlanMaterializationError(
+            `Required resource binding ${missingResource.resourceId ?? '<unknown>'} is not present in materialization input.`,
+            path,
+            {
+              resourceId: missingResource.resourceId ?? '<unknown>',
+              fieldPath: missingResource.fieldPath,
+              expression: value.expression.expression,
+            }
+          );
+        }
       }
       if (
         value.expression.references.some((reference) => reference.source === 'resource') &&
@@ -511,10 +538,35 @@ function materialize(
           continue;
         }
         if (segment.kind === 'expression') {
-          const onlySpecReferences = segment.expression.references.every(
+          const resourceReferences = segment.expression.references.filter(
+            (reference) => reference.source === 'resource'
+          );
+          const specReferences = segment.expression.references.filter(
             (reference) => reference.source === 'spec'
           );
-          if (bindings.spec !== undefined && onlySpecReferences) {
+          if (bindings.resources !== undefined) {
+            const missingResource = resourceReferences.find(
+              (reference) =>
+                !reference.resourceId ||
+                !Object.hasOwn(bindings.resources ?? {}, reference.resourceId)
+            );
+            if (missingResource) {
+              throw new PlanMaterializationError(
+                `Required resource binding ${missingResource.resourceId ?? '<unknown>'} is not present in materialization input.`,
+                path,
+                {
+                  resourceId: missingResource.resourceId ?? '<unknown>',
+                  fieldPath: missingResource.fieldPath,
+                  expression: segment.expression.expression,
+                }
+              );
+            }
+          }
+          const canEvaluate =
+            segment.expression.language === 'portable-cel' &&
+            (resourceReferences.length === 0 || bindings.resources !== undefined) &&
+            (specReferences.length === 0 || bindings.spec !== undefined);
+          if (canEvaluate) {
             renderedSegments.push(
               String(
                 evaluatePortableExpression(
@@ -557,6 +609,17 @@ function materialize(
           if (resolved === OMIT) return OMIT;
           renderedSegments.push(String(resolved));
           continue;
+        }
+        if (segment.source === 'resource' && bindings.resources !== undefined) {
+          if (segment.optional === true) return OMIT;
+          throw new PlanMaterializationError(
+            `Required resource binding ${segment.resourceId ?? '<unknown>'} is not present in materialization input.`,
+            path,
+            {
+              resourceId: segment.resourceId ?? '<unknown>',
+              fieldPath: segment.fieldPath,
+            }
+          );
         }
         renderedSegments.push(
           markerString(

--- a/src/core/planning/plan-codec.ts
+++ b/src/core/planning/plan-codec.ts
@@ -145,6 +145,15 @@ function schemaNode(value: unknown, path: string): asserts value is SchemaNodeIR
       schemaNode(node.values, `${path}.values`);
       return;
     case 'object': {
+      if (
+        node.additionalProperties !== undefined &&
+        node.additionalProperties !== true
+      ) {
+        throw new DesiredStatePlanDecodeError(
+          `Invalid additionalProperties flag at ${path}.`,
+          `${path}.additionalProperties`
+        );
+      }
       const names = new Set<string>();
       array(node.properties, `${path}.properties`).forEach((propertyValue, index) => {
         const property = record(propertyValue, `${path}.properties[${index}]`);

--- a/src/core/planning/schema.ts
+++ b/src/core/planning/schema.ts
@@ -105,6 +105,13 @@ function lowerSchemaNode(value: unknown, path: string, state: SchemaLoweringStat
     if (value === 'string' || value === 'number' || value === 'boolean' || value === 'unknown') {
       return { kind: 'primitive', type: value };
     }
+    if (value === 'object') {
+      return {
+        kind: 'object',
+        properties: [],
+        additionalProperties: true,
+      };
+    }
     if (value === 'null') return { kind: 'primitive', type: 'null' };
     return unsupportedSchemaNode(value, path, state, `Unsupported ArkType string node ${value}`);
   }

--- a/src/core/planning/schema.ts
+++ b/src/core/planning/schema.ts
@@ -150,7 +150,16 @@ function lowerSchemaNode(value: unknown, path: string, state: SchemaLoweringStat
       ...schemaProperties(Reflect.get(value, 'required'), true, `${path}.required`, state),
       ...schemaProperties(Reflect.get(value, 'optional'), false, `${path}.optional`, state),
     ].sort((left, right) => left.name.localeCompare(right.name));
-    return { kind: 'object', properties };
+    const undeclared = Reflect.get(value, 'undeclared');
+    return {
+      kind: 'object',
+      properties,
+      // ArkType omits `undeclared` for both its ordinary passthrough policy
+      // and explicit `ignore`. Only reject/delete describe a closed shape.
+      ...(undeclared === 'reject' || undeclared === 'delete'
+        ? {}
+        : { additionalProperties: true }),
+    };
   }
 
   if (domain === 'string' || domain === 'number' || domain === 'boolean') {

--- a/src/core/planning/types.ts
+++ b/src/core/planning/types.ts
@@ -176,7 +176,12 @@ export type SchemaNodeIR =
   | { readonly kind: 'literal'; readonly value: PlanPrimitive }
   | { readonly kind: 'array'; readonly items: SchemaNodeIR }
   | { readonly kind: 'map'; readonly values: SchemaNodeIR }
-  | { readonly kind: 'object'; readonly properties: readonly SchemaPropertyIR[] }
+  | {
+      readonly kind: 'object';
+      readonly properties: readonly SchemaPropertyIR[];
+      /** The schema accepts keys beyond the explicitly described properties. */
+      readonly additionalProperties?: true;
+    }
   | { readonly kind: 'union'; readonly variants: readonly SchemaNodeIR[] }
   | { readonly kind: 'unsupported'; readonly description: string; readonly raw: PlanValue };
 

--- a/src/core/types/deployment.ts
+++ b/src/core/types/deployment.ts
@@ -932,7 +932,7 @@ export interface DirectResourceFactory<
    */
   toAlchemyResources(
     spec: TSpec,
-    opts?: { instanceNameOverride?: string }
+    opts?: { instanceNameOverride?: string; singletonSpecFingerprint?: string }
   ): Promise<AlchemyResourceDeclaration[]>;
 }
 

--- a/src/experimental-planning.ts
+++ b/src/experimental-planning.ts
@@ -126,6 +126,7 @@ export {
   lowerPlanValue,
   mapPlanValueSensitiveBindings,
   materializeKroArtifactBundleOperation,
+  materializePlanOutputs,
   materializePlanValue,
   mergeKroArtifactBundleOperations,
   orderKroArtifactBundleOperations,

--- a/src/factories/envoy-ai-gateway/compositions/platform.ts
+++ b/src/factories/envoy-ai-gateway/compositions/platform.ts
@@ -72,11 +72,14 @@ export function makeEnvoyAIGatewayPlatformInstallation(
       );
       const repositoryNamespace = defaultString(spec.repositoryNamespace, DEFAULT_FLUX_NAMESPACE);
       const rateLimitRedisUrl = options.rateLimitRedisUrl;
+      const defaultNamespaceOwnership = options.namespaceOwnership ?? 'owned';
       const ownsNamespaces = graphMode
         ? Cel.expr<boolean>(
-            '!has(schema.spec.namespaceOwnership) || schema.spec.namespaceOwnership == "owned"'
+            `has(schema.spec.namespaceOwnership) ? ` +
+              `schema.spec.namespaceOwnership == "owned" : ` +
+              `${defaultNamespaceOwnership === 'owned'}`
           )
-        : spec.namespaceOwnership !== 'external';
+        : (spec.namespaceOwnership ?? defaultNamespaceOwnership) !== 'external';
 
       namespace({
         metadata: {

--- a/src/factories/envoy-ai-gateway/compositions/platform.ts
+++ b/src/factories/envoy-ai-gateway/compositions/platform.ts
@@ -49,6 +49,7 @@ export function makeEnvoyAIGatewayPlatformInstallation(
       status: EnvoyAIGatewayPlatformStatusSchema,
     },
     (spec: EnvoyAIGatewayPlatformInstallationSpec) => {
+      const graphMode = isKubernetesRef(spec.name);
       const envoyGatewayNamespace = defaultString(
         spec.envoyGatewayNamespace,
         DEFAULT_ENVOY_GATEWAY_NAMESPACE
@@ -71,6 +72,11 @@ export function makeEnvoyAIGatewayPlatformInstallation(
       );
       const repositoryNamespace = defaultString(spec.repositoryNamespace, DEFAULT_FLUX_NAMESPACE);
       const rateLimitRedisUrl = options.rateLimitRedisUrl;
+      const ownsNamespaces = graphMode
+        ? Cel.expr<boolean>(
+            '!has(schema.spec.namespaceOwnership) || schema.spec.namespaceOwnership == "owned"'
+          )
+        : spec.namespaceOwnership !== 'external';
 
       namespace({
         metadata: {
@@ -78,14 +84,14 @@ export function makeEnvoyAIGatewayPlatformInstallation(
           labels: platformLabels('envoy-gateway'),
         },
         id: 'envoyGatewayNamespace',
-      });
+      }).withIncludeWhen(ownsNamespaces);
       namespace({
         metadata: {
           name: aiGatewayNamespace,
           labels: platformLabels('envoy-ai-gateway'),
         },
         id: 'aiGatewayNamespace',
-      });
+      }).withIncludeWhen(ownsNamespaces);
       configMap({
         metadata: {
           name: `${spec.name}-platform-contract`,
@@ -206,6 +212,7 @@ export function makeEnvoyAIGatewayPlatformBootstrap(
     aiGatewayVersion: options.aiGatewayVersion ?? DEFAULT_ENVOY_AI_GATEWAY_VERSION,
     repositoryName: options.repositoryName ?? DEFAULT_ENVOY_PROXY_REPOSITORY_NAME,
     repositoryNamespace: options.repositoryNamespace ?? DEFAULT_FLUX_NAMESPACE,
+    namespaceOwnership: options.namespaceOwnership ?? 'owned',
     gatewayClassName: options.gatewayClassName ?? DEFAULT_ENVOY_AI_GATEWAY_CLASS_NAME,
     configurationDigest: platformConfigurationDigest(options),
   };
@@ -341,6 +348,7 @@ function platformConfigurationDigest(options: EnvoyAIGatewayPlatformBuildOptions
       envoyGatewayValues: options.envoyGatewayValues ?? {},
       aiGatewayValues: options.aiGatewayValues ?? {},
       rateLimitRedisUrl: options.rateLimitRedisUrl ?? null,
+      namespaceOwnership: options.namespaceOwnership ?? 'owned',
       mcpSessionEncryptionSeedSecret: options.mcpSessionEncryptionSeedSecret ?? null,
     })
   );

--- a/src/factories/envoy-ai-gateway/types.ts
+++ b/src/factories/envoy-ai-gateway/types.ts
@@ -14,6 +14,7 @@ export const EnvoyAIGatewayPlatformInstallationSpecSchema = type({
   'aiGatewayVersion?': 'string > 0',
   'repositoryName?': kubernetesDnsLabel,
   'repositoryNamespace?': kubernetesDnsLabel,
+  'namespaceOwnership?': '"owned" | "external"',
   'gatewayClassName?': kubernetesDnsLabel,
   'configurationDigest?': 'string > 0',
 });
@@ -58,6 +59,12 @@ export interface EnvoyAIGatewayPlatformBuildOptions {
   readonly aiGatewayVersion?: string;
   readonly repositoryName?: string;
   readonly repositoryNamespace?: string;
+  /**
+   * Lifecycle of the Envoy Gateway and AI Gateway controller namespaces.
+   * Use `external` when a parent deployment graph establishes them.
+   * @default 'owned'
+   */
+  readonly namespaceOwnership?: 'owned' | 'external';
   readonly gatewayClassName?: string;
   /** Envoy Gateway global rate-limit service Redis endpoint, without a URL scheme. */
   readonly rateLimitRedisUrl?: string;

--- a/src/factories/helm/helm-release.ts
+++ b/src/factories/helm/helm-release.ts
@@ -11,14 +11,20 @@ import type {
 import type { Enhanced } from '../../core/types/index.js';
 import { createResource } from '../shared.js';
 import { helmReleaseReadinessEvaluator } from './readiness-evaluators.js';
-import type { HelmReleaseSpec, HelmReleaseStatus, HelmReleaseValuesFromSource } from './types.js';
+import type {
+  HelmReleasePostRenderer,
+  HelmReleaseSpec,
+  HelmReleaseStatus,
+  HelmReleaseValuesFromSource,
+} from './types.js';
 
 type HelmReleaseAuthoringSpec<TValues extends object> = Omit<
   HelmReleaseSpec<TValues>,
-  'values' | 'valuesFrom'
+  'values' | 'valuesFrom' | 'postRenderers'
 > & {
   values?: TypeKroChartValue<TValues>;
   valuesFrom?: TypeKroValue<HelmReleaseValuesFromSource>[];
+  postRenderers?: TypeKroValue<HelmReleasePostRenderer>[];
 };
 
 export interface HelmReleaseConfig<TValues extends object = TypeKroValueTreeObject> {
@@ -53,6 +59,11 @@ export interface HelmReleaseConfig<TValues extends object = TypeKroValueTreeObje
    * ConfigMap created in the same composition can supply its generated name.
    */
   valuesFrom?: TypeKroValue<HelmReleaseValuesFromSource>[];
+  /**
+   * Flux Kustomize transformations applied after Helm rendering. Patch targets
+   * remain graph-aware, allowing generated names to be selected in KRO mode.
+   */
+  postRenderers?: TypeKroValue<HelmReleasePostRenderer>[];
   /**
    * Flux install policy. The supplied fields override TypeKro's bounded retry
    * defaults; nested remediation fields are merged rather than replaced.
@@ -237,6 +248,7 @@ export function helmRelease<TValues extends object = TypeKroValueTreeObject>(
       },
       ...(config.driftDetection && { driftDetection: config.driftDetection }),
       ...(config.valuesFrom && { valuesFrom: config.valuesFrom }),
+      ...(config.postRenderers && { postRenderers: config.postRenderers }),
       ...(config.values && { values: config.values }),
     },
   }).withReadinessEvaluator(helmReleaseReadinessEvaluator) as Enhanced<

--- a/src/factories/helm/index.ts
+++ b/src/factories/helm/index.ts
@@ -33,6 +33,10 @@ export { helmReleaseConditionSummary } from './status.js';
 
 // types.ts
 export type {
+  HelmReleasePostRenderer,
+  HelmReleasePostRendererImage,
+  HelmReleasePostRendererPatch,
+  HelmReleasePostRendererPatchTarget,
   HelmReleaseSpec,
   HelmReleaseStatus,
   HelmReleaseValuesFromSource,

--- a/src/factories/helm/types.ts
+++ b/src/factories/helm/types.ts
@@ -19,6 +19,39 @@ export interface HelmReleaseValuesFromSource {
   optional?: boolean;
 }
 
+/** Select Kubernetes resources for a Flux Kustomize post-render patch. */
+export interface HelmReleasePostRendererPatchTarget {
+  group?: string;
+  version?: string;
+  kind?: string;
+  name?: string;
+  namespace?: string;
+  labelSelector?: string;
+  annotationSelector?: string;
+}
+
+/** An inline strategic-merge or JSON 6902 patch applied after Helm rendering. */
+export interface HelmReleasePostRendererPatch {
+  patch: string;
+  target?: HelmReleasePostRendererPatchTarget;
+}
+
+/** Rewrite an image reference after Helm rendering. */
+export interface HelmReleasePostRendererImage {
+  name: string;
+  newName?: string;
+  newTag?: string;
+  digest?: string;
+}
+
+/** Flux Kustomize post-renderer configuration. */
+export interface HelmReleasePostRenderer {
+  kustomize: {
+    patches?: HelmReleasePostRendererPatch[];
+    images?: HelmReleasePostRendererImage[];
+  };
+}
+
 // Helm Release Resource Types
 export interface HelmReleaseSpec<TValues extends object = Record<string, unknown>> {
   interval?: string;
@@ -41,6 +74,8 @@ export interface HelmReleaseSpec<TValues extends object = Record<string, unknown
   values?: TypeKroChartValues<TValues>;
   /** Values loaded from Secrets or ConfigMaps by Flux. */
   valuesFrom?: HelmReleaseValuesFromSource[];
+  /** Kustomize transformations applied by Flux after Helm renders the chart. */
+  postRenderers?: HelmReleasePostRenderer[];
   targetNamespace?: string;
   install?: {
     createNamespace?: boolean;

--- a/src/factories/kubernetes/config/secret.ts
+++ b/src/factories/kubernetes/config/secret.ts
@@ -58,5 +58,7 @@ export function secret(resource: V1Secret & { id?: string }): Enhanced<SecretSpe
     kind: 'Secret',
     metadata: resource.metadata ?? { name: 'unnamed-secret' },
     // Note: No spec field - Secrets have data/stringData/type/immutable at root level
-  }).withReadinessEvaluator(createAlwaysReadyEvaluator<V1Secret>('Secret'));
+  }, { factoryName: 'secret' }).withReadinessEvaluator(
+    createAlwaysReadyEvaluator<V1Secret>('Secret')
+  );
 }

--- a/src/factories/ory/compositions/ory-identity-stack.ts
+++ b/src/factories/ory/compositions/ory-identity-stack.ts
@@ -92,6 +92,44 @@ function withChartValuesOverlay<T extends object>(values: T, overlay: object): T
   return deepMergeKnownValues(values, overlay) as T;
 }
 
+function removeChartOwnedSecretEnv(
+  kind: 'Deployment' | 'StatefulSet',
+  releaseName: string,
+  containerName: 'hydra' | 'kratos' | 'kratos-courier',
+  names: string[]
+) {
+  return {
+    kustomize: {
+      patches: [
+        {
+          target: {
+            group: 'apps',
+            version: 'v1',
+            kind,
+            name: releaseName,
+          },
+          patch: [
+            'apiVersion: apps/v1',
+            `kind: ${kind}`,
+            'metadata:',
+            '  name: ignored-by-target-selector',
+            'spec:',
+            '  template:',
+            '    spec:',
+            '      containers:',
+            `        - name: ${containerName}`,
+            '          env:',
+            ...names.flatMap((name) => [
+              `            - name: ${name}`,
+              '              $patch: delete',
+            ]),
+          ].join('\n'),
+        },
+      ],
+    },
+  };
+}
+
 function oathkeeperProbeValues(): Record<string, unknown> {
   const aliveProbe = {
     httpGet: {
@@ -433,6 +471,11 @@ export const oryIdentityStack = kubernetesComposition(
         'hydra-maester',
         values.hydraMaester
       ),
+      postRenderers: [
+        removeChartOwnedSecretEnv('Deployment', `${typedSpec.name}-hydra`, 'hydra', [
+          'SECRETS_SYSTEM',
+        ]),
+      ],
     });
 
     const kratos = kratosHelmRelease({
@@ -443,6 +486,18 @@ export const oryIdentityStack = kubernetesComposition(
       repositoryName: 'ory',
       repositoryNamespace: resolvedNamespace,
       values: values.kratos,
+      postRenderers: [
+        removeChartOwnedSecretEnv('Deployment', `${typedSpec.name}-kratos`, 'kratos', [
+          'SECRETS_COOKIE',
+          'SECRETS_CIPHER',
+        ]),
+        removeChartOwnedSecretEnv(
+          'StatefulSet',
+          `${typedSpec.name}-kratos-courier`,
+          'kratos-courier',
+          ['SECRETS_COOKIE', 'SECRETS_CIPHER']
+        ),
+      ],
     });
 
     const keto = ketoHelmRelease({

--- a/src/factories/ory/compositions/ory-identity-stack.ts
+++ b/src/factories/ory/compositions/ory-identity-stack.ts
@@ -140,6 +140,7 @@ function graphSafeConfig(
     return defined({
       name: config.name,
       namespace: config.namespace,
+      namespaceOwnership: config.namespaceOwnership,
       version: config.version,
       dependencySources: config.dependencySources,
       shared: config.shared,
@@ -382,7 +383,7 @@ export const oryIdentityStack = kubernetesComposition(
       });
     }
 
-    if (concreteSpec) {
+    if (concreteSpec && typedSpec.namespaceOwnership !== 'external') {
       namespace({
         id: 'oryNamespace',
         metadata: {

--- a/src/factories/ory/compositions/ory-identity-stack.ts
+++ b/src/factories/ory/compositions/ory-identity-stack.ts
@@ -1,9 +1,9 @@
-import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import {
   isValuesMergeExpression,
   mergeValuesExpression,
   type ValuesMergeExpression,
 } from '../../../core/aspects/values-merge.js';
+import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { Cel } from '../../../core/references/cel.js';
 import { isKubernetesRef } from '../../../utils/type-guards.js';
 import { configMap } from '../../kubernetes/config/config-map.js';
@@ -12,12 +12,12 @@ import {
   hydraHelmRelease,
   ketoHelmRelease,
   kratosHelmRelease,
-  oathkeeperHelmRelease,
   ORY_CHART_VERSION,
+  oathkeeperHelmRelease,
   oryHelmRepository,
 } from '../resources/helm.js';
-import { oauth2Client } from '../resources/oauth2-client.js';
 import { oathkeeperRule } from '../resources/oathkeeper-rule.js';
+import { oauth2Client } from '../resources/oauth2-client.js';
 import {
   type OryDependencySource,
   type OryEndpointStatus,
@@ -90,6 +90,31 @@ function withChartValuesOverlay<T extends object>(values: T, overlay: object): T
   }
 
   return deepMergeKnownValues(values, overlay) as T;
+}
+
+/**
+ * The external-secret post-renderers address chart workloads and containers
+ * by name. Keep those names stack-owned even when callers pass raw chart
+ * values so the security patch cannot silently miss its target.
+ *
+ * Graph-mode values merges must append this overlay last: placing it in the
+ * base would let a schema-provided values overlay restore an unsafe chart
+ * naming override at reconciliation time.
+ */
+function withStackOwnedChartNames<T extends object>(
+  values: T,
+  chartName: 'hydra' | 'kratos',
+  releaseName: string
+): T {
+  const protectedNames = {
+    nameOverride: chartName,
+    fullnameOverride: releaseName,
+  };
+  return (
+    isValuesMergeExpression(values)
+      ? mergeValuesExpression(values, protectedNames)
+      : deepMergeKnownValues(values, protectedNames)
+  ) as T;
 }
 
 function removeChartOwnedSecretEnv(
@@ -240,14 +265,20 @@ function graphSafeConfig(
   };
 }
 
-function defaultManagedDependencySources(name: string): OryIdentityStackConfig['dependencySources'] {
+function defaultManagedDependencySources(
+  name: string
+): OryIdentityStackConfig['dependencySources'] {
   return {
     hydra: {
-      database: { dsn: { mode: 'managed', resourceName: `${name}-hydra-db-app`, secretKey: 'uri' } },
+      database: {
+        dsn: { mode: 'managed', resourceName: `${name}-hydra-db-app`, secretKey: 'uri' },
+      },
       systemSecret: { mode: 'managed', secretName: `${name}-hydra-secrets`, secretKey: 'system' },
     },
     kratos: {
-      database: { dsn: { mode: 'managed', resourceName: `${name}-kratos-db-app`, secretKey: 'uri' } },
+      database: {
+        dsn: { mode: 'managed', resourceName: `${name}-kratos-db-app`, secretKey: 'uri' },
+      },
       secrets: {
         cookie: { mode: 'managed', secretName: `${name}-kratos-secrets`, secretKey: 'cookie' },
         cipher: { mode: 'managed', secretName: `${name}-kratos-secrets`, secretKey: 'cipher' },
@@ -291,7 +322,10 @@ function mergeDependencySource(
   }) as OryDependencySource;
 }
 
-function defaulted<T extends string>(explicit: T | undefined, fallback: T | undefined): T | undefined {
+function defaulted<T extends string>(
+  explicit: T | undefined,
+  fallback: T | undefined
+): T | undefined {
   if (explicit === undefined) return fallback;
   if (fallback !== undefined && isKubernetesRef(explicit)) {
     return Cel.default(explicit, fallback) as T;
@@ -337,7 +371,10 @@ function mergeDependencySourceDefaults(
         url: mergeDependencySource(defaults.kratos?.publicBaseUrl?.url, kratos?.publicBaseUrl?.url),
       }),
       browserBaseUrl: defined({
-        url: mergeDependencySource(defaults.kratos?.browserBaseUrl?.url, kratos?.browserBaseUrl?.url),
+        url: mergeDependencySource(
+          defaults.kratos?.browserBaseUrl?.url,
+          kratos?.browserBaseUrl?.url
+        ),
       }),
       secrets: defined({
         cookie: mergeDependencySource(defaults.kratos?.secrets?.cookie, kratos?.secrets?.cookie),
@@ -353,7 +390,10 @@ function mergeDependencySourceDefaults(
     }),
     oathkeeper: defined({
       proxyRoute: defined({
-        url: mergeDependencySource(defaults.oathkeeper?.proxyRoute?.url, oathkeeper?.proxyRoute?.url),
+        url: mergeDependencySource(
+          defaults.oathkeeper?.proxyRoute?.url,
+          oathkeeper?.proxyRoute?.url
+        ),
       }),
       apiRoute: defined({
         url: mergeDependencySource(defaults.oathkeeper?.apiRoute?.url, oathkeeper?.apiRoute?.url),
@@ -361,8 +401,10 @@ function mergeDependencySourceDefaults(
       upstream: defined({
         url: mergeDependencySource(defaults.oathkeeper?.upstream?.url, oathkeeper?.upstream?.url),
       }),
-      mutatorIdTokenJwks:
-        mergeDependencySource(defaults.oathkeeper?.mutatorIdTokenJwks, oathkeeper?.mutatorIdTokenJwks),
+      mutatorIdTokenJwks: mergeDependencySource(
+        defaults.oathkeeper?.mutatorIdTokenJwks,
+        oathkeeper?.mutatorIdTokenJwks
+      ),
     }),
     courier: mergeDependencySource(defaults.courier, explicit?.courier),
   });
@@ -395,12 +437,9 @@ export const oryIdentityStack = kubernetesComposition(
     const resolvedVersion = typedSpec.version ?? ORY_CHART_VERSION;
     const concreteSpec =
       !isSchemaSpec(typedSpec) &&
-      ![
-        typedSpec.name,
-        typedSpec.namespace,
-        typedSpec.version,
-        typedSpec.dependencySources,
-      ].some((value) => isKubernetesRef(value));
+      ![typedSpec.name, typedSpec.namespace, typedSpec.version, typedSpec.dependencySources].some(
+        (value) => isKubernetesRef(value)
+      );
     const graphSpec = graphSafeConfig(typedSpec, !concreteSpec);
     const graphFallbackSpec = graphSpec;
     const graphDependencySources = mergeDependencySourceDefaults(
@@ -420,6 +459,11 @@ export const oryIdentityStack = kubernetesComposition(
         version: resolvedVersion,
       });
     }
+    values = {
+      ...values,
+      hydra: withStackOwnedChartNames(values.hydra, 'hydra', `${typedSpec.name}-hydra`),
+      kratos: withStackOwnedChartNames(values.kratos, 'kratos', `${typedSpec.name}-kratos`),
+    };
 
     const ownsNamespace = concreteSpec
       ? typedSpec.namespaceOwnership !== 'external'
@@ -466,11 +510,7 @@ export const oryIdentityStack = kubernetesComposition(
       version: resolvedVersion,
       repositoryName: 'ory',
       repositoryNamespace: resolvedNamespace,
-      values: withMaesterSubchartValues(
-        values.hydra,
-        'hydra-maester',
-        values.hydraMaester
-      ),
+      values: withMaesterSubchartValues(values.hydra, 'hydra-maester', values.hydraMaester),
       postRenderers: [
         removeChartOwnedSecretEnv('Deployment', `${typedSpec.name}-hydra`, 'hydra', [
           'SECRETS_SYSTEM',

--- a/src/factories/ory/compositions/ory-identity-stack.ts
+++ b/src/factories/ory/compositions/ory-identity-stack.ts
@@ -383,20 +383,23 @@ export const oryIdentityStack = kubernetesComposition(
       });
     }
 
-    if (concreteSpec && typedSpec.namespaceOwnership !== 'external') {
-      namespace({
-        id: 'oryNamespace',
-        metadata: {
-          name: resolvedNamespace,
-          labels: {
-            'app.kubernetes.io/name': 'ory-identity-stack',
-            'app.kubernetes.io/instance': typedSpec.name,
-            'app.kubernetes.io/version': resolvedVersion,
-            'app.kubernetes.io/managed-by': 'typekro',
-          },
+    const ownsNamespace = concreteSpec
+      ? typedSpec.namespaceOwnership !== 'external'
+      : Cel.expr<boolean>(
+          '!has(schema.spec.namespaceOwnership) || schema.spec.namespaceOwnership == "owned"'
+        );
+    namespace({
+      id: 'oryNamespace',
+      metadata: {
+        name: resolvedNamespace,
+        labels: {
+          'app.kubernetes.io/name': 'ory-identity-stack',
+          'app.kubernetes.io/instance': typedSpec.name,
+          'app.kubernetes.io/version': resolvedVersion,
+          'app.kubernetes.io/managed-by': 'typekro',
         },
-      });
-    }
+      },
+    }).withIncludeWhen(ownsNamespace);
 
     const _oryHelmRepository = oryHelmRepository({
       id: 'oryHelmRepository',

--- a/src/factories/ory/resources/helm.ts
+++ b/src/factories/ory/resources/helm.ts
@@ -94,6 +94,7 @@ function createOryHelmRelease<TValues extends OryChartValues>(
       namespace: config.repositoryNamespace ?? DEFAULT_FLUX_NAMESPACE,
     },
     ...(config.values && { values: config.values }),
+    ...(config.postRenderers && { postRenderers: config.postRenderers }),
   }).withReadinessEvaluator(oryHelmReleaseReadinessEvaluator);
 }
 

--- a/src/factories/ory/types.ts
+++ b/src/factories/ory/types.ts
@@ -26,9 +26,13 @@ import type {
   KroResourceFactory,
   PublicFactoryOptions,
 } from '../../core/types/index.js';
-import type { TypeKroChartValue } from '../../core/types/common.js';
+import type { TypeKroChartValue, TypeKroValue } from '../../core/types/common.js';
 import type { HelmRepositorySpec, HelmRepositoryStatus } from '../helm/helm-repository.js';
-import type { HelmReleaseSpec, HelmReleaseStatus } from '../helm/types.js';
+import type {
+  HelmReleasePostRenderer,
+  HelmReleaseSpec,
+  HelmReleaseStatus,
+} from '../helm/types.js';
 import type { ResourceRequirements } from '../cert-manager/types.js';
 import type {
   OAuth2ClientConfig,
@@ -708,6 +712,8 @@ export interface OryHelmReleaseConfigBase<TValues extends object> {
   interval?: string;
   /** Graph-aware chart values serialized recursively by TypeKro. */
   values?: TypeKroChartValue<TValues>;
+  /** Transformations applied after Helm renders the chart. */
+  postRenderers?: TypeKroValue<HelmReleasePostRenderer>[];
   /** TypeKro composition resource id. */
   id?: string;
 }

--- a/src/factories/ory/types.ts
+++ b/src/factories/ory/types.ts
@@ -344,6 +344,12 @@ export interface OryIdentityStackConfig {
   name: string;
   /** Target namespace for Ory services and Maester resources. */
   namespace?: string;
+  /**
+   * Lifecycle of the target namespace. Use `external` when a parent
+   * deployment graph establishes it.
+   * @default 'owned'
+   */
+  namespaceOwnership?: 'owned' | 'external';
   /** Ory chart version. Defaults to the pinned `0.62.0` contract. */
   version?: string;
   /** Explicit external or graph-managed dependency sources. */
@@ -1370,6 +1376,7 @@ const oathkeeperRuleConfigSchema = type({
 export const OryIdentityStackConfigSchema = type({
   name: 'string',
   'namespace?': 'string',
+  'namespaceOwnership?': '"owned" | "external"',
   'version?': 'string',
   'dependencySources?': oryDependencySourceConfigSchema,
   'shared?': 'boolean',

--- a/src/factories/ory/utils/helm-values-mapper.ts
+++ b/src/factories/ory/utils/helm-values-mapper.ts
@@ -29,6 +29,11 @@ import type {
   OryValueSource,
 } from '../types.js';
 
+// Hydra Maester v0.0.40+ regressed namespaced cache scoping even when the
+// chart passes --namespace. Keep the last known-good controller until the
+// upstream fix for ory/hydra-maester#252 is released.
+const HYDRA_MAESTER_SINGLE_NAMESPACE_IMAGE_TAG = 'v0.0.39';
+
 function hasValueSource(source: OryValueSource | undefined): boolean {
   return !!source && (('secretRef' in source && !!source.secretRef.name && !!source.secretRef.key) || ('value' in source && source.value.length > 0));
 }
@@ -640,6 +645,7 @@ export const mapOryConfigToHelmValues: OryHelmValuesMapper = (config) => {
     hydraMaester: mergeValues<OryHydraMaesterChartValues>(
       compact<OryHydraMaesterChartValues>({
         singleNamespaceMode: resolvedConfig.maester?.hydra?.singleNamespaceMode ?? true,
+        image: { tag: HYDRA_MAESTER_SINGLE_NAMESPACE_IMAGE_TAG },
         enabledNamespaces: resolvedConfig.maester?.hydra?.enabledNamespaces,
         serviceMonitor: resolvedConfig.maester?.hydra?.serviceMonitor,
       }),

--- a/src/factories/rook/compositions/rook-ceph-platform.ts
+++ b/src/factories/rook/compositions/rook-ceph-platform.ts
@@ -136,6 +136,11 @@ export const rookCephSingleNodePlatform = kubernetesComposition(
       id: 'objectStore',
     });
     objectStore.dependsOn(cluster);
+    // `cluster` is an observed prerequisite rather than an applied graph node.
+    // Preserve the executable lifecycle edge explicitly so direct/Alchemy
+    // teardown removes the object store before deleting the HelmRelease that
+    // owns the CephCluster and its finalizer.
+    objectStore.dependsOn(clusterRelease);
     const bucketStorageClass = rookBucketStorageClass({
       name: bucketStorageClassName,
       objectStoreName,
@@ -266,6 +271,7 @@ export const rookCephProductionPlatform = kubernetesComposition(
       id: 'objectStore',
     });
     objectStore.dependsOn(cluster);
+    objectStore.dependsOn(clusterRelease);
     const bucketStorageClass = rookBucketStorageClass({
       name: bucketStorageClassName,
       objectStoreName,
@@ -390,6 +396,7 @@ export const rookCephExternalOperatorSingleNodePlatform = kubernetesComposition(
       id: 'objectStore',
     });
     objectStore.dependsOn(cluster);
+    objectStore.dependsOn(clusterRelease);
     const bucketStorageClass = rookBucketStorageClass({
       name: bucketStorageClassName,
       objectStoreName,

--- a/test/conformance/effect-runtime-boundary.test.ts
+++ b/test/conformance/effect-runtime-boundary.test.ts
@@ -10,6 +10,7 @@ describe('Effect runtime architecture boundary', () => {
     expect(provider).toContain('Effect.tryPromise');
     expect(provider).not.toMatch(/Effect\.run(?:Promise|Fork|Sync)/);
     expect(provider).not.toContain('ManagedRuntime');
+    expect(provider).not.toContain('Bun.sleep');
   });
 
   it('keeps the standalone Effect runtime lazy and behind factory facades', async () => {

--- a/test/core/direct-factory.test.ts
+++ b/test/core/direct-factory.test.ts
@@ -12,6 +12,8 @@ import {
   singleton,
   toResourceGraph,
 } from '../../src/index.js';
+import { resourceFromDirectArtifactRecordForTest } from '../../src/alchemy/resource-registration.js';
+import { getReadinessEvaluator } from '../../src/core/metadata/index.js';
 import { decodeDirectArtifactExecutionRecord } from '../../src/experimental-planning.js';
 
 describe('DirectResourceFactory', () => {
@@ -471,12 +473,16 @@ describe('DirectResourceFactory', () => {
           status: type({ ready: 'boolean' }),
         },
         (ownerSpec) => {
-          simple.ConfigMap({
+          const config = simple.ConfigMap({
             id: 'ownerConfig',
             name: ownerSpec.name,
             namespace: 'typekro-singletons',
             data: { installed: 'true' },
           });
+          config.withReadinessEvaluator((resource) => ({
+            ready: resource.data?.installed === 'true',
+            message: 'runtime-bound singleton readiness',
+          }));
           return { ready: true };
         }
       );
@@ -515,6 +521,18 @@ describe('DirectResourceFactory', () => {
       expect(declarations[0]?.props.retain).toBe(true);
       expect(declarations[0]?.props.resourceId).toContain('ownerConfig');
       expect(declarations[0]?.props.artifactExecutionRecord).toBeString();
+      const rehydrated = resourceFromDirectArtifactRecordForTest(
+        declarations[0]!.props
+      );
+      expect(rehydrated?.metadata.annotations).toEqual(
+        expect.objectContaining({
+          'typekro.io/singleton-spec-fingerprint': expect.stringMatching(
+            /^fnv64:[a-f0-9]{16}$/
+          ),
+        })
+      );
+      expect(getReadinessEvaluator(declarations[0]!.props.resource)).toBeFunction();
+      expect(getReadinessEvaluator(rehydrated!)).toBeFunction();
     });
 
     it('persists an explicitly authored resource namespace instead of the factory default', async () => {

--- a/test/core/direct-factory.test.ts
+++ b/test/core/direct-factory.test.ts
@@ -4,7 +4,14 @@
 
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
-import { Cel, createResource, simple, toResourceGraph } from '../../src/index.js';
+import {
+  Cel,
+  createResource,
+  kubernetesComposition,
+  simple,
+  singleton,
+  toResourceGraph,
+} from '../../src/index.js';
 import { decodeDirectArtifactExecutionRecord } from '../../src/experimental-planning.js';
 
 describe('DirectResourceFactory', () => {
@@ -452,6 +459,62 @@ describe('DirectResourceFactory', () => {
       }
       // Distinct alchemy ids per resource (independent state entries).
       expect(decls[0]!.id).not.toBe(decls[1]!.id);
+    });
+
+    it('emits singleton-owner resources when Alchemy is the direct deployment authority', async () => {
+      const owner = kubernetesComposition(
+        {
+          name: 'direct-alchemy-singleton-owner',
+          apiVersion: 'testing.typekro.dev/v1alpha1',
+          kind: 'DirectAlchemySingletonOwner',
+          spec: type({ name: 'string' }),
+          status: type({ ready: 'boolean' }),
+        },
+        (ownerSpec) => {
+          simple.ConfigMap({
+            id: 'ownerConfig',
+            name: ownerSpec.name,
+            namespace: 'typekro-singletons',
+            data: { installed: 'true' },
+          });
+          return { ready: true };
+        }
+      );
+      const consumer = kubernetesComposition(
+        {
+          name: 'direct-alchemy-singleton-consumer',
+          apiVersion: 'testing.typekro.dev/v1alpha1',
+          kind: 'DirectAlchemySingletonConsumer',
+          spec: type({ name: 'string' }),
+          status: type({ ready: 'boolean' }),
+        },
+        () => {
+          const shared = singleton(owner, {
+            id: 'shared-owner',
+            spec: { name: 'shared-owner' },
+          });
+          return { ready: shared.status.ready };
+        }
+      );
+
+      const declarations = await consumer
+        .factory('direct', { namespace: 'apps' })
+        .toAlchemyResources({ name: 'consumer' });
+
+      expect(declarations).toHaveLength(1);
+      expect(declarations[0]?.props.resource.kind).toBe('ConfigMap');
+      expect(declarations[0]?.props.resource.metadata).toMatchObject({
+        name: 'shared-owner',
+        namespace: 'typekro-singletons',
+        annotations: {
+          'typekro.io/singleton-spec-fingerprint': expect.stringMatching(
+            /^fnv64:[a-f0-9]{16}$/
+          ),
+        },
+      });
+      expect(declarations[0]?.props.retain).toBe(true);
+      expect(declarations[0]?.props.resourceId).toContain('ownerConfig');
+      expect(declarations[0]?.props.artifactExecutionRecord).toBeString();
     });
 
     it('persists an explicitly authored resource namespace instead of the factory default', async () => {

--- a/test/core/planning/schema.test.ts
+++ b/test/core/planning/schema.test.ts
@@ -52,6 +52,7 @@ describe('SchemaIR portable profile', () => {
     expect(result.diagnostics).toEqual([]);
     expect(result.root).toEqual({
       kind: 'object',
+      additionalProperties: true,
       properties: [
         {
           name: 'items',
@@ -76,6 +77,45 @@ describe('SchemaIR portable profile', () => {
         },
       ],
     });
+  });
+
+  it('preserves root open-object and undeclared-key policies', () => {
+    expect(schemaToIR(type('object'), { strict: true }).root).toEqual({
+      kind: 'object',
+      properties: [],
+      additionalProperties: true,
+    });
+    expect(
+      schemaToIR(type({ value: 'string' }).onUndeclaredKey('ignore'), {
+        strict: true,
+      }).root
+    ).toEqual({
+      kind: 'object',
+      properties: [
+        {
+          name: 'value',
+          required: true,
+          schema: { kind: 'primitive', type: 'string' },
+        },
+      ],
+      additionalProperties: true,
+    });
+    for (const policy of ['reject', 'delete'] as const) {
+      expect(
+        schemaToIR(type({ value: 'string' }).onUndeclaredKey(policy), {
+          strict: true,
+        }).root
+      ).toEqual({
+        kind: 'object',
+        properties: [
+          {
+            name: 'value',
+            required: true,
+            schema: { kind: 'primitive', type: 'string' },
+          },
+        ],
+      });
+    }
   });
 
   it('diagnoses constructs outside the portable profile before execution', () => {

--- a/test/core/planning/schema.test.ts
+++ b/test/core/planning/schema.test.ts
@@ -40,6 +40,44 @@ describe('SchemaIR portable profile', () => {
     expect(left.digest).toBe(right.digest);
   });
 
+  it('preserves explicitly open object and collection element schemas', () => {
+    const result = schemaToIR(
+      type({
+        payload: 'object',
+        items: 'object[]',
+      }),
+      { strict: true }
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.root).toEqual({
+      kind: 'object',
+      properties: [
+        {
+          name: 'items',
+          required: true,
+          schema: {
+            kind: 'array',
+            items: {
+              kind: 'object',
+              properties: [],
+              additionalProperties: true,
+            },
+          },
+        },
+        {
+          name: 'payload',
+          required: true,
+          schema: {
+            kind: 'object',
+            properties: [],
+            additionalProperties: true,
+          },
+        },
+      ],
+    });
+  });
+
   it('diagnoses constructs outside the portable profile before execution', () => {
     const unsupported = { json: { domain: 'symbol' } };
 

--- a/test/core/planning/values.test.ts
+++ b/test/core/planning/values.test.ts
@@ -12,6 +12,7 @@ import {
   expressionIR,
   externalInput,
   lowerPlanValue,
+  materializePlanOutputs,
   materializePlanValue,
   planExpression,
   resolveStaticYamlSensitiveBindings,
@@ -126,6 +127,67 @@ describe('PlanValue and ExpressionIR', () => {
         spec: { repositoryName: 'custom-repository' },
       })
     ).toBe('custom-repository');
+  });
+
+  it('hydrates composition outputs from live resources without re-running the closure', () => {
+    const outputs = {
+      endpoint: {
+        kind: 'expression' as const,
+        expression: expressionIR(
+          'has(gateway.status.addresses) && size(gateway.status.addresses) > 0 ? "http://" + string(gateway.status.addresses[0].value) + ":" + string(gateway.spec.listeners[0].port) : ""'
+        ),
+      },
+      observedName: {
+        kind: 'reference' as const,
+        source: 'resource' as const,
+        resourceId: 'gateway',
+        fieldPath: 'metadata.name',
+      },
+      advertised: {
+        kind: 'template' as const,
+        segments: [
+          { kind: 'literal' as const, value: 'gateway=' },
+          {
+            kind: 'reference' as const,
+            source: 'resource' as const,
+            resourceId: 'gateway',
+            fieldPath: 'metadata.name',
+          },
+        ],
+      },
+    };
+
+    expect(
+      materializePlanOutputs(outputs, {
+        resources: {
+          gateway: {
+            metadata: { name: 'inference' },
+            spec: { listeners: [{ port: 8080 }] },
+            status: { addresses: [{ value: '10.0.0.12' }] },
+          },
+        },
+      })
+    ).toEqual({
+      advertised: 'gateway=inference',
+      endpoint: 'http://10.0.0.12:8080',
+      observedName: 'inference',
+    });
+  });
+
+  it('preserves resource references when live bindings are not supplied', () => {
+    const value = {
+      kind: 'reference' as const,
+      source: 'resource' as const,
+      resourceId: 'service',
+      fieldPath: 'metadata.name',
+    };
+
+    expect(materializePlanValue(value)).toEqual(
+      expect.objectContaining({
+        resourceId: 'service',
+        fieldPath: 'metadata.name',
+      })
+    );
   });
 
   it('derives references from parsed CEL rather than matching text inside literals', () => {

--- a/test/core/planning/values.test.ts
+++ b/test/core/planning/values.test.ts
@@ -112,6 +112,22 @@ describe('PlanValue and ExpressionIR', () => {
     expect(materializePlanValue(value, { spec: { enabled: false } })).toBe(false);
   });
 
+  it('treats KRO dyn type widening as identity during portable direct materialization', () => {
+    const value = {
+      kind: 'expression' as const,
+      expression: expressionIR(
+        'has(schema.spec.repositoryName) && dyn(schema.spec.repositoryName) != null ? schema.spec.repositoryName : "envoyproxy-helm"'
+      ),
+    };
+
+    expect(materializePlanValue(value, { spec: {} })).toBe('envoyproxy-helm');
+    expect(
+      materializePlanValue(value, {
+        spec: { repositoryName: 'custom-repository' },
+      })
+    ).toBe('custom-repository');
+  });
+
   it('derives references from parsed CEL rather than matching text inside literals', () => {
     const expression = expressionIR(
       '"deployment.status.notAReference" + schema.spec.name + service.metadata.name'

--- a/test/core/planning/values.test.ts
+++ b/test/core/planning/values.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
-
-import { createSchemaProxy } from '../../../src/core/references/schema-proxy.js';
-
 import {
   artifactOutput,
   decodePlanValue,
@@ -19,6 +16,7 @@ import {
   schemaToIR,
   sensitiveValue,
 } from '../../../src/core/planning/index.js';
+import { createSchemaProxy } from '../../../src/core/references/schema-proxy.js';
 
 describe('PlanValue and ExpressionIR', () => {
   it('preserves arrays, object order independence, and omitted values', () => {
@@ -172,6 +170,76 @@ describe('PlanValue and ExpressionIR', () => {
       endpoint: 'http://10.0.0.12:8080',
       observedName: 'inference',
     });
+  });
+
+  it('hydrates resource-backed template expressions from complete live bindings', () => {
+    const value = {
+      kind: 'template' as const,
+      segments: [
+        { kind: 'literal' as const, value: 'replicas=' },
+        {
+          kind: 'expression' as const,
+          expression: expressionIR('string(deployment.status.readyReplicas)'),
+        },
+      ],
+    };
+
+    expect(
+      materializePlanValue(value, {
+        resources: {
+          deployment: { status: { readyReplicas: 3 } },
+        },
+      })
+    ).toBe('replicas=3');
+  });
+
+  it('fails closed when a complete live-resource binding omits a required producer', () => {
+    const required = {
+      kind: 'reference' as const,
+      source: 'resource' as const,
+      resourceId: 'deployment',
+      fieldPath: 'status.readyReplicas',
+    };
+    const expressionTemplate = {
+      kind: 'template' as const,
+      segments: [
+        {
+          kind: 'expression' as const,
+          expression: expressionIR('string(deployment.status.readyReplicas)'),
+        },
+      ],
+    };
+    const expression = {
+      kind: 'expression' as const,
+      expression: expressionIR('deployment.status.readyReplicas'),
+    };
+
+    expect(() => materializePlanValue(required, { resources: {} })).toThrow(
+      'Required resource binding deployment'
+    );
+    expect(() => materializePlanValue(expression, { resources: {} })).toThrow(
+      'Required resource binding deployment'
+    );
+    expect(() => materializePlanValue(expressionTemplate, { resources: {} })).toThrow(
+      'Required resource binding deployment'
+    );
+  });
+
+  it('omits optional resource references absent from complete live bindings', () => {
+    const optional = {
+      kind: 'reference' as const,
+      source: 'resource' as const,
+      resourceId: 'optionalService',
+      fieldPath: 'status.endpoint',
+      optional: true as const,
+    };
+    const template = {
+      kind: 'template' as const,
+      segments: [{ kind: 'literal' as const, value: 'endpoint=' }, optional],
+    };
+
+    expect(materializePlanValue(optional, { resources: {} })).toBeUndefined();
+    expect(materializePlanValue(template, { resources: {} })).toBeUndefined();
   });
 
   it('preserves resource references when live bindings are not supplied', () => {

--- a/test/core/planning/values.test.ts
+++ b/test/core/planning/values.test.ts
@@ -242,6 +242,54 @@ describe('PlanValue and ExpressionIR', () => {
     expect(materializePlanValue(template, { resources: {} })).toBeUndefined();
   });
 
+  it('fails closed on missing spec bindings during concrete template hydration', () => {
+    const referenceTemplate = {
+      kind: 'template' as const,
+      segments: [
+        { kind: 'literal' as const, value: 'label=' },
+        {
+          kind: 'reference' as const,
+          source: 'spec' as const,
+          fieldPath: 'label',
+        },
+      ],
+    };
+    const expressionTemplate = {
+      kind: 'template' as const,
+      segments: [
+        { kind: 'literal' as const, value: 'label=' },
+        {
+          kind: 'expression' as const,
+          expression: expressionIR('string(schema.spec.label)'),
+        },
+      ],
+    };
+
+    expect(() => materializePlanValue(referenceTemplate, { resources: {} })).toThrow(
+      'Spec binding is required to resolve label'
+    );
+    expect(() => materializePlanValue(expressionTemplate, { resources: {} })).toThrow(
+      'Spec binding is required to evaluate string(schema.spec.label)'
+    );
+  });
+
+  it('omits optional spec template references during concrete hydration without spec bindings', () => {
+    const template = {
+      kind: 'template' as const,
+      segments: [
+        { kind: 'literal' as const, value: 'label=' },
+        {
+          kind: 'reference' as const,
+          source: 'spec' as const,
+          fieldPath: 'label',
+          optional: true as const,
+        },
+      ],
+    };
+
+    expect(materializePlanValue(template, { resources: {} })).toBeUndefined();
+  });
+
   it('preserves resource references when live bindings are not supplied', () => {
     const value = {
       kind: 'reference' as const,

--- a/test/factories/envoy-ai-gateway/factory-modes.test.ts
+++ b/test/factories/envoy-ai-gateway/factory-modes.test.ts
@@ -649,6 +649,24 @@ describe('Envoy AI Gateway integration', () => {
     ).toThrow(/must come from mcpSessionEncryptionSeedSecret/);
   });
 
+  test('supports externally owned platform namespaces for parent deployment graphs', () => {
+    const platform = makeEnvoyAIGatewayPlatformInstallation({
+      profile: 'production',
+      namespaceOwnership: 'external',
+      mcpSessionEncryptionSeedSecret: { name: 'managed-seed' },
+    });
+    const yaml = platform.factory('direct', { namespace: 'typekro-system' }).toYaml({
+      name: 'envoy-ai',
+      namespaceOwnership: 'external',
+    });
+
+    expect(
+      documents(yaml).filter((document) => document.kind === 'Namespace')
+    ).toEqual([]);
+    expect(yaml).toContain('namespace: envoy-gateway-system');
+    expect(yaml).toContain('namespace: envoy-ai-gateway-system');
+  });
+
   test('rejects a nested platform profile that weakens or conflicts with the gateway profile', () => {
     expect(() =>
       makeEnvoyAIGateway({

--- a/test/factories/envoy-ai-gateway/factory-modes.test.ts
+++ b/test/factories/envoy-ai-gateway/factory-modes.test.ts
@@ -657,7 +657,6 @@ describe('Envoy AI Gateway integration', () => {
     });
     const yaml = platform.factory('direct', { namespace: 'typekro-system' }).toYaml({
       name: 'envoy-ai',
-      namespaceOwnership: 'external',
     });
 
     expect(
@@ -665,6 +664,22 @@ describe('Envoy AI Gateway integration', () => {
     ).toEqual([]);
     expect(yaml).toContain('namespace: envoy-gateway-system');
     expect(yaml).toContain('namespace: envoy-ai-gateway-system');
+  });
+
+  test('lets the installation spec override the build-time namespace ownership default', () => {
+    const platform = makeEnvoyAIGatewayPlatformInstallation({
+      profile: 'production',
+      namespaceOwnership: 'external',
+      mcpSessionEncryptionSeedSecret: { name: 'managed-seed' },
+    });
+    const yaml = platform.factory('direct', { namespace: 'typekro-system' }).toYaml({
+      name: 'envoy-ai',
+      namespaceOwnership: 'owned',
+    });
+
+    expect(
+      documents(yaml).filter((document) => document.kind === 'Namespace')
+    ).toHaveLength(2);
   });
 
   test('rejects a nested platform profile that weakens or conflicts with the gateway profile', () => {

--- a/test/factories/helm/helm-integration.test.ts
+++ b/test/factories/helm/helm-integration.test.ts
@@ -195,6 +195,54 @@ describe('Helm Integration with TypeKro Magic Proxy System', () => {
     expect(yaml).not.toContain('__KUBERNETES_REF_');
   });
 
+  it('serializes graph-aware Flux post-renderer patch targets', () => {
+    const graph = toResourceGraph(
+      {
+        name: 'helm-post-renderers',
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'TestApp',
+        spec: TestSpecSchema,
+        status: TestStatusSchema,
+      },
+      (schema) => ({
+        app: helmRelease({
+          name: 'my-app',
+          chart: {
+            repository: 'https://charts.example.com',
+            name: 'my-chart',
+          },
+          postRenderers: [
+            {
+              kustomize: {
+                patches: [
+                  {
+                    target: {
+                      group: 'apps',
+                      version: 'v1',
+                      kind: 'Deployment',
+                      name: schema.spec.hostname,
+                    },
+                    patch: '- op: remove\n  path: /metadata/annotations/legacy',
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      }),
+      () => ({ ready: true })
+    );
+
+    const yaml = graph.toYaml();
+
+    expect(yaml).toContain('postRenderers:');
+    expect(yaml).toContain('kustomize:');
+    expect(yaml).toContain('patches:');
+    expect(yaml).toContain('name: ${schema.spec.hostname}');
+    expect(yaml).toContain('/metadata/annotations/legacy');
+    expect(yaml).not.toContain('__KUBERNETES_REF_');
+  });
+
   it('rejects Flux 2.9 literal values sources while the managed baseline is Flux 2.7.5', () => {
     expect(() =>
       helmRelease({

--- a/test/factories/opensearch/factory-modes.test.ts
+++ b/test/factories/opensearch/factory-modes.test.ts
@@ -274,6 +274,31 @@ describe('OpenSearch integration', () => {
     expect(instance).toContain('namespace: typekro-singletons');
   });
 
+  test('emits the complete shared operator installation through direct Alchemy', async () => {
+    const declarations = await openSearchOperatorBootstrap
+      .factory('direct', {
+        namespace: 'application-control',
+        waitForReady: false,
+      })
+      .toAlchemyResources({ name: 'opensearch-operator' });
+
+    expect(
+      declarations.map((declaration) => declaration.props.resource.kind)
+    ).toEqual(['HelmRepository', 'Namespace', 'HelmRelease']);
+    expect(declarations.every((declaration) => declaration.props.retain)).toBe(
+      true
+    );
+    expect(
+      declarations.find(
+        (declaration) =>
+          declaration.props.resource.kind === 'HelmRepository'
+      )?.props.resource.metadata
+    ).toMatchObject({
+      name: 'opensearch-operator',
+      namespace: 'flux-system',
+    });
+  });
+
   test('exposes local operator ownership only through the explicit installation composition', () => {
     const yaml = openSearchOperatorInstallation
       .factory('kro', {

--- a/test/factories/ory/bootstrap-composition.test.ts
+++ b/test/factories/ory/bootstrap-composition.test.ts
@@ -1,9 +1,55 @@
 import { describe, expect, it } from 'bun:test';
 import { oryIdentityStack } from '../../../src/factories/ory/index.js';
-import { OryIdentityStackConfigSchema, OryIdentityStackStatusSchema } from '../../../src/factories/ory/types.js';
+import {
+  OryIdentityStackConfigSchema,
+  OryIdentityStackStatusSchema,
+} from '../../../src/factories/ory/types.js';
 
 function endpoint(url: string, host: string, port: number) {
   return { url, scheme: 'http', host, port };
+}
+
+function managedIdentityConfig(namespaceOwnership: 'owned' | 'external') {
+  return {
+    name: 'identity-test',
+    namespace: 'ory-test',
+    namespaceOwnership,
+    dependencySources: {
+      hydra: {
+        database: { dsn: { mode: 'managed', resourceName: 'identity-test-hydra-db' } },
+        systemSecret: {
+          mode: 'managed',
+          secretName: 'identity-test-hydra-secrets',
+          secretKey: 'system',
+        },
+      },
+      kratos: {
+        database: { dsn: { mode: 'managed', resourceName: 'identity-test-kratos-db' } },
+        secrets: {
+          cookie: {
+            mode: 'managed',
+            secretName: 'identity-test-kratos-secrets',
+            secretKey: 'cookie',
+          },
+          cipher: {
+            mode: 'managed',
+            secretName: 'identity-test-kratos-secrets',
+            secretKey: 'cipher',
+          },
+        },
+      },
+      keto: {
+        database: { dsn: { mode: 'managed', resourceName: 'identity-test-keto-db' } },
+      },
+      oathkeeper: {
+        mutatorIdTokenJwks: {
+          mode: 'managed',
+          secretName: 'identity-test-oathkeeper-secrets',
+          secretKey: 'jwks',
+        },
+      },
+    },
+  } as const;
 }
 
 // Test decision: keep this file focused on Ory-only Helm wiring. Graph-managed
@@ -114,6 +160,36 @@ describe('Ory identity stack composition', () => {
     expect(yaml).not.toContain('schema.spec.resources');
     expect(yaml).not.toContain('__typekroSchemaKey');
     expect(yaml).not.toContain('undefined');
+  });
+
+  it('materializes KRO namespace ownership outside the RGD lifecycle', async () => {
+    const factory = oryIdentityStack.factory('kro', { namespace: 'typekro-system' });
+    const owned = managedIdentityConfig('owned');
+    const external = managedIdentityConfig('external');
+    const ownedDeclarations = await factory.toAlchemyResources(owned);
+    const externalDeclarations = await factory.toAlchemyResources(external);
+
+    expect(
+      ownedDeclarations.filter((declaration) => declaration.props.resource.kind === 'Namespace')
+    ).toEqual([
+      expect.objectContaining({
+        props: expect.objectContaining({
+          resource: expect.objectContaining({
+            metadata: expect.objectContaining({ name: 'ory-test' }),
+          }),
+          namespaceEmptyGate: true,
+        }),
+      }),
+    ]);
+    expect(
+      externalDeclarations.filter((declaration) => declaration.props.resource.kind === 'Namespace')
+    ).toEqual([]);
+    expect(factory.toYaml(owned)).toContain(
+      'typekro.io/hoisted-namespaces: \'["ory-test"]\''
+    );
+    expect(factory.toYaml(external)).toContain(
+      "typekro.io/hoisted-namespaces: '[]'"
+    );
   });
 
   it('Merges graph-mode Ory whole-object Helm values through Kro map merge', () => {

--- a/test/factories/ory/bootstrap-composition.test.ts
+++ b/test/factories/ory/bootstrap-composition.test.ts
@@ -221,6 +221,7 @@ describe('Ory identity stack composition', () => {
     const yaml = await factory.toYaml({
       name: 'identity-values-test',
       namespace: 'ory-test',
+      namespaceOwnership: 'external',
       dependencySources: {
         hydra: {
           database: { dsn: { mode: 'managed', resourceName: 'identity-values-test-hydra-db' } },
@@ -267,6 +268,8 @@ describe('Ory identity stack composition', () => {
     expect(yaml).toContain('level: debug');
     expect(yaml).toContain('replicaCount: 1');
     expect(yaml).not.toContain('customValues');
+    expect(yaml).not.toContain('kind: Namespace');
+    expect(yaml).toContain('namespace: ory-test');
   });
 
 });

--- a/test/factories/ory/bootstrap-composition.test.ts
+++ b/test/factories/ory/bootstrap-composition.test.ts
@@ -206,6 +206,16 @@ describe('Ory identity stack composition', () => {
     expect(yaml).toContain('schema.spec.oathkeeper.values');
     expect(yaml).toContain('json.unmarshal(json.marshal(schema.spec.hydra.values))');
     expect(yaml).toContain('OATHKEEPER_MUTATOR_ID_TOKEN_JWKS');
+    expect(yaml).toContain('postRenderers:');
+    expect(yaml).toContain('name: ${string(schema.spec.name)}-hydra');
+    expect(yaml).toContain('name: ${string(schema.spec.name)}-kratos');
+    expect(yaml).toContain('name: ${string(schema.spec.name)}-kratos-courier');
+    expect(yaml).toContain('kind: StatefulSet');
+    expect(yaml).toContain('name: kratos-courier');
+    expect(yaml).toContain('name: SECRETS_SYSTEM');
+    expect(yaml).toContain('name: SECRETS_COOKIE');
+    expect(yaml).toContain('name: SECRETS_CIPHER');
+    expect(yaml).toContain('$patch: delete');
     expect(yaml).toContain('customReadinessProbe');
     expect(yaml).toContain('customStartupProbe');
     expect(yaml).toContain('/health/alive');
@@ -285,6 +295,10 @@ describe('Ory identity stack composition', () => {
     expect(yaml).toContain('managedAccessRules: false');
     expect(yaml).toContain("access-rules.json: '[]'");
     expect(yaml).toContain('path: /health/alive');
+    expect(yaml).toContain('postRenderers:');
+    expect(yaml).toContain('name: identity-test-hydra');
+    expect(yaml).toContain('name: identity-test-kratos');
+    expect(yaml).toContain('$patch: delete');
     expect(yaml).toContain('kind: OAuth2Client');
     expect(yaml).toContain('kind: Rule');
     expect(yaml).toContain('apiVersion: hydra.ory.sh/v1alpha1');

--- a/test/factories/ory/bootstrap-composition.test.ts
+++ b/test/factories/ory/bootstrap-composition.test.ts
@@ -60,18 +60,33 @@ describe('Ory identity stack composition', () => {
       name: 'identity',
       dependencySources: {
         hydra: {
-          database: { dsn: { mode: 'external', value: { secretRef: { name: 'ory-dsns', key: 'hydra' } } } },
-          systemSecret: { mode: 'external', value: { secretRef: { name: 'ory-secrets', key: 'hydra-system' } } },
+          database: {
+            dsn: { mode: 'external', value: { secretRef: { name: 'ory-dsns', key: 'hydra' } } },
+          },
+          systemSecret: {
+            mode: 'external',
+            value: { secretRef: { name: 'ory-secrets', key: 'hydra-system' } },
+          },
         },
         kratos: {
-          database: { dsn: { mode: 'external', value: { secretRef: { name: 'ory-dsns', key: 'kratos' } } } },
+          database: {
+            dsn: { mode: 'external', value: { secretRef: { name: 'ory-dsns', key: 'kratos' } } },
+          },
           secrets: {
-            cookie: { mode: 'external', value: { secretRef: { name: 'ory-secrets', key: 'kratos-cookie' } } },
-            cipher: { mode: 'external', value: { secretRef: { name: 'ory-secrets', key: 'kratos-cipher' } } },
+            cookie: {
+              mode: 'external',
+              value: { secretRef: { name: 'ory-secrets', key: 'kratos-cookie' } },
+            },
+            cipher: {
+              mode: 'external',
+              value: { secretRef: { name: 'ory-secrets', key: 'kratos-cipher' } },
+            },
           },
         },
         keto: {
-          database: { dsn: { mode: 'external', value: { secretRef: { name: 'ory-dsns', key: 'keto' } } } },
+          database: {
+            dsn: { mode: 'external', value: { secretRef: { name: 'ory-dsns', key: 'keto' } } },
+          },
         },
         oathkeeper: {
           mutatorIdTokenJwks: {
@@ -110,14 +125,46 @@ describe('Ory identity stack composition', () => {
       components: { hydra: true, kratos: true, keto: true, oathkeeper: true },
       maester: { hydra: true, oathkeeper: true },
       endpoints: {
-        hydraPublic: endpoint('http://hydra-public.ory-system.svc.cluster.local:4444', 'hydra-public.ory-system.svc.cluster.local', 4444),
-        hydraAdmin: endpoint('http://hydra-admin.ory-system.svc.cluster.local:4445', 'hydra-admin.ory-system.svc.cluster.local', 4445),
-        kratosPublic: endpoint('http://kratos-public.ory-system.svc.cluster.local:4433', 'kratos-public.ory-system.svc.cluster.local', 4433),
-        kratosAdmin: endpoint('http://kratos-admin.ory-system.svc.cluster.local:4434', 'kratos-admin.ory-system.svc.cluster.local', 4434),
-        ketoRead: endpoint('http://keto-read.ory-system.svc.cluster.local:4466', 'keto-read.ory-system.svc.cluster.local', 4466),
-        ketoWrite: endpoint('http://keto-write.ory-system.svc.cluster.local:4467', 'keto-write.ory-system.svc.cluster.local', 4467),
-        oathkeeperProxy: endpoint('http://oathkeeper-proxy.ory-system.svc.cluster.local:4455', 'oathkeeper-proxy.ory-system.svc.cluster.local', 4455),
-        oathkeeperApi: endpoint('http://oathkeeper-api.ory-system.svc.cluster.local:4456', 'oathkeeper-api.ory-system.svc.cluster.local', 4456),
+        hydraPublic: endpoint(
+          'http://hydra-public.ory-system.svc.cluster.local:4444',
+          'hydra-public.ory-system.svc.cluster.local',
+          4444
+        ),
+        hydraAdmin: endpoint(
+          'http://hydra-admin.ory-system.svc.cluster.local:4445',
+          'hydra-admin.ory-system.svc.cluster.local',
+          4445
+        ),
+        kratosPublic: endpoint(
+          'http://kratos-public.ory-system.svc.cluster.local:4433',
+          'kratos-public.ory-system.svc.cluster.local',
+          4433
+        ),
+        kratosAdmin: endpoint(
+          'http://kratos-admin.ory-system.svc.cluster.local:4434',
+          'kratos-admin.ory-system.svc.cluster.local',
+          4434
+        ),
+        ketoRead: endpoint(
+          'http://keto-read.ory-system.svc.cluster.local:4466',
+          'keto-read.ory-system.svc.cluster.local',
+          4466
+        ),
+        ketoWrite: endpoint(
+          'http://keto-write.ory-system.svc.cluster.local:4467',
+          'keto-write.ory-system.svc.cluster.local',
+          4467
+        ),
+        oathkeeperProxy: endpoint(
+          'http://oathkeeper-proxy.ory-system.svc.cluster.local:4455',
+          'oathkeeper-proxy.ory-system.svc.cluster.local',
+          4455
+        ),
+        oathkeeperApi: endpoint(
+          'http://oathkeeper-api.ory-system.svc.cluster.local:4456',
+          'oathkeeper-api.ory-system.svc.cluster.local',
+          4456
+        ),
       },
       version: '0.62.0',
     });
@@ -184,19 +231,15 @@ describe('Ory identity stack composition', () => {
     expect(
       externalDeclarations.filter((declaration) => declaration.props.resource.kind === 'Namespace')
     ).toEqual([]);
-    expect(factory.toYaml(owned)).toContain(
-      'typekro.io/hoisted-namespaces: \'["ory-test"]\''
-    );
-    expect(factory.toYaml(external)).toContain(
-      "typekro.io/hoisted-namespaces: '[]'"
-    );
+    expect(factory.toYaml(owned)).toContain('typekro.io/hoisted-namespaces: \'["ory-test"]\'');
+    expect(factory.toYaml(external)).toContain("typekro.io/hoisted-namespaces: '[]'");
   });
 
   it('Merges graph-mode Ory whole-object Helm values through Kro map merge', () => {
     const yaml = oryIdentityStack.toYaml();
 
     expect(yaml).toContain('schema.spec.global');
-    expect(yaml).toContain('${dyn(((has(schema.spec.hydra) && has(schema.spec.hydra.values)');
+    expect(yaml).toContain('${dyn((((has(schema.spec.hydra) && has(schema.spec.hydra.values)');
     expect(yaml).toContain('json.unmarshal(json.marshal(schema.spec.hydra.values)) : {}).merge');
     expect(yaml).toContain('["deployment"]).merge');
     expect(yaml).toContain('["hydra"]).merge');
@@ -205,6 +248,10 @@ describe('Ory identity stack composition', () => {
     expect(yaml).toContain('schema.spec.keto.values');
     expect(yaml).toContain('schema.spec.oathkeeper.values');
     expect(yaml).toContain('json.unmarshal(json.marshal(schema.spec.hydra.values))');
+    expect(yaml).toContain('"fullnameOverride": string(schema.spec.name) + "-hydra"');
+    expect(yaml).toContain('"nameOverride": "hydra"');
+    expect(yaml).toContain('"fullnameOverride": string(schema.spec.name) + "-kratos"');
+    expect(yaml).toContain('"nameOverride": "kratos"');
     expect(yaml).toContain('OATHKEEPER_MUTATOR_ID_TOKEN_JWKS');
     expect(yaml).toContain('postRenderers:');
     expect(yaml).toContain('name: ${string(schema.spec.name)}-hydra');
@@ -224,6 +271,82 @@ describe('Ory identity stack composition', () => {
     expect(yaml).not.toContain('[object Object]');
   });
 
+  it('keeps external-secret post-renderers aligned when raw chart naming overrides are supplied', async () => {
+    const factory = oryIdentityStack.factory('direct', { namespace: 'ory-test' });
+    const base = managedIdentityConfig('external');
+    const config = {
+      ...base,
+      dependencySources: {
+        ...base.dependencySources,
+        hydra: {
+          database: {
+            dsn: {
+              mode: 'external',
+              value: { secretRef: { name: 'ory-dsns', key: 'hydra' } },
+            },
+          },
+          systemSecret: {
+            mode: 'external',
+            value: { secretRef: { name: 'ory-secrets', key: 'hydra-system' } },
+          },
+        },
+        kratos: {
+          database: {
+            dsn: {
+              mode: 'external',
+              value: { secretRef: { name: 'ory-dsns', key: 'kratos' } },
+            },
+          },
+          secrets: {
+            cookie: {
+              mode: 'external',
+              value: { secretRef: { name: 'ory-secrets', key: 'kratos-cookie' } },
+            },
+            cipher: {
+              mode: 'external',
+              value: { secretRef: { name: 'ory-secrets', key: 'kratos-cipher' } },
+            },
+          },
+        },
+      },
+      hydra: {
+        values: {
+          nameOverride: 'unsafe-hydra-name',
+          fullnameOverride: 'unsafe-hydra-fullname',
+        },
+      },
+      kratos: {
+        values: {
+          nameOverride: 'unsafe-kratos-name',
+          fullnameOverride: 'unsafe-kratos-fullname',
+        },
+      },
+    } as const;
+    const direct = await factory.toYaml(config);
+    const kro = oryIdentityStack.toYaml();
+
+    expect(direct).toContain('nameOverride: hydra');
+    expect(direct).toContain('fullnameOverride: identity-test-hydra');
+    expect(direct).toContain('nameOverride: kratos');
+    expect(direct).toContain('fullnameOverride: identity-test-kratos');
+    expect(direct).not.toContain('unsafe-hydra-name');
+    expect(direct).not.toContain('unsafe-hydra-fullname');
+    expect(direct).not.toContain('unsafe-kratos-name');
+    expect(direct).not.toContain('unsafe-kratos-fullname');
+    expect(direct).toContain('name: ory-secrets');
+    expect(direct).toContain('name: identity-test-hydra');
+    expect(direct).toContain('name: identity-test-kratos');
+    expect(direct).toContain('name: identity-test-kratos-courier');
+
+    expect(kro).toContain('"fullnameOverride": string(schema.spec.name) + "-hydra"');
+    expect(kro).toContain('"nameOverride": "hydra"');
+    expect(kro).toContain('"fullnameOverride": string(schema.spec.name) + "-kratos"');
+    expect(kro).toContain('"nameOverride": "kratos"');
+    expect(kro).toContain('name: ${string(schema.spec.name)}-hydra');
+    expect(kro).toContain('name: ${string(schema.spec.name)}-kratos');
+    expect(kro).toContain('name: ${string(schema.spec.name)}-kratos-courier');
+  });
+
   it('Generate direct-mode YAML for managed local dependency sources with starter OAuth2Client and Rule resources', async () => {
     const factory = oryIdentityStack.factory('direct', { namespace: 'ory-test' });
     const yaml = await factory.toYaml({
@@ -232,13 +355,25 @@ describe('Ory identity stack composition', () => {
       dependencySources: {
         hydra: {
           database: { dsn: { mode: 'managed', resourceName: 'identity-test-hydra-db' } },
-          systemSecret: { mode: 'managed', secretName: 'identity-test-hydra-secrets', secretKey: 'system' },
+          systemSecret: {
+            mode: 'managed',
+            secretName: 'identity-test-hydra-secrets',
+            secretKey: 'system',
+          },
         },
         kratos: {
           database: { dsn: { mode: 'managed', resourceName: 'identity-test-kratos-db' } },
           secrets: {
-            cookie: { mode: 'managed', secretName: 'identity-test-kratos-secrets', secretKey: 'cookie' },
-            cipher: { mode: 'managed', secretName: 'identity-test-kratos-secrets', secretKey: 'cipher' },
+            cookie: {
+              mode: 'managed',
+              secretName: 'identity-test-kratos-secrets',
+              secretKey: 'cookie',
+            },
+            cipher: {
+              mode: 'managed',
+              secretName: 'identity-test-kratos-secrets',
+              secretKey: 'cipher',
+            },
           },
         },
         keto: {
@@ -315,13 +450,25 @@ describe('Ory identity stack composition', () => {
       dependencySources: {
         hydra: {
           database: { dsn: { mode: 'managed', resourceName: 'identity-values-test-hydra-db' } },
-          systemSecret: { mode: 'managed', secretName: 'identity-values-test-hydra-secrets', secretKey: 'system' },
+          systemSecret: {
+            mode: 'managed',
+            secretName: 'identity-values-test-hydra-secrets',
+            secretKey: 'system',
+          },
         },
         kratos: {
           database: { dsn: { mode: 'managed', resourceName: 'identity-values-test-kratos-db' } },
           secrets: {
-            cookie: { mode: 'managed', secretName: 'identity-values-test-kratos-secrets', secretKey: 'cookie' },
-            cipher: { mode: 'managed', secretName: 'identity-values-test-kratos-secrets', secretKey: 'cipher' },
+            cookie: {
+              mode: 'managed',
+              secretName: 'identity-values-test-kratos-secrets',
+              secretKey: 'cookie',
+            },
+            cipher: {
+              mode: 'managed',
+              secretName: 'identity-values-test-kratos-secrets',
+              secretKey: 'cipher',
+            },
           },
         },
         keto: {
@@ -361,5 +508,4 @@ describe('Ory identity stack composition', () => {
     expect(yaml).not.toContain('kind: Namespace');
     expect(yaml).toContain('namespace: ory-test');
   });
-
 });

--- a/test/factories/ory/platform-composition.test.ts
+++ b/test/factories/ory/platform-composition.test.ts
@@ -276,6 +276,39 @@ describe('Ory platform stack composition', () => {
     expect(renderedYaml).not.toContain('${${');
   });
 
+  it('produces a strict semantic plan for the managed platform contract', () => {
+    const spec = {
+      name: 'identity-start-identity',
+      namespace: 'identity-start-system',
+      shared: true,
+      managed: {
+        databases: true,
+        secrets: true,
+        routes: false,
+        sampleUpstream: false,
+        courierSes: false,
+      },
+    } as const;
+
+    if (!oryPlatformStack.inspect || !oryPlatformStack.plan) {
+      throw new Error('Ory platform composition must expose semantic planning.');
+    }
+    const inspection = oryPlatformStack.inspect();
+    const plan = oryPlatformStack.plan(spec, { strict: true });
+    const errors = [...inspection.diagnostics, ...plan.diagnostics].filter(
+      (diagnostic) => diagnostic.severity === 'error'
+    );
+
+    expect(errors).toEqual([]);
+    expect(
+      plan.diagnostics.filter(
+        (diagnostic) =>
+          diagnostic.code === 'PLAN_FACTORY_PROVENANCE_AMBIGUOUS' ||
+          diagnostic.code === 'SCHEMA_IR_UNSUPPORTED'
+      )
+    ).toEqual([]);
+  });
+
   it('Reject disabled managed dependencies unless external replacements are supplied', async () => {
     const factory = oryPlatformStack.factory('direct', { namespace: 'ory-system' });
 

--- a/test/factories/ory/values-mapper.test.ts
+++ b/test/factories/ory/values-mapper.test.ts
@@ -122,6 +122,7 @@ describe('Ory Helm values mapper', () => {
       default_browser_return_url: 'http://identity-test-kratos-public.ory-test.svc.cluster.local',
     });
     expect(values.hydraMaester.singleNamespaceMode).toBe(true);
+    expect(values.hydraMaester.image?.tag).toBe('v0.0.39');
     expect(values.oathkeeperMaester.singleNamespaceMode).toBe(true);
     expect(values.oathkeeper.oathkeeper?.managedAccessRules).toBe(false);
   });

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -173,6 +173,28 @@ describe('official Rook Ceph cluster chart platform', () => {
     expectCleanYaml(yaml);
   });
 
+  it('keeps the object store behind the executable cluster release lifecycle edge', async () => {
+    const declarations = await rookCephSingleNodePlatform
+      .factory('direct', { namespace: 'control' })
+      .toAlchemyResources({
+        name: 'rook-local',
+        profile: 'single-node-development',
+        namespace: 'ceph-data',
+        operatorNamespace: 'ceph-operator',
+        storageClassName: 'local-path',
+        bucketStorageClassName: 'harbor-retain',
+      });
+    const clusterRelease = declarations.find(
+      (declaration) => declaration.props.resourceId === 'clusterRelease'
+    );
+    const objectStore = declarations.find(
+      (declaration) => declaration.props.resourceId === 'objectStore'
+    );
+
+    expect(clusterRelease).toBeDefined();
+    expect(objectStore?.dependsOn).toContain(clusterRelease?.id);
+  });
+
   it('generates a KRO graph with complete public status and graph-aware defaults', () => {
     const yaml = rookCephSingleNodePlatform
       .factory('kro', { namespace: 'typekro-control' })

--- a/test/unit/alchemy/live-drift.test.ts
+++ b/test/unit/alchemy/live-drift.test.ts
@@ -116,6 +116,29 @@ describe('Alchemy persisted TypeKro resource drift', () => {
     expect(sleeps).toBe(1);
   });
 
+  it('uses a runtime-neutral default wait while a terminating identity disappears', async () => {
+    let reads = 0;
+    await waitForPersistedIdentityDeletionForTest(props, output, undefined, {
+      reader: {
+        read: async () => {
+          reads += 1;
+          if (reads === 1) {
+            return {
+              ...deployed,
+              metadata: {
+                ...deployed.metadata,
+                deletionTimestamp: new Date('2026-08-02T00:00:00.000Z'),
+              },
+            };
+          }
+          throw Object.assign(new Error('not found'), { statusCode: 404 });
+        },
+      },
+      pollIntervalMs: 0,
+    });
+    expect(reads).toBe(2);
+  });
+
   it('fails rather than reporting success while a persisted identity remains terminating', async () => {
     const owner = {
       apiVersion: 'apps/v1',


### PR DESCRIPTION
## What changed

- represent ArkType `object` and `object[]` nodes as explicitly open objects in the versioned semantic-planning schema IR
- validate the new `additionalProperties` marker during plan decoding
- record exact lowercase `secret` factory provenance from the Kubernetes Secret factory
- add strict semantic-plan regression coverage for the managed `oryPlatformStack`

## Why

Applik8s v0.7 uses TypeKro strict semantic planning for every infrastructure composition. The released managed Ory composition was rejected with 214 `SCHEMA_IR_UNSUPPORTED` diagnostics for chart-value passthrough objects and six `PLAN_FACTORY_PROVENANCE_AMBIGUOUS` diagnostics for managed Secrets. Both were representation/provenance gaps: the composition itself is valid and renders correctly.

This keeps Applik8s fail-closed and fixes the abstraction at TypeKro’s planning boundary instead of filtering diagnostics downstream.

## Validation

- full TypeKro unit suite: 5,251 passed, 0 failed
- focused planning/Ory suite: 42 passed
- full typecheck
- lint
- library build
- `git diff --check`
