### PR TITLE
fix: separate Alchemy scheduling from artifact dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Direct Alchemy singleton owners now gate consumer scheduling through a dedicated barrier instead
+  of being injected into each consumer's canonical live-resource dependencies. This preserves
+  singleton readiness ordering without making direct artifact execution records fail dependency
+  parity during materialization.
+- Automatic KRO artifact-binding migration now replaces the complete generated CRD with
+  resource-version concurrency rather than sending a partial merge patch through
+  `KubernetesObjectApi`. This avoids the client serializer's `data is not iterable` failure while
+  retaining restart-safe conflict retries.
 - Semantic planning now represents ArkType's explicitly open `object` and
   `object[]` nodes—including root `type('object')` schemas and ordinary or
   `ignore` undeclared-key policies—without falsely opening `reject`/`delete`

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -343,7 +343,7 @@ export function materializeAlchemyResources(
           `materializeAlchemyResources: duplicate declaration id '${decl.id}' in one materialization call.`
         );
       }
-      const deps = decl.dependsOn.map((id) => {
+      const dependencyHandle = (id: string) => {
         const handle = handles[id];
         if (!handle) {
           // Declarations must be topologically ordered so every dependency is instantiated first.
@@ -355,7 +355,9 @@ export function materializeAlchemyResources(
           );
         }
         return handle;
-      });
+      };
+      const deps = decl.dependsOn.map(dependencyHandle);
+      const schedulingDeps = (decl.schedulingDependsOn ?? []).map(dependencyHandle);
       const artifactRequirements =
         decl.artifactRequirements ?? decl.props.artifactRequirements ?? [];
       const artifactOutputUses = decl.artifactOutputUses ?? decl.props.artifactOutputUses ?? [];
@@ -368,6 +370,17 @@ export function materializeAlchemyResources(
       const props = {
         ...decl.props,
         ...(deps.length > 0 ? { dependencies: Output.all(...deps.map((d) => Output.of(d))) } : {}),
+        ...(schedulingDeps.length > 0
+          ? {
+              // Resolve every scheduling handle, but persist only a stable scalar. The barrier
+              // creates Alchemy edges without copying unrelated singleton outputs into consumer
+              // state or direct artifact materialization.
+              schedulingBarrier: Output.map(
+                Output.all(...schedulingDeps.map((dependency) => Output.of(dependency))),
+                () => true
+              ),
+            }
+          : {}),
         ...(artifactOutputs ? { artifactOutputs } : {}),
       };
       // Cast: `props` carries an `Output` for `dependencies` that the `KroResource` constructor

--- a/src/alchemy/types.ts
+++ b/src/alchemy/types.ts
@@ -174,6 +174,16 @@ export interface TypeKroResourceProps<T extends Enhanced<any, any>> {
   dependencies?: TypeKroResource<Enhanced<unknown, unknown>>[];
 
   /**
+   * Alchemy-only ordering inputs which must resolve before this resource is reconciled but are not
+   * semantic dependencies of the Kubernetes operation. Singleton owners use this channel so their
+   * readiness orders consumers without being injected into the consumer's canonical direct
+   * execution record or live-resource bindings.
+   *
+   * Populated by {@link materializeAlchemyResources}; callers should not set it by hand.
+   */
+  schedulingBarrier?: boolean;
+
+  /**
    * Optional deployment options
    */
   options?: Partial<Omit<DeploymentOptions, 'mode' | 'namespace'>>;
@@ -200,6 +210,12 @@ export interface AlchemyResourceDeclaration {
    * these into alchemy `Output` dependencies (ordering + direct-mode reference resolution).
    */
   readonly dependsOn: readonly string[];
+  /**
+   * Declaration ids that gate Alchemy scheduling only. Unlike {@link dependsOn}, these resources
+   * are not exposed to direct-mode reference resolution and therefore are not required to appear
+   * in the canonical artifact execution record.
+   */
+  readonly schedulingDependsOn?: readonly string[];
   /** External provider requirements consumed by this declaration. */
   readonly artifactRequirements?: readonly ArtifactRequirement[];
   /** Exact outputs used by this declaration, including sensitivity taint. */

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -1810,7 +1810,10 @@ export class DirectResourceFactoryImpl<
       ...singletonDeclarations,
       ...applicationDeclarations.map((declaration) => ({
         ...declaration,
-        dependsOn: [...new Set([...singletonIds, ...declaration.dependsOn])],
+        // Singleton owners gate Alchemy scheduling, but are not canonical dependencies of every
+        // consumer Kubernetes operation. Keeping this edge separate preserves the compiled direct
+        // execution record while still waiting for singleton readiness before reconciliation.
+        schedulingDependsOn: singletonIds,
       })),
     ];
   }

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -7,7 +7,7 @@ const STABLE_BINDING_SCHEMA = 'map[string]map[string]string';
 const MAX_CRD_PATCH_ATTEMPTS = 5;
 type MigrationApi = Pick<
   ReturnType<typeof createBunCompatibleKubernetesObjectApi>,
-  'read' | 'list' | 'patch'
+  'read' | 'list' | 'patch' | 'replace'
 >;
 
 interface ResourceGraphDefinition extends KubernetesObject {
@@ -262,24 +262,23 @@ export async function migrateLegacyKroArtifactBindingCrd(
     }
 
     try {
-      await api.patch(
-        {
-          apiVersion: 'apiextensions.k8s.io/v1',
-          kind: 'CustomResourceDefinition',
-          metadata: {
-            name: crd.metadata.name,
-            ...(crd.metadata.resourceVersion
-              ? { resourceVersion: crd.metadata.resourceVersion }
-              : {}),
-          },
-          spec: { versions },
+      // KubernetesObjectApi.patch() asks @kubernetes/client-node to serialize this typed CRD as
+      // JSON Patch, even when a merge-patch content type is supplied. A partial CRD object then
+      // fails inside ObjectSerializer ("data is not iterable") before reaching Kubernetes.
+      // Replace the complete object read above instead. resourceVersion provides optimistic
+      // concurrency and the retry loop re-reads on conflict, preserving restart safety.
+      await api.replace({
+        ...crd,
+        // KubernetesObjectApi list deserialization does not consistently retain TypeMeta on
+        // individual CRD items. A generic replacement requires it even though the list endpoint
+        // and returned spec already identify the resource type.
+        apiVersion: 'apiextensions.k8s.io/v1',
+        kind: 'CustomResourceDefinition',
+        spec: {
+          ...crd.spec,
+          versions,
         },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'application/merge-patch+json'
-      );
+      });
       await requestRgdReconcile(api, rgdName);
       return;
     } catch (error: unknown) {

--- a/test/core/direct-factory.test.ts
+++ b/test/core/direct-factory.test.ts
@@ -499,6 +499,12 @@ describe('DirectResourceFactory', () => {
             id: 'shared-owner',
             spec: { name: 'shared-owner' },
           });
+          simple.ConfigMap({
+            id: 'consumerConfig',
+            name: 'consumer',
+            namespace: 'apps',
+            data: { role: 'application-resource' },
+          });
           return { ready: shared.status.ready };
         }
       );
@@ -507,9 +513,13 @@ describe('DirectResourceFactory', () => {
         .factory('direct', { namespace: 'apps' })
         .toAlchemyResources({ name: 'consumer' });
 
-      expect(declarations).toHaveLength(1);
-      expect(declarations[0]?.props.resource.kind).toBe('ConfigMap');
-      expect(declarations[0]?.props.resource.metadata).toMatchObject({
+      expect(declarations).toHaveLength(2);
+      const singletonDeclaration = declarations.find((declaration) => declaration.props.retain);
+      const consumerDeclaration = declarations.find(
+        (declaration) => declaration.props.resourceId === 'consumerConfig'
+      );
+      expect(singletonDeclaration?.props.resource.kind).toBe('ConfigMap');
+      expect(singletonDeclaration?.props.resource.metadata).toMatchObject({
         name: 'shared-owner',
         namespace: 'typekro-singletons',
         annotations: {
@@ -518,11 +528,11 @@ describe('DirectResourceFactory', () => {
           ),
         },
       });
-      expect(declarations[0]?.props.retain).toBe(true);
-      expect(declarations[0]?.props.resourceId).toContain('ownerConfig');
-      expect(declarations[0]?.props.artifactExecutionRecord).toBeString();
+      expect(singletonDeclaration?.props.retain).toBe(true);
+      expect(singletonDeclaration?.props.resourceId).toContain('ownerConfig');
+      expect(singletonDeclaration?.props.artifactExecutionRecord).toBeString();
       const rehydrated = resourceFromDirectArtifactRecordForTest(
-        declarations[0]!.props
+        singletonDeclaration!.props
       );
       expect(rehydrated?.metadata.annotations).toEqual(
         expect.objectContaining({
@@ -531,8 +541,15 @@ describe('DirectResourceFactory', () => {
           ),
         })
       );
-      expect(getReadinessEvaluator(declarations[0]!.props.resource)).toBeFunction();
+      expect(getReadinessEvaluator(singletonDeclaration!.props.resource)).toBeFunction();
       expect(getReadinessEvaluator(rehydrated!)).toBeFunction();
+
+      const consumerRecord = decodeDirectArtifactExecutionRecord(
+        consumerDeclaration!.props.artifactExecutionRecord!
+      );
+      expect(consumerRecord.dependencies).toEqual([]);
+      expect(consumerDeclaration?.dependsOn).toEqual([]);
+      expect(consumerDeclaration?.schedulingDependsOn).toEqual([singletonDeclaration!.id]);
     });
 
     it('persists an explicitly authored resource namespace instead of the factory default', async () => {

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -29,8 +29,8 @@ function desiredRgd(): KubernetesObject {
 
 function legacyCrd(resourceVersion: string): KubernetesObject {
   return {
-    apiVersion: 'apiextensions.k8s.io/v1',
-    kind: 'CustomResourceDefinition',
+    // Match KubernetesObjectApi list deserialization: TypeMeta may be omitted
+    // from each returned item even though the list endpoint determines it.
     metadata: {
       name: 'applications.application.example',
       resourceVersion,
@@ -88,26 +88,26 @@ describe('KRO artifact-binding migration', () => {
       .mockResolvedValueOnce({ items: [legacyCrd('10')] })
       .mockResolvedValueOnce({ items: [legacyCrd('11')] });
     const crdVersions: string[] = [];
-    const patch = mock(async (resource: KubernetesObject) => {
-      if (resource.kind === 'CustomResourceDefinition') {
-        crdVersions.push(resource.metadata?.resourceVersion ?? '');
-        if (crdVersions.length === 1) {
-          throw { statusCode: 409, message: 'conflict' };
-        }
+    const patch = mock(async (resource: KubernetesObject) => resource);
+    const replace = mock(async (resource: KubernetesObject) => {
+      crdVersions.push(resource.metadata?.resourceVersion ?? '');
+      if (crdVersions.length === 1) {
+        throw { statusCode: 409, message: 'conflict' };
       }
       return resource;
     });
 
     await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
-      api: { read, list, patch } as never,
+      api: { read, list, patch, replace } as never,
     });
 
     expect(crdVersions).toEqual(['10', '11']);
     expect(list).toHaveBeenCalledTimes(2);
-    const crdPatches = patch.mock.calls
-      .map(([resource]) => resource as KubernetesObject)
-      .filter((resource: KubernetesObject) => resource.kind === 'CustomResourceDefinition');
-    const finalCrdPatch = crdPatches[crdPatches.length - 1];
+    const finalCrdPatch = replace.mock.calls.at(-1)?.[0] as KubernetesObject | undefined;
+    expect(finalCrdPatch).toMatchObject({
+      apiVersion: 'apiextensions.k8s.io/v1',
+      kind: 'CustomResourceDefinition',
+    });
     const versions = Reflect.get(
       Reflect.get(finalCrdPatch ?? {}, 'spec') ?? {},
       'versions'

--- a/test/unit/alchemy/materialize-alchemy-resources.test.ts
+++ b/test/unit/alchemy/materialize-alchemy-resources.test.ts
@@ -65,6 +65,20 @@ describe('materializeAlchemyResources', () => {
     expect(bCall?.props.dependencies).toBeDefined();
   });
 
+  it('wires scheduling-only edges without exposing them as live-resource dependencies', async () => {
+    const { fake, calls } = makeFakeKroResource();
+    await Effect.runPromise(
+      materializeAlchemyResources(fake, [
+        decl('owner'),
+        { ...decl('consumer'), schedulingDependsOn: ['owner'] },
+      ]) as Effect.Effect<unknown>
+    );
+
+    const consumer = calls.find((call) => call.id === 'consumer');
+    expect(consumer?.props.schedulingBarrier).toBeDefined();
+    expect('dependencies' in (consumer?.props ?? {})).toBe(false);
+  });
+
   it('throws loudly when a dependsOn id is not (yet) instantiated (out-of-order/unknown)', async () => {
     const { fake } = makeFakeKroResource();
     // 'b' lists 'a' but 'a' comes AFTER it → 'a' handle not present when 'b' is materialized.


### PR DESCRIPTION
## What

- add an Alchemy-only scheduling dependency channel so direct singleton owners gate consumer reconciliation without becoming canonical live-resource dependencies
- materialize scheduling edges as a stable scalar barrier rather than persisting singleton output state in every consumer
- migrate generated KRO artifact-binding CRDs with a full resourceVersion-protected replacement instead of a partial generic merge patch
- restore CRD TypeMeta explicitly because KubernetesObjectApi list deserialization can omit it

## Why

Applik8s v0.7 qualification exposed two released v0.33.2 blockers:

1. singleton owner IDs were prepended to each direct declaration's `dependsOn`, while the canonical artifact execution record correctly contained only semantic resource dependencies; materialization then failed closed on dependency mismatch
2. the v0.32 artifact-binding migration used `KubernetesObjectApi.patch()` with a partial CRD merge body; `@kubernetes/client-node` attempted JSON-patch serialization and failed with `TypeError: data is not iterable`

The fixes preserve the intended boundaries: Alchemy scheduling remains host-level, canonical direct records remain compiler-authoritative, and CRD migration remains restart-safe with optimistic-concurrency retries.

## Verification

- `bun run test`: 5,269 passed, 13 skipped, 1 todo, 0 failed
- `bun run typecheck`
- `bun run lint`
- focused Alchemy/direct/migration suites: 216 passed
- Applik8s TypeKro provider qualification against this worktree
- live OrbStack v0.32 artifact-backed KRO instance upgrade, including stable schema admission, new output reconciliation, and complete cleanup