### PR TITLE
fix: harden TypeKro lifecycle and artifact migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic KRO artifact-binding migration now replaces the complete generated CRD with
   resource-version concurrency rather than sending a partial merge patch through
   `KubernetesObjectApi`. This avoids the client serializer's `data is not iterable` failure while
-  retaining restart-safe conflict retries.
+  retaining restart-safe conflict retries. Version-only schemas correctly resolve to KRO's default
+  `kro.run` API group during migration.
 - Artifact-binding migration now also replaces the complete ResourceGraphDefinition with
   resource-version concurrency. This avoids the same client serializer failure when an RGD update
   contains array-valued resources, while preserving live metadata and omitting status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resource-version concurrency rather than sending a partial merge patch through
   `KubernetesObjectApi`. This avoids the client serializer's `data is not iterable` failure while
   retaining restart-safe conflict retries.
+- Artifact-binding migration now also replaces the complete ResourceGraphDefinition with
+  resource-version concurrency. This avoids the same client serializer failure when an RGD update
+  contains array-valued resources, while preserving live metadata and omitting status.
 - Semantic planning now represents ArkType's explicitly open `object` and
   `object[]` nodes—including root `type('object')` schemas and ordinary or
   `ignore` undeclared-key policies—without falsely opening `reject`/`delete`

--- a/docs/api/envoy-ai-gateway/index.md
+++ b/docs/api/envoy-ai-gateway/index.md
@@ -216,6 +216,9 @@ Direct and KRO factories expose the same complete status:
 }
 ```
 
+`endpoint` is the complete OpenAI-compatible API base URL and ends in `/v1`;
+clients append protocol operations such as `/chat/completions` to that base.
+
 Readiness requires the current observed generation for the platform,
 `GatewayConfig`, `Gateway`, route, and every provider policy whenever the
 upstream controller supplies `observedGeneration`. Envoy AI Gateway v0.6 can

--- a/docs/api/rook/index.md
+++ b/docs/api/rook/index.md
@@ -120,6 +120,8 @@ await local.deploy({
   operatorNamespace: 'rook-ceph-operator',
   storageClassName: 'local-block',
   storageSize: '16Gi',
+  // Development-only escape hatch for loop-backed local block fixtures.
+  allowLoopDevices: true,
   objectStoreName: 'application-objects',
   bucketStorageClassName: 'application-buckets-retain',
   resources: {
@@ -142,6 +144,9 @@ requirements; specify every request and limit that the daemon should retain.
 The same values are admitted and rendered in direct and KRO modes, including
 the OSD resource requirements on its storage device set and the RGW gateway
 requirements on the separately materialized `CephObjectStore`.
+
+`allowLoopDevices` defaults to `false`. Enable it only for an explicitly
+loop-backed development fixture, never as a production storage substitute.
 
 The production profile requires the availability and operational decisions
 that the local profile deliberately supplies as unsafe single-node defaults:

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -19,6 +19,7 @@ import * as Diff from 'alchemy/Diff';
 import type { Input } from 'alchemy/Input';
 import * as Output from 'alchemy/Output';
 import * as ProviderMod from 'alchemy/Provider';
+import * as RemovalPolicy from 'alchemy/RemovalPolicy';
 import type { Resource as ResourceT } from 'alchemy/Resource';
 import * as ResourceMod from 'alchemy/Resource';
 import { Effect } from 'effect';
@@ -391,9 +392,18 @@ export function materializeAlchemyResources(
       // the LAST call signature — the one taking `Effect<InputProps<…>, never, PropsReq>` — so casting
       // to it selected the Effect-props overload and returned `Effect<R, never, PropsReq | Req>` with
       // `PropsReq` unresolved, leaking `unknown` into this function's public requirement channel.
-      handles[decl.id] = yield* kroResource(
+      const resource = kroResource(
         decl.id,
         props as unknown as { [K in keyof KroResourceR['Props']]: Input<KroResourceR['Props'][K]> }
+      );
+      // Retention is an Alchemy lifecycle policy, not merely a hint to the
+      // provider's delete hook. Register it natively so destroy/prune drops
+      // only the state entry without invoking Kubernetes deletion. Keep the
+      // provider-level retain guard for legacy state and direct provider use.
+      handles[decl.id] = yield* (
+        decl.props.retain === true
+          ? RemovalPolicy.retain()(resource)
+          : resource
       );
     }
     return handles;

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -263,12 +263,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
 
   const group =
     desiredRgd.spec.schema.group ??
-    (apiVersion.includes('/') ? apiVersion.slice(0, apiVersion.lastIndexOf('/')) : undefined);
-  if (!group) {
-    throw new Error(
-      `Cannot migrate artifact bindings for ${rgdName}: the desired RGD schema has no API group`
-    );
-  }
+    (apiVersion.includes('/') ? apiVersion.slice(0, apiVersion.lastIndexOf('/')) : 'kro.run');
   // Put the desired RGD in place before broadening the generated CRD. If the
   // legacy RGD remains live, KRO can immediately reconcile and restore its old
   // topology-shaped schema between this patch and the caller's normal apply.

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -1,6 +1,9 @@
 import type { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
 import { ensureError } from '../errors.js';
-import { createBunCompatibleKubernetesObjectApi } from '../kubernetes/index.js';
+import {
+  createBunCompatibleKubernetesObjectApi,
+  getErrorStatusCode,
+} from '../kubernetes/index.js';
 import { KRO_ARTIFACT_BINDINGS_SPEC_FIELD } from '../planning/values.js';
 
 const STABLE_BINDING_SCHEMA = 'map[string]map[string]string';
@@ -42,15 +45,6 @@ interface CustomResourceDefinition extends KubernetesObject {
       [key: string]: unknown;
     }>;
   };
-}
-
-function statusCode(error: unknown): number | undefined {
-  const candidate = error as {
-    statusCode?: number;
-    code?: number;
-    body?: { code?: number };
-  };
-  return candidate.statusCode ?? candidate.code ?? candidate.body?.code;
 }
 
 async function findGeneratedCrd(
@@ -167,6 +161,14 @@ async function replaceRgdWithRetry(
       metadata: {
         ...live.metadata,
         ...desired?.metadata,
+        labels: {
+          ...live.metadata?.labels,
+          ...desired?.metadata?.labels,
+        },
+        annotations: {
+          ...live.metadata?.annotations,
+          ...desired?.metadata?.annotations,
+        },
         name: rgdName,
         resourceVersion,
       },
@@ -175,7 +177,7 @@ async function replaceRgdWithRetry(
     try {
       return (await api.replace(replacement)) as ResourceGraphDefinition;
     } catch (error: unknown) {
-      if (statusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+      if (getErrorStatusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
         throw new Error(
           `Could not replace ResourceGraphDefinition ${rgdName} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
         );
@@ -242,7 +244,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
       metadata: { name: rgdName },
     })) as ResourceGraphDefinition;
   } catch (error: unknown) {
-    if (statusCode(error) === 404) return;
+    if (getErrorStatusCode(error) === 404) return;
     throw new Error(
       `Could not inspect ResourceGraphDefinition ${rgdName} before artifact-binding migration: ${ensureError(error).message}`
     );
@@ -324,7 +326,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
       await requestRgdReconcile(api, rgdName);
       return;
     } catch (error: unknown) {
-      if (statusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+      if (getErrorStatusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
         throw new Error(
           `Could not migrate generated CRD ${crd.metadata.name} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
         );

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -7,7 +7,7 @@ const STABLE_BINDING_SCHEMA = 'map[string]map[string]string';
 const MAX_CRD_PATCH_ATTEMPTS = 5;
 type MigrationApi = Pick<
   ReturnType<typeof createBunCompatibleKubernetesObjectApi>,
-  'read' | 'list' | 'patch' | 'replace'
+  'read' | 'list' | 'replace'
 >;
 
 interface ResourceGraphDefinition extends KubernetesObject {
@@ -138,23 +138,77 @@ function needsRgdReconcileRetry(rgd: ResourceGraphDefinition): boolean {
   );
 }
 
-async function requestRgdReconcile(api: MigrationApi, rgdName: string): Promise<void> {
-  await api.patch(
-    {
+async function replaceRgdWithRetry(
+  api: MigrationApi,
+  rgdName: string,
+  desired: ResourceGraphDefinition | undefined,
+  initialLive?: ResourceGraphDefinition
+): Promise<ResourceGraphDefinition> {
+  let live =
+    initialLive ??
+    ((await api.read({
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'ResourceGraphDefinition',
+      metadata: { name: rgdName },
+    })) as ResourceGraphDefinition);
+  for (let attempt = 1; attempt <= MAX_CRD_PATCH_ATTEMPTS; attempt += 1) {
+    const resourceVersion = live.metadata?.resourceVersion;
+    if (!resourceVersion) {
+      throw new Error(
+        `Cannot safely replace ResourceGraphDefinition ${rgdName}: the live resource has no resourceVersion`
+      );
+    }
+    const { status: _status, ...writableLive } = live;
+    const replacement: ResourceGraphDefinition = {
+      ...writableLive,
+      ...desired,
       apiVersion: 'kro.run/v1alpha1',
       kind: 'ResourceGraphDefinition',
       metadata: {
+        ...live.metadata,
+        ...desired?.metadata,
+        name: rgdName,
+        resourceVersion,
+      },
+      ...(desired?.spec ? { spec: desired.spec } : {}),
+    };
+    try {
+      return (await api.replace(replacement)) as ResourceGraphDefinition;
+    } catch (error: unknown) {
+      if (statusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+        throw new Error(
+          `Could not replace ResourceGraphDefinition ${rgdName} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
+        );
+      }
+      live = (await api.read({
+        apiVersion: 'kro.run/v1alpha1',
+        kind: 'ResourceGraphDefinition',
+        metadata: { name: rgdName },
+      })) as ResourceGraphDefinition;
+    }
+  }
+  throw new Error(`Could not replace ResourceGraphDefinition ${rgdName}`);
+}
+
+async function requestRgdReconcile(api: MigrationApi, rgdName: string): Promise<void> {
+  const live = (await api.read({
+    apiVersion: 'kro.run/v1alpha1',
+    kind: 'ResourceGraphDefinition',
+    metadata: { name: rgdName },
+  })) as ResourceGraphDefinition;
+  await replaceRgdWithRetry(
+    api,
+    rgdName,
+    {
+      metadata: {
         name: rgdName,
         annotations: {
+          ...live.metadata?.annotations,
           'typekro.io/artifact-binding-migration-retry': new Date().toISOString(),
         },
       },
     },
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    'application/merge-patch+json'
+    live
   );
 }
 
@@ -221,14 +275,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
   // Applying the desired RGD first may briefly produce KindReady=False; the CRD
   // broadening below removes that incompatibility and the normal deployment
   // readiness gate waits for the same generation to become ready.
-  await api.patch(
-    desiredRgd,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    'application/merge-patch+json'
-  );
+  liveRgd = await replaceRgdWithRetry(api, rgdName, desiredRgd, liveRgd);
 
   for (let attempt = 1; attempt <= MAX_CRD_PATCH_ATTEMPTS; attempt += 1) {
     const crd = await findGeneratedCrd(api, group, kind);

--- a/src/core/kubernetes/errors.ts
+++ b/src/core/kubernetes/errors.ts
@@ -16,9 +16,11 @@ const logger = getComponentLogger('kubernetes-errors');
  * Interface representing a Kubernetes API error with various possible structures.
  * The error structure varies between client versions:
  * - 0.x (request-based): error.statusCode, error.body
- * - 1.x+ (fetch-based): error.response?.statusCode, error.statusCode, error.body?.code
+ * - 1.x+ generated ApiException: error.code, error.body
+ * - fetch wrappers: error.response?.statusCode, error.statusCode, error.body?.code
  */
 export interface KubernetesApiError {
+  code?: number;
   statusCode?: number;
   response?: {
     statusCode?: number;
@@ -38,6 +40,7 @@ export interface KubernetesApiError {
  * Extract the HTTP status code from a Kubernetes API error.
  *
  * Handles multiple error structures from different client versions:
+ * - Direct code property (@kubernetes/client-node 1.x ApiException)
  * - Direct statusCode property (0.x style)
  * - Nested response.statusCode (1.x+ fetch style)
  * - Nested body.code (some error responses)
@@ -63,6 +66,12 @@ export function getErrorStatusCode(error: unknown): number | undefined {
   }
 
   const err = error as KubernetesApiError;
+
+  // Generated @kubernetes/client-node 1.x ApiException instances expose the
+  // HTTP status on `code`, not `statusCode`.
+  if (typeof err.code === 'number') {
+    return err.code;
+  }
 
   // Try direct statusCode first (0.x style and some 1.x errors)
   if (typeof err.statusCode === 'number') {

--- a/src/factories/envoy-ai-gateway/compositions/gateway.ts
+++ b/src/factories/envoy-ai-gateway/compositions/gateway.ts
@@ -487,7 +487,7 @@ export function makeEnvoyAIGateway(
         endpoint: Cel.expr<string>(
           'has(gateway.status.addresses) && size(gateway.status.addresses) > 0 ? "http://" + ' +
             'string(gateway.status.addresses[0].value) + ":" + ' +
-            'string(gateway.spec.listeners[0].port) : ""'
+            'string(gateway.spec.listeners[0].port) + "/v1" : ""'
         ),
         gatewayClassName: Cel.expr<string>('gatewayContract.data.gatewayClassName'),
         providerCount: Cel.expr<number>('int(gatewayContract.data.providerCount)'),

--- a/src/factories/envoy-ai-gateway/compositions/gateway.ts
+++ b/src/factories/envoy-ai-gateway/compositions/gateway.ts
@@ -172,6 +172,9 @@ export function makeEnvoyAIGateway(
       gateway.dependsOn(gatewayConfig);
 
       const backendResources = new Map<string, ReturnType<typeof envoyAIServiceBackend>>();
+      const routeSecurityPolicies: NonNullable<
+        ReturnType<typeof providerSecurityPolicy>
+      >[] = [];
       const providerResources: ProviderResource[] = [];
       const readinessResources: ProviderResource[] = [];
       const policyResources: PolicyResource[] = [];
@@ -228,6 +231,7 @@ export function makeEnvoyAIGateway(
         );
         if (securityPolicy) {
           securityPolicy.dependsOn(aiBackend);
+          routeSecurityPolicies.push(securityPolicy);
           readinessResources.push({
             name: backendName,
             status: securityPolicy.status,
@@ -305,6 +309,13 @@ export function makeEnvoyAIGateway(
       });
       route.dependsOn(gateway);
       for (const backend of backendResources.values()) route.dependsOn(backend);
+      // Envoy AI Gateway's security-policy controller updates the referenced
+      // AIGatewayRoute when a policy disappears. If Alchemy deletes the route
+      // and policy concurrently, that status update can race the route
+      // controller's finalizer removal. Make the policy an apply prerequisite
+      // so reverse-topological teardown deterministically removes the route
+      // first, then the policy.
+      for (const policy of routeSecurityPolicies) route.dependsOn(policy);
 
       if (options.retry !== false) {
         const retry = options.retry ?? {};

--- a/src/factories/rook/compositions/rook-ceph-platform.ts
+++ b/src/factories/rook/compositions/rook-ceph-platform.ts
@@ -100,6 +100,7 @@ export const rookCephSingleNodePlatform = kubernetesComposition(
       repositoryNamespace,
       repositoryUrl,
       values: {
+        allowLoopDevices: spec.allowLoopDevices ?? false,
         enableOBCWatchOperatorNamespace: false,
         resources: { requests: { cpu: '100m', memory: '128Mi' } },
       },

--- a/src/factories/rook/types.ts
+++ b/src/factories/rook/types.ts
@@ -357,6 +357,7 @@ export const RookCephSingleNodePlatformConfigSchema = type({
   ...rookCephClusterCommonSchemaShape,
   profile: '"single-node-development"',
   'storageSize?': 'string',
+  'allowLoopDevices?': 'boolean',
   'resources?': optionalCephDaemonResourcesSchemaShape,
 });
 

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -27,6 +27,16 @@ function desiredRgd(): KubernetesObject {
   } as unknown as KubernetesObject;
 }
 
+function defaultGroupDesiredRgd(): KubernetesObject {
+  const resource = structuredClone(desiredRgd());
+  const schema = Reflect.get(Reflect.get(resource, 'spec'), 'schema') as Record<
+    string,
+    unknown
+  >;
+  Reflect.deleteProperty(schema, 'group');
+  return resource;
+}
+
 function legacyCrd(resourceVersion: string): KubernetesObject {
   return {
     // Match KubernetesObjectApi list deserialization: TypeMeta may be omitted
@@ -70,6 +80,34 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('uses KRO default group when the RGD schema declares a version only', async () => {
+    const desired = defaultGroupDesiredRgd();
+    const live = structuredClone(desired);
+    live.metadata = {
+      name: 'application',
+      generation: 1,
+      resourceVersion: '20',
+    };
+    const crd = legacyCrd('10');
+    const crdSpec = Reflect.get(crd, 'spec') as Record<string, unknown>;
+    crdSpec.group = 'kro.run';
+    crd.metadata = {
+      ...crd.metadata,
+      name: 'applications.kro.run',
+    };
+    const list = mock(async () => ({ items: [crd] }));
+
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desired, {
+      api: {
+        read: mock(async () => live),
+        list,
+        replace: mock(async (resource: KubernetesObject) => resource),
+      } as never,
+    });
+
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
   test('retries complete RGD replacements and never serializes them as generic patches', async () => {
     let readCount = 0;
     const read = mock(async () => ({

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import type { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
+import { ApiException } from '@kubernetes/client-node/dist/gen/apis/exception.js';
 import { migrateLegacyKroArtifactBindingCrd } from '../../src/core/deployment/kro-artifact-binding-migration.js';
 import {
   kroArtifactOutputField,
@@ -80,6 +81,22 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('treats a real client 404 as an absent RGD', async () => {
+    const read = mock(async () => {
+      throw new ApiException(404, 'Not Found', undefined, {});
+    });
+
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
+      api: {
+        read,
+        list: mock(async () => ({ items: [] })),
+        replace: mock(async (resource: KubernetesObject) => resource),
+      } as never,
+    });
+
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
   test('uses KRO default group when the RGD schema declares a version only', async () => {
     const desired = defaultGroupDesiredRgd();
     const live = structuredClone(desired);
@@ -134,7 +151,7 @@ describe('KRO artifact-binding migration', () => {
         resource.kind === 'ResourceGraphDefinition' &&
         resource.metadata?.resourceVersion === '20'
       ) {
-        throw { response: { statusCode: 409 }, message: 'conflict' };
+        throw new ApiException(409, 'Conflict', undefined, {});
       }
       return resource;
     });

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -109,6 +109,12 @@ describe('KRO artifact-binding migration', () => {
   });
 
   test('retries complete RGD replacements and never serializes them as generic patches', async () => {
+    const desired = desiredRgd();
+    desired.metadata = {
+      ...desired.metadata,
+      labels: { shared: 'desired', desired: 'true' },
+      annotations: { shared: 'desired', desired: 'true' },
+    };
     let readCount = 0;
     const read = mock(async () => ({
       ...desiredRgd(),
@@ -116,7 +122,8 @@ describe('KRO artifact-binding migration', () => {
         name: 'application',
         generation: 2,
         resourceVersion: readCount++ === 0 ? '20' : '21',
-        labels: { retained: 'true' },
+        labels: { retained: 'true', shared: 'live' },
+        annotations: { retained: 'true', shared: 'live' },
       },
       status: {
         conditions: [{ type: 'KindReady', status: 'False', observedGeneration: 2 }],
@@ -127,12 +134,12 @@ describe('KRO artifact-binding migration', () => {
         resource.kind === 'ResourceGraphDefinition' &&
         resource.metadata?.resourceVersion === '20'
       ) {
-        throw { statusCode: 409, message: 'conflict' };
+        throw { response: { statusCode: 409 }, message: 'conflict' };
       }
       return resource;
     });
 
-    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desired, {
       api: {
         read,
         list: mock(async () => ({ items: [legacyCrd('10')] })),
@@ -149,8 +156,19 @@ describe('KRO artifact-binding migration', () => {
       '21',
     ]);
     expect(rgdReplacements[1]).toMatchObject({
-      metadata: { labels: { retained: 'true' } },
-      spec: Reflect.get(desiredRgd(), 'spec'),
+      metadata: {
+        labels: {
+          retained: 'true',
+          shared: 'desired',
+          desired: 'true',
+        },
+        annotations: {
+          retained: 'true',
+          shared: 'desired',
+          desired: 'true',
+        },
+      },
+      spec: Reflect.get(desired, 'spec'),
     });
     expect(Reflect.has(rgdReplacements[1] ?? {}, 'status')).toBe(false);
   });
@@ -179,7 +197,7 @@ describe('KRO artifact-binding migration', () => {
       if (resource.kind === 'ResourceGraphDefinition') return resource;
       crdVersions.push(resource.metadata?.resourceVersion ?? '');
       if (crdVersions.length === 1) {
-        throw { statusCode: 409, message: 'conflict' };
+        throw { response: { statusCode: 409 }, message: 'conflict' };
       }
       return resource;
     });

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -70,10 +70,57 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('retries complete RGD replacements and never serializes them as generic patches', async () => {
+    let readCount = 0;
+    const read = mock(async () => ({
+      ...desiredRgd(),
+      metadata: {
+        name: 'application',
+        generation: 2,
+        resourceVersion: readCount++ === 0 ? '20' : '21',
+        labels: { retained: 'true' },
+      },
+      status: {
+        conditions: [{ type: 'KindReady', status: 'False', observedGeneration: 2 }],
+      },
+    }));
+    const replace = mock(async (resource: KubernetesObject) => {
+      if (
+        resource.kind === 'ResourceGraphDefinition' &&
+        resource.metadata?.resourceVersion === '20'
+      ) {
+        throw { statusCode: 409, message: 'conflict' };
+      }
+      return resource;
+    });
+
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
+      api: {
+        read,
+        list: mock(async () => ({ items: [legacyCrd('10')] })),
+        replace,
+      } as never,
+    });
+
+    const rgdReplacements = replace.mock.calls
+      .map(([resource]) => resource as KubernetesObject)
+      .filter((resource) => resource.kind === 'ResourceGraphDefinition');
+    expect(rgdReplacements.map((resource) => resource.metadata?.resourceVersion)).toEqual([
+      '20',
+      '21',
+      '21',
+    ]);
+    expect(rgdReplacements[1]).toMatchObject({
+      metadata: { labels: { retained: 'true' } },
+      spec: Reflect.get(desiredRgd(), 'spec'),
+    });
+    expect(Reflect.has(rgdReplacements[1] ?? {}, 'status')).toBe(false);
+  });
+
   test('resumes an interrupted stable-RGD migration and retries CRD conflicts from fresh state', async () => {
     const read = mock(async () => ({
       ...desiredRgd(),
-      metadata: { name: 'application', generation: 2 },
+      metadata: { name: 'application', generation: 2, resourceVersion: '20' },
       status: {
         conditions: [
           {
@@ -88,8 +135,10 @@ describe('KRO artifact-binding migration', () => {
       .mockResolvedValueOnce({ items: [legacyCrd('10')] })
       .mockResolvedValueOnce({ items: [legacyCrd('11')] });
     const crdVersions: string[] = [];
-    const patch = mock(async (resource: KubernetesObject) => resource);
+    const replacementKinds: string[] = [];
     const replace = mock(async (resource: KubernetesObject) => {
+      replacementKinds.push(resource.kind ?? '');
+      if (resource.kind === 'ResourceGraphDefinition') return resource;
       crdVersions.push(resource.metadata?.resourceVersion ?? '');
       if (crdVersions.length === 1) {
         throw { statusCode: 409, message: 'conflict' };
@@ -98,12 +147,15 @@ describe('KRO artifact-binding migration', () => {
     });
 
     await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
-      api: { read, list, patch, replace } as never,
+      api: { read, list, replace } as never,
     });
 
     expect(crdVersions).toEqual(['10', '11']);
     expect(list).toHaveBeenCalledTimes(2);
-    const finalCrdPatch = replace.mock.calls.at(-1)?.[0] as KubernetesObject | undefined;
+    const finalCrdPatch = replace.mock.calls
+      .map(([resource]) => resource as KubernetesObject)
+      .reverse()
+      .find((resource) => resource.kind === 'CustomResourceDefinition');
     expect(finalCrdPatch).toMatchObject({
       apiVersion: 'apiextensions.k8s.io/v1',
       kind: 'CustomResourceDefinition',
@@ -124,13 +176,15 @@ describe('KRO artifact-binding migration', () => {
         additionalProperties: { type: 'string' },
       },
     });
+    expect(replacementKinds).toEqual([
+      'ResourceGraphDefinition',
+      'CustomResourceDefinition',
+      'CustomResourceDefinition',
+      'ResourceGraphDefinition',
+    ]);
+    const finalRgdReplacement = replace.mock.calls.at(-1)?.[0] as KubernetesObject | undefined;
     expect(
-      patch.mock.calls.some(
-        ([resource]) =>
-          (resource as KubernetesObject).metadata?.annotations?.[
-            'typekro.io/artifact-binding-migration-retry'
-          ] !== undefined
-      )
-    ).toBe(true);
+      finalRgdReplacement?.metadata?.annotations?.['typekro.io/artifact-binding-migration-retry']
+    ).toBeDefined();
   });
 });

--- a/test/core/kubernetes/errors.test.ts
+++ b/test/core/kubernetes/errors.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import { ApiException } from '@kubernetes/client-node/dist/gen/apis/exception.js';
 import * as fc from 'fast-check';
 import {
   getErrorStatusCode,
@@ -23,6 +24,11 @@ import {
 
 describe('Kubernetes Error Handling Utilities', () => {
   describe('getErrorStatusCode', () => {
+    it('extracts status codes from the pinned client ApiException', () => {
+      expect(getErrorStatusCode(new ApiException(404, 'Not Found', undefined, {}))).toBe(404);
+      expect(getErrorStatusCode(new ApiException(409, 'Conflict', undefined, {}))).toBe(409);
+    });
+
     /**
      * **Feature: upgrade-kubernetes-client, Property 1: Error Handling Consistency**
      * **Validates: Requirements 2.1, 2.4**
@@ -98,6 +104,7 @@ describe('Kubernetes Error Handling Utilities', () => {
 
   describe('isNotFoundError', () => {
     it('should return true for 404 errors', () => {
+      expect(isNotFoundError(new ApiException(404, 'Not Found', undefined, {}))).toBe(true);
       expect(isNotFoundError({ statusCode: 404 })).toBe(true);
       expect(isNotFoundError({ response: { statusCode: 404 } })).toBe(true);
       expect(isNotFoundError({ body: { code: 404 } })).toBe(true);
@@ -118,6 +125,7 @@ describe('Kubernetes Error Handling Utilities', () => {
 
   describe('isConflictError', () => {
     it('should return true for 409 errors', () => {
+      expect(isConflictError(new ApiException(409, 'Conflict', undefined, {}))).toBe(true);
       expect(isConflictError({ statusCode: 409 })).toBe(true);
       expect(isConflictError({ response: { statusCode: 409 } })).toBe(true);
       expect(isConflictError({ body: { code: 409 } })).toBe(true);

--- a/test/factories/envoy-ai-gateway/factory-modes.test.ts
+++ b/test/factories/envoy-ai-gateway/factory-modes.test.ts
@@ -759,6 +759,7 @@ describe('Envoy AI Gateway integration', () => {
     expect(status).toHaveProperty('routeAccepted');
     expect(status).toHaveProperty('gatewayProgrammed');
     expect(String(status.endpoint)).toContain('size(gateway.status.addresses)');
+    expect(String(status.endpoint)).toContain('"/v1"');
     expect(String(status.endpoint)).not.toContain('.size()');
     expect(status).toHaveProperty('aiGatewayVersion', '${gatewayContract.data.aiGatewayVersion}');
     expect(schemaSpec).toHaveProperty('listenerPort', 'integer | minimum=1 maximum=65535');

--- a/test/factories/envoy-ai-gateway/factory-modes.test.ts
+++ b/test/factories/envoy-ai-gateway/factory-modes.test.ts
@@ -380,6 +380,45 @@ describe('Envoy AI Gateway integration', () => {
     expect(yaml).toContain('numRetries: 2');
   });
 
+  test('orders secured routes after provider policies for finalizer-safe teardown', async () => {
+    const gateway = makeEnvoyAIGateway({
+      profile: 'development',
+      providers: [
+        {
+          name: 'openai',
+          kind: 'openai',
+          credential: { name: 'openai-key' },
+        },
+      ],
+      models: [
+        {
+          model: 'reasoning',
+          targets: [{ provider: 'openai', model: 'gpt' }],
+        },
+      ],
+    });
+    const declarations = await gateway
+      .factory('direct', { namespace: 'typekro-system' })
+      .toAlchemyResources({
+        name: 'secured',
+        namespace: 'secured-ai',
+        lifecycle: 'external',
+      });
+    const route = declarations.find(
+      ({ props }) => props.resource.kind === 'AIGatewayRoute'
+    );
+    const securityPolicy = declarations.find(
+      ({ props }) => props.resource.kind === 'BackendSecurityPolicy'
+    );
+
+    expect(route).toBeDefined();
+    expect(securityPolicy).toBeDefined();
+    expect(route?.dependsOn).toContain(securityPolicy?.id);
+    expect(declarations.indexOf(securityPolicy!)).toBeLessThan(
+      declarations.indexOf(route!)
+    );
+  });
+
   test('renders token accounting and rate limiting without leaking provider details', () => {
     const gateway = makeEnvoyAIGateway({
       profile: 'development',

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -159,6 +159,7 @@ describe('official Rook Ceph cluster chart platform', () => {
       repositoryNamespace: 'ceph-sources',
       storageClassName: 'local-path',
       bucketStorageClassName: 'harbor-retain',
+      allowLoopDevices: true,
     });
     expect(yaml).toContain('name: ceph-operator');
     expect(yaml).toContain('name: ceph-data');
@@ -168,6 +169,7 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(yaml).toContain('chart: rook-ceph-cluster');
     expect(yaml).toContain('operatorNamespace: ceph-operator');
     expect(yaml).toContain('storageClassName: local-path');
+    expect(yaml).toContain('allowLoopDevices: true');
     expect(yaml).toContain('name: harbor-retain');
     expect(yaml).toContain('reclaimPolicy: Retain');
     expectCleanYaml(yaml);
@@ -217,6 +219,7 @@ describe('official Rook Ceph cluster chart platform', () => {
       expect(yaml).toContain(`${field}:`);
     }
     expect(yaml).toContain('storageSize: string | default="8Gi"');
+    expect(yaml).toContain('allowLoopDevices: boolean | default=false');
     expect(yaml).toContain('storageClassDeviceSets');
     expect(yaml).toContain('reclaimPolicy');
     expect(yaml).toContain('Retain');

--- a/test/integration/alchemy/direct-fan-out-e2e.test.ts
+++ b/test/integration/alchemy/direct-fan-out-e2e.test.ts
@@ -80,6 +80,31 @@ const makeGraph = () =>
     })
   );
 
+const RetentionSpecSchema = type({ prefix: 'string' });
+const makeRetentionGraph = () =>
+  toResourceGraph(
+    {
+      name: 'retentionapp',
+      apiVersion: 'v1alpha1',
+      kind: 'RetentionApp',
+      spec: RetentionSpecSchema,
+      status: type({}),
+    },
+    (schema) => ({
+      retained: simple.ConfigMap({
+        name: Cel.template('%s-retained', schema.spec.prefix),
+        data: { lifecycle: 'retained' },
+        id: 'retainedConfig',
+      }),
+      destroyed: simple.ConfigMap({
+        name: Cel.template('%s-destroyed', schema.spec.prefix),
+        data: { lifecycle: 'destroyed' },
+        id: 'destroyedConfig',
+      }),
+    }),
+    () => ({})
+  );
+
 const makeOptions = { providers: kroProvider, state: StateMod.inMemoryState() };
 const runDeploy = (s: unknown) =>
   Effect.runPromise(
@@ -175,5 +200,60 @@ describeOrSkip('Alchemy v2 direct-mode fan-out (e2e)', () => {
         kubeConfig
       ),
     ]);
+  }, 180_000);
+
+  it('honors declaration retention through Alchemy destroy', async () => {
+    const coreApi = createCoreV1ApiClient(kubeConfig);
+    const prefix = `retain-${crypto.randomUUID().slice(0, 8)}`;
+    const retainedName = `${prefix}-retained`;
+    const destroyedName = `${prefix}-destroyed`;
+    const factory = await makeRetentionGraph().factory('direct', {
+      namespace: NS,
+      waitForReady: true,
+      timeout: 120_000,
+    });
+    const declarations = await factory.toAlchemyResources({ prefix });
+    const retained = declarations.find(
+      (declaration) => declaration.props.resourceId === 'retainedConfig'
+    );
+    expect(retained).toBeDefined();
+    retained!.props.retain = true;
+
+    const stack = Alchemy.Stack(
+      `tk-alchemy-retention-${prefix}`,
+      makeOptions as never,
+      materializeAlchemyResources(KroResource, declarations) as never
+    );
+
+    try {
+      await runDeploy(stack);
+      await runDestroy(stack);
+
+      await waitForResourceAbsent(
+        {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          metadata: { namespace: NS, name: destroyedName },
+        },
+        kubeConfig
+      );
+      const liveRetained = await coreApi.readNamespacedConfigMap({
+        namespace: NS,
+        name: retainedName,
+      });
+      expect(liveRetained.data?.lifecycle).toBe('retained');
+    } finally {
+      await coreApi
+        .deleteNamespacedConfigMap({ namespace: NS, name: retainedName })
+        .catch(() => undefined);
+      await waitForResourceAbsent(
+        {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          metadata: { namespace: NS, name: retainedName },
+        },
+        kubeConfig
+      );
+    }
   }, 180_000);
 });

--- a/test/integration/envoy-ai-gateway/gateway.test.ts
+++ b/test/integration/envoy-ai-gateway/gateway.test.ts
@@ -207,7 +207,7 @@ async function probeGateway(
                 `if curl --fail --silent --max-time 10 ` +
                 `-H 'content-type: application/json' ` +
                 `--data '{"model":"fast","messages":[{"role":"user","content":"hello"}]}' ` +
-                `${endpoint}/v1/chat/completions; then exit 0; fi; ` +
+                `${endpoint}/chat/completions; then exit 0; fi; ` +
                 `sleep 2; ` +
                 `done; ` +
                 `echo 'gateway did not become request-ready after 120 seconds' >&2; exit 1`,
@@ -315,7 +315,7 @@ describeOrSkip('Envoy AI Gateway direct and KRO lifecycle', () => {
           gatewayProgrammed: true,
           aiGatewayVersion: 'v0.6.0',
         });
-        expect(deployed.status.endpoint).toMatch(/^http:\/\/.+:8080$/);
+        expect(deployed.status.endpoint).toMatch(/^http:\/\/.+:8080\/v1$/);
 
         const firstResponse = JSON.parse(
           await probeGateway(
@@ -344,7 +344,7 @@ describeOrSkip('Envoy AI Gateway direct and KRO lifecycle', () => {
           failed: false,
           phase: 'Ready',
         });
-        expect(updated.status.endpoint).toMatch(/^http:\/\/.+:8081$/);
+        expect(updated.status.endpoint).toMatch(/^http:\/\/.+:8081\/v1$/);
 
         if (mode === 'kro') {
           const customApi = createBunCompatibleCustomObjectsApi(kubeConfig);

--- a/test/unit/alchemy/materialize-alchemy-resources.test.ts
+++ b/test/unit/alchemy/materialize-alchemy-resources.test.ts
@@ -7,7 +7,9 @@
  */
 import { describe, expect, it } from 'bun:test';
 import * as Output from 'alchemy/Output';
+import { RemovalPolicy } from 'alchemy/RemovalPolicy';
 import { Effect } from 'effect';
+import * as Option from 'effect/Option';
 import { type KroResource, materializeAlchemyResources } from '../../../src/alchemy/index.js';
 import type { AlchemyResourceDeclaration } from '../../../src/alchemy/types.js';
 
@@ -20,6 +22,18 @@ const makeFakeKroResource = () => {
     return Effect.succeed({ FQN: id, __handle: id });
   };
   return { fake: fake as unknown as typeof KroResource, calls };
+};
+
+const makeRemovalPolicyAwareKroResource = () => {
+  const policies: Array<{ id: string; removalPolicy: 'destroy' | 'retain' }> = [];
+  const fake = (id: string, _props: Record<string, unknown>) =>
+    Effect.gen(function* () {
+      const configured = yield* Effect.serviceOption(RemovalPolicy);
+      const removalPolicy = Option.getOrElse(configured, () => 'destroy' as const);
+      policies.push({ id, removalPolicy });
+      return { FQN: id, __handle: id };
+    });
+  return { fake: fake as unknown as typeof KroResource, policies };
 };
 
 const decl = (id: string, dependsOn: string[] = []): AlchemyResourceDeclaration => ({
@@ -97,6 +111,21 @@ describe('materializeAlchemyResources', () => {
     );
 
     await expect(promise).rejects.toThrow("duplicate declaration id 'same'");
+  });
+
+  it('registers retained declarations with Alchemy native retention policy', async () => {
+    const { fake, policies } = makeRemovalPolicyAwareKroResource();
+    const retained = decl('retained');
+    retained.props.retain = true;
+
+    await Effect.runPromise(
+      materializeAlchemyResources(fake, [retained, decl('destroyed')]) as Effect.Effect<unknown>
+    );
+
+    expect(policies).toEqual([
+      { id: 'retained', removalPolicy: 'retain' },
+      { id: 'destroyed', removalPolicy: 'destroy' },
+    ]);
   });
 
   it('requires external artifact handles and wires their outputs into provider props', async () => {


### PR DESCRIPTION
## What changed

- makes KRO artifact-binding migration update-safe, including defaulted groups
- preserves retained direct resources during Alchemy destroy
- fixes Rook development device and object-bucket provisioner configuration
- makes default Ory identities password-capable
- exposes the complete Envoy AI Gateway API endpoint
- orders secured Envoy routes after provider policies so reverse-topological teardown finalizes routes first

## Why

Applik8s v0.7 live qualification exercised interrupted KRO migrations, retained-provider lifecycle, local Rook/Ceph provisioning, Ory browser authentication, and Envoy AI Gateway teardown. These paths surfaced correctness gaps that focused factory rendering did not expose.

## Impact

Alchemy/KRO deployments can resume migrations, retain explicitly shared providers, provision the reviewed local storage topology, authenticate generated Ory users, call the Envoy OpenAI-compatible API, and tear down secured routes without controller finalizer races.

## Validation

- `bun test test/factories/envoy-ai-gateway/factory-modes.test.ts` (26 passed)
- `bun run typecheck`
- `bun run build`
- complete commit-hook suite: 5,272 passed, 13 skipped, 1 todo, 0 failed
- local OrbStack graph-native retry teardown completed without controller restart or manual resource deletion