### PR TITLE
fix direct values merge materialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Direct and Alchemy deployments now materialize TypeKro's internal Helm-values merge expressions
+  before encoding the canonical artifact record. Concrete chart overrides therefore deep-merge with
+  integration defaults instead of leaking `__typekroValuesMerge` as literal Helm values; KRO keeps
+  its graph-aware CEL merge behavior.
+- Restart-safe KRO artifact-binding migration now resolves an omitted schema group to KRO's
+  documented `kro.run` default. Repeated deployments of otherwise valid default-group compositions
+  no longer fail while inspecting the generated CRD.
 - Direct Alchemy singleton owners now gate consumer scheduling through a dedicated barrier instead
   of being injected into each consumer's canonical live-resource dependencies. This preserves
   singleton readiness ordering without making direct artifact execution records fail dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic KRO artifact-binding migration now replaces the complete generated CRD with
   resource-version concurrency rather than sending a partial merge patch through
   `KubernetesObjectApi`. This avoids the client serializer's `data is not iterable` failure while
-  retaining restart-safe conflict retries.
+  retaining restart-safe conflict retries. Version-only schemas correctly resolve to KRO's default
+  `kro.run` API group during migration.
 - Artifact-binding migration now also replaces the complete ResourceGraphDefinition with
   resource-version concurrency. This avoids the same client serializer failure when an RGD update
   contains array-valued resources, while preserving live metadata and omitting status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resource-version concurrency rather than sending a partial merge patch through
   `KubernetesObjectApi`. This avoids the client serializer's `data is not iterable` failure while
   retaining restart-safe conflict retries.
+- Artifact-binding migration now also replaces the complete ResourceGraphDefinition with
+  resource-version concurrency. This avoids the same client serializer failure when an RGD update
+  contains array-valued resources, while preserving live metadata and omitting status.
 - Semantic planning now represents ArkType's explicitly open `object` and
   `object[]` nodes—including root `type('object')` schemas and ordinary or
   `ignore` undeclared-key policies—without falsely opening `reject`/`delete`

--- a/src/alchemy/deployers.ts
+++ b/src/alchemy/deployers.ts
@@ -46,7 +46,7 @@ interface KroTypeKroDeployerOptions {
   deleteInstance?: (name: string, abortSignal?: AbortSignal) => Promise<ResourceDeletionResult>;
   /** True when an RGD still has live instances and must be preserved. */
   shouldSkipRgdDelete?: (rgdName: string, abortSignal?: AbortSignal) => Promise<boolean>;
-  /** Delete the RGD and generated CRD when no CR instance exists. */
+  /** Delete the RGD when no CR instance exists; the generated CRD is retained for safe reuse. */
   deleteResourceGraphDefinition?: (rgdName: string, abortSignal?: AbortSignal) => Promise<void>;
 }
 

--- a/src/core/aspects/values-merge.ts
+++ b/src/core/aspects/values-merge.ts
@@ -1,3 +1,10 @@
+import {
+  isCelExpression,
+  isKubernetesRef,
+  isMixedTemplate,
+  isResourceReference,
+} from '../../utils/type-guards.js';
+
 export interface ValuesMergeExpression {
   readonly __typekroValuesMerge: true;
   readonly base: unknown;
@@ -27,4 +34,98 @@ export function mergeValuesExpression(base: unknown, overlay: unknown): ValuesMe
   }
 
   return { __typekroValuesMerge: true, base, overlays: [overlay] };
+}
+
+function isPlainMergeObject(value: unknown): value is Record<string, unknown> {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    isValuesMergeExpression(value) ||
+    isKubernetesRef(value) ||
+    isResourceReference(value) ||
+    isCelExpression(value) ||
+    isMixedTemplate(value)
+  ) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function mergeMaterializedValues(base: unknown, overlay: unknown): unknown {
+  if (overlay === undefined) return base;
+  if (!isPlainMergeObject(base) || !isPlainMergeObject(overlay)) return overlay;
+
+  return Object.fromEntries(
+    Array.from(new Set([...Object.keys(base), ...Object.keys(overlay)])).flatMap((key) => {
+      const merged = Object.hasOwn(overlay, key)
+        ? mergeMaterializedValues(base[key], overlay[key])
+        : base[key];
+      return merged === undefined ? [] : [[key, merged]];
+    })
+  );
+}
+
+/**
+ * Resolve TypeKro's internal Helm-values merge nodes for concrete/direct execution.
+ *
+ * KRO serialization preserves these nodes long enough to compile graph-aware map
+ * merges. Direct execution already has concrete values, so the operation must be
+ * evaluated before the manifest enters the canonical artifact record. The walk is
+ * immutable and treats references/CEL/templates as atomic leaves.
+ */
+export function materializeValuesMergeExpressions(value: unknown): unknown {
+  const visiting = new WeakSet<object>();
+
+  const materialize = (current: unknown): unknown => {
+    if (isValuesMergeExpression(current)) {
+      if (visiting.has(current)) {
+        throw new TypeError('Circular TypeKro values merge expression.');
+      }
+      visiting.add(current);
+      let merged = materialize(current.base);
+      const overlays = Array.isArray(current.overlays) ? current.overlays : [current.overlays];
+      for (const overlay of overlays) {
+        merged = mergeMaterializedValues(merged, materialize(overlay));
+      }
+      visiting.delete(current);
+      return merged;
+    }
+
+    if (
+      isKubernetesRef(current) ||
+      isResourceReference(current) ||
+      isCelExpression(current) ||
+      isMixedTemplate(current)
+    ) {
+      return current;
+    }
+
+    if (Array.isArray(current)) {
+      let changed = false;
+      const materialized = current.map((entry, index) => {
+        const next = materialize(entry);
+        if (next !== current[index]) changed = true;
+        return next;
+      });
+      return changed ? materialized : current;
+    }
+
+    if (!isPlainMergeObject(current)) return current;
+    if (visiting.has(current)) {
+      throw new TypeError('Circular value tree containing a TypeKro values merge expression.');
+    }
+    visiting.add(current);
+    let changed = false;
+    const entries = Object.entries(current).map(([key, entry]) => {
+      const next = materialize(entry);
+      if (next !== entry) changed = true;
+      return [key, next] as const;
+    });
+    visiting.delete(current);
+    return changed ? Object.fromEntries(entries) : current;
+  };
+
+  return materialize(value);
 }

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -12,6 +12,7 @@ import { createAlchemyResourceId } from '../../alchemy/utilities.js';
 import { toCamelCase } from '../../utils/string.js';
 import { isCelExpression, isKubernetesRef } from '../../utils/type-guards.js';
 import { applyAspects } from '../aspects/apply.js';
+import { materializeValuesMergeExpressions } from '../aspects/values-merge.js';
 import { createCompositionContext, runWithCompositionContext } from '../composition/context.js';
 import { buildNestedCompositionAliasTargets } from '../composition/nested-status-cel.js';
 import {
@@ -1249,7 +1250,15 @@ export class DirectResourceFactoryImpl<
       readonly singletonSpecFingerprint?: string;
     } = {}
   ): DirectArtifactExecution {
-    const capturedGraph = this.createLegacyResourceGraphForInstance(spec, instanceNameOverride);
+    const authoredGraph = this.createLegacyResourceGraphForInstance(spec, instanceNameOverride);
+    const capturedGraph = {
+      ...authoredGraph,
+      resources: authoredGraph.resources.map(({ id, manifest }) => {
+        const materialized = materializeValuesMergeExpressions(manifest) as typeof manifest;
+        if (materialized !== manifest) copyResourceMetadata(manifest, materialized);
+        return { id, manifest: materialized };
+      }),
+    };
     const legacyGraph = options.singletonSpecFingerprint
       ? {
           ...capturedGraph,

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -263,12 +263,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
 
   const group =
     desiredRgd.spec.schema.group ??
-    (apiVersion.includes('/') ? apiVersion.slice(0, apiVersion.lastIndexOf('/')) : undefined);
-  if (!group) {
-    throw new Error(
-      `Cannot migrate artifact bindings for ${rgdName}: the desired RGD schema has no API group`
-    );
-  }
+    (apiVersion.includes('/') ? apiVersion.slice(0, apiVersion.lastIndexOf('/')) : 'kro.run');
   // Put the desired RGD in place before broadening the generated CRD. If the
   // legacy RGD remains live, KRO can immediately reconcile and restore its old
   // topology-shaped schema between this patch and the caller's normal apply.

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -1,6 +1,9 @@
 import type { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
 import { ensureError } from '../errors.js';
-import { createBunCompatibleKubernetesObjectApi } from '../kubernetes/index.js';
+import {
+  createBunCompatibleKubernetesObjectApi,
+  getErrorStatusCode,
+} from '../kubernetes/index.js';
 import { KRO_ARTIFACT_BINDINGS_SPEC_FIELD } from '../planning/values.js';
 
 const STABLE_BINDING_SCHEMA = 'map[string]map[string]string';
@@ -42,15 +45,6 @@ interface CustomResourceDefinition extends KubernetesObject {
       [key: string]: unknown;
     }>;
   };
-}
-
-function statusCode(error: unknown): number | undefined {
-  const candidate = error as {
-    statusCode?: number;
-    code?: number;
-    body?: { code?: number };
-  };
-  return candidate.statusCode ?? candidate.code ?? candidate.body?.code;
 }
 
 async function findGeneratedCrd(
@@ -167,6 +161,14 @@ async function replaceRgdWithRetry(
       metadata: {
         ...live.metadata,
         ...desired?.metadata,
+        labels: {
+          ...live.metadata?.labels,
+          ...desired?.metadata?.labels,
+        },
+        annotations: {
+          ...live.metadata?.annotations,
+          ...desired?.metadata?.annotations,
+        },
         name: rgdName,
         resourceVersion,
       },
@@ -175,7 +177,7 @@ async function replaceRgdWithRetry(
     try {
       return (await api.replace(replacement)) as ResourceGraphDefinition;
     } catch (error: unknown) {
-      if (statusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+      if (getErrorStatusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
         throw new Error(
           `Could not replace ResourceGraphDefinition ${rgdName} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
         );
@@ -242,7 +244,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
       metadata: { name: rgdName },
     })) as ResourceGraphDefinition;
   } catch (error: unknown) {
-    if (statusCode(error) === 404) return;
+    if (getErrorStatusCode(error) === 404) return;
     throw new Error(
       `Could not inspect ResourceGraphDefinition ${rgdName} before artifact-binding migration: ${ensureError(error).message}`
     );
@@ -324,7 +326,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
       await requestRgdReconcile(api, rgdName);
       return;
     } catch (error: unknown) {
-      if (statusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+      if (getErrorStatusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
         throw new Error(
           `Could not migrate generated CRD ${crd.metadata.name} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
         );

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -7,7 +7,7 @@ const STABLE_BINDING_SCHEMA = 'map[string]map[string]string';
 const MAX_CRD_PATCH_ATTEMPTS = 5;
 type MigrationApi = Pick<
   ReturnType<typeof createBunCompatibleKubernetesObjectApi>,
-  'read' | 'list' | 'patch' | 'replace'
+  'read' | 'list' | 'replace'
 >;
 
 interface ResourceGraphDefinition extends KubernetesObject {
@@ -138,23 +138,77 @@ function needsRgdReconcileRetry(rgd: ResourceGraphDefinition): boolean {
   );
 }
 
-async function requestRgdReconcile(api: MigrationApi, rgdName: string): Promise<void> {
-  await api.patch(
-    {
+async function replaceRgdWithRetry(
+  api: MigrationApi,
+  rgdName: string,
+  desired: ResourceGraphDefinition | undefined,
+  initialLive?: ResourceGraphDefinition
+): Promise<ResourceGraphDefinition> {
+  let live =
+    initialLive ??
+    ((await api.read({
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'ResourceGraphDefinition',
+      metadata: { name: rgdName },
+    })) as ResourceGraphDefinition);
+  for (let attempt = 1; attempt <= MAX_CRD_PATCH_ATTEMPTS; attempt += 1) {
+    const resourceVersion = live.metadata?.resourceVersion;
+    if (!resourceVersion) {
+      throw new Error(
+        `Cannot safely replace ResourceGraphDefinition ${rgdName}: the live resource has no resourceVersion`
+      );
+    }
+    const { status: _status, ...writableLive } = live;
+    const replacement: ResourceGraphDefinition = {
+      ...writableLive,
+      ...desired,
       apiVersion: 'kro.run/v1alpha1',
       kind: 'ResourceGraphDefinition',
       metadata: {
+        ...live.metadata,
+        ...desired?.metadata,
+        name: rgdName,
+        resourceVersion,
+      },
+      ...(desired?.spec ? { spec: desired.spec } : {}),
+    };
+    try {
+      return (await api.replace(replacement)) as ResourceGraphDefinition;
+    } catch (error: unknown) {
+      if (statusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+        throw new Error(
+          `Could not replace ResourceGraphDefinition ${rgdName} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
+        );
+      }
+      live = (await api.read({
+        apiVersion: 'kro.run/v1alpha1',
+        kind: 'ResourceGraphDefinition',
+        metadata: { name: rgdName },
+      })) as ResourceGraphDefinition;
+    }
+  }
+  throw new Error(`Could not replace ResourceGraphDefinition ${rgdName}`);
+}
+
+async function requestRgdReconcile(api: MigrationApi, rgdName: string): Promise<void> {
+  const live = (await api.read({
+    apiVersion: 'kro.run/v1alpha1',
+    kind: 'ResourceGraphDefinition',
+    metadata: { name: rgdName },
+  })) as ResourceGraphDefinition;
+  await replaceRgdWithRetry(
+    api,
+    rgdName,
+    {
+      metadata: {
         name: rgdName,
         annotations: {
+          ...live.metadata?.annotations,
           'typekro.io/artifact-binding-migration-retry': new Date().toISOString(),
         },
       },
     },
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    'application/merge-patch+json'
+    live
   );
 }
 
@@ -221,14 +275,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
   // Applying the desired RGD first may briefly produce KindReady=False; the CRD
   // broadening below removes that incompatibility and the normal deployment
   // readiness gate waits for the same generation to become ready.
-  await api.patch(
-    desiredRgd,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    'application/merge-patch+json'
-  );
+  liveRgd = await replaceRgdWithRetry(api, rgdName, desiredRgd, liveRgd);
 
   for (let attempt = 1; attempt <= MAX_CRD_PATCH_ATTEMPTS; attempt += 1) {
     const crd = await findGeneratedCrd(api, group, kind);

--- a/src/core/kubernetes/errors.ts
+++ b/src/core/kubernetes/errors.ts
@@ -16,9 +16,11 @@ const logger = getComponentLogger('kubernetes-errors');
  * Interface representing a Kubernetes API error with various possible structures.
  * The error structure varies between client versions:
  * - 0.x (request-based): error.statusCode, error.body
- * - 1.x+ (fetch-based): error.response?.statusCode, error.statusCode, error.body?.code
+ * - 1.x+ generated ApiException: error.code, error.body
+ * - fetch wrappers: error.response?.statusCode, error.statusCode, error.body?.code
  */
 export interface KubernetesApiError {
+  code?: number;
   statusCode?: number;
   response?: {
     statusCode?: number;
@@ -38,6 +40,7 @@ export interface KubernetesApiError {
  * Extract the HTTP status code from a Kubernetes API error.
  *
  * Handles multiple error structures from different client versions:
+ * - Direct code property (@kubernetes/client-node 1.x ApiException)
  * - Direct statusCode property (0.x style)
  * - Nested response.statusCode (1.x+ fetch style)
  * - Nested body.code (some error responses)
@@ -63,6 +66,12 @@ export function getErrorStatusCode(error: unknown): number | undefined {
   }
 
   const err = error as KubernetesApiError;
+
+  // Generated @kubernetes/client-node 1.x ApiException instances expose the
+  // HTTP status on `code`, not `statusCode`.
+  if (typeof err.code === 'number') {
+    return err.code;
+  }
 
   // Try direct statusCode first (0.x style and some 1.x errors)
   if (typeof err.statusCode === 'number') {

--- a/src/core/planning/direct-runtime-adapter.ts
+++ b/src/core/planning/direct-runtime-adapter.ts
@@ -1,4 +1,5 @@
 import { toCamelCase } from '../../utils/string.js';
+import { materializeValuesMergeExpressions } from '../aspects/values-merge.js';
 import { DependencyGraph } from '../dependencies/graph.js';
 import { TypeKroError } from '../errors.js';
 import {
@@ -148,10 +149,8 @@ export function materializeDirectArtifactManifest(
       { artifactId: artifact.id, role: artifact.role }
     );
   }
-  const value = materializePlanValue(
-    artifact.desired,
-    options,
-    `$.resources.${artifact.id}.desired`
+  const value = materializeValuesMergeExpressions(
+    materializePlanValue(artifact.desired, options, `$.resources.${artifact.id}.desired`)
   );
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new DirectArtifactRuntimeAdapterError(

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -27,6 +27,16 @@ function desiredRgd(): KubernetesObject {
   } as unknown as KubernetesObject;
 }
 
+function defaultGroupDesiredRgd(): KubernetesObject {
+  const resource = structuredClone(desiredRgd());
+  const schema = Reflect.get(Reflect.get(resource, 'spec'), 'schema') as Record<
+    string,
+    unknown
+  >;
+  Reflect.deleteProperty(schema, 'group');
+  return resource;
+}
+
 function legacyCrd(resourceVersion: string): KubernetesObject {
   return {
     // Match KubernetesObjectApi list deserialization: TypeMeta may be omitted
@@ -70,6 +80,34 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('uses KRO default group when the RGD schema declares a version only', async () => {
+    const desired = defaultGroupDesiredRgd();
+    const live = structuredClone(desired);
+    live.metadata = {
+      name: 'application',
+      generation: 1,
+      resourceVersion: '20',
+    };
+    const crd = legacyCrd('10');
+    const crdSpec = Reflect.get(crd, 'spec') as Record<string, unknown>;
+    crdSpec.group = 'kro.run';
+    crd.metadata = {
+      ...crd.metadata,
+      name: 'applications.kro.run',
+    };
+    const list = mock(async () => ({ items: [crd] }));
+
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desired, {
+      api: {
+        read: mock(async () => live),
+        list,
+        replace: mock(async (resource: KubernetesObject) => resource),
+      } as never,
+    });
+
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
   test('retries complete RGD replacements and never serializes them as generic patches', async () => {
     let readCount = 0;
     const read = mock(async () => ({

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import type { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
+import { ApiException } from '@kubernetes/client-node/dist/gen/apis/exception.js';
 import { migrateLegacyKroArtifactBindingCrd } from '../../src/core/deployment/kro-artifact-binding-migration.js';
 import {
   kroArtifactOutputField,
@@ -80,6 +81,22 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('treats a real client 404 as an absent RGD', async () => {
+    const read = mock(async () => {
+      throw new ApiException(404, 'Not Found', undefined, {});
+    });
+
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
+      api: {
+        read,
+        list: mock(async () => ({ items: [] })),
+        replace: mock(async (resource: KubernetesObject) => resource),
+      } as never,
+    });
+
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
   test('uses KRO default group when the RGD schema declares a version only', async () => {
     const desired = defaultGroupDesiredRgd();
     const live = structuredClone(desired);
@@ -134,7 +151,7 @@ describe('KRO artifact-binding migration', () => {
         resource.kind === 'ResourceGraphDefinition' &&
         resource.metadata?.resourceVersion === '20'
       ) {
-        throw { response: { statusCode: 409 }, message: 'conflict' };
+        throw new ApiException(409, 'Conflict', undefined, {});
       }
       return resource;
     });

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -109,6 +109,12 @@ describe('KRO artifact-binding migration', () => {
   });
 
   test('retries complete RGD replacements and never serializes them as generic patches', async () => {
+    const desired = desiredRgd();
+    desired.metadata = {
+      ...desired.metadata,
+      labels: { shared: 'desired', desired: 'true' },
+      annotations: { shared: 'desired', desired: 'true' },
+    };
     let readCount = 0;
     const read = mock(async () => ({
       ...desiredRgd(),
@@ -116,7 +122,8 @@ describe('KRO artifact-binding migration', () => {
         name: 'application',
         generation: 2,
         resourceVersion: readCount++ === 0 ? '20' : '21',
-        labels: { retained: 'true' },
+        labels: { retained: 'true', shared: 'live' },
+        annotations: { retained: 'true', shared: 'live' },
       },
       status: {
         conditions: [{ type: 'KindReady', status: 'False', observedGeneration: 2 }],
@@ -127,12 +134,12 @@ describe('KRO artifact-binding migration', () => {
         resource.kind === 'ResourceGraphDefinition' &&
         resource.metadata?.resourceVersion === '20'
       ) {
-        throw { statusCode: 409, message: 'conflict' };
+        throw { response: { statusCode: 409 }, message: 'conflict' };
       }
       return resource;
     });
 
-    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desired, {
       api: {
         read,
         list: mock(async () => ({ items: [legacyCrd('10')] })),
@@ -149,8 +156,19 @@ describe('KRO artifact-binding migration', () => {
       '21',
     ]);
     expect(rgdReplacements[1]).toMatchObject({
-      metadata: { labels: { retained: 'true' } },
-      spec: Reflect.get(desiredRgd(), 'spec'),
+      metadata: {
+        labels: {
+          retained: 'true',
+          shared: 'desired',
+          desired: 'true',
+        },
+        annotations: {
+          retained: 'true',
+          shared: 'desired',
+          desired: 'true',
+        },
+      },
+      spec: Reflect.get(desired, 'spec'),
     });
     expect(Reflect.has(rgdReplacements[1] ?? {}, 'status')).toBe(false);
   });
@@ -179,7 +197,7 @@ describe('KRO artifact-binding migration', () => {
       if (resource.kind === 'ResourceGraphDefinition') return resource;
       crdVersions.push(resource.metadata?.resourceVersion ?? '');
       if (crdVersions.length === 1) {
-        throw { statusCode: 409, message: 'conflict' };
+        throw { response: { statusCode: 409 }, message: 'conflict' };
       }
       return resource;
     });

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -70,10 +70,57 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('retries complete RGD replacements and never serializes them as generic patches', async () => {
+    let readCount = 0;
+    const read = mock(async () => ({
+      ...desiredRgd(),
+      metadata: {
+        name: 'application',
+        generation: 2,
+        resourceVersion: readCount++ === 0 ? '20' : '21',
+        labels: { retained: 'true' },
+      },
+      status: {
+        conditions: [{ type: 'KindReady', status: 'False', observedGeneration: 2 }],
+      },
+    }));
+    const replace = mock(async (resource: KubernetesObject) => {
+      if (
+        resource.kind === 'ResourceGraphDefinition' &&
+        resource.metadata?.resourceVersion === '20'
+      ) {
+        throw { statusCode: 409, message: 'conflict' };
+      }
+      return resource;
+    });
+
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
+      api: {
+        read,
+        list: mock(async () => ({ items: [legacyCrd('10')] })),
+        replace,
+      } as never,
+    });
+
+    const rgdReplacements = replace.mock.calls
+      .map(([resource]) => resource as KubernetesObject)
+      .filter((resource) => resource.kind === 'ResourceGraphDefinition');
+    expect(rgdReplacements.map((resource) => resource.metadata?.resourceVersion)).toEqual([
+      '20',
+      '21',
+      '21',
+    ]);
+    expect(rgdReplacements[1]).toMatchObject({
+      metadata: { labels: { retained: 'true' } },
+      spec: Reflect.get(desiredRgd(), 'spec'),
+    });
+    expect(Reflect.has(rgdReplacements[1] ?? {}, 'status')).toBe(false);
+  });
+
   test('resumes an interrupted stable-RGD migration and retries CRD conflicts from fresh state', async () => {
     const read = mock(async () => ({
       ...desiredRgd(),
-      metadata: { name: 'application', generation: 2 },
+      metadata: { name: 'application', generation: 2, resourceVersion: '20' },
       status: {
         conditions: [
           {
@@ -88,8 +135,10 @@ describe('KRO artifact-binding migration', () => {
       .mockResolvedValueOnce({ items: [legacyCrd('10')] })
       .mockResolvedValueOnce({ items: [legacyCrd('11')] });
     const crdVersions: string[] = [];
-    const patch = mock(async (resource: KubernetesObject) => resource);
+    const replacementKinds: string[] = [];
     const replace = mock(async (resource: KubernetesObject) => {
+      replacementKinds.push(resource.kind ?? '');
+      if (resource.kind === 'ResourceGraphDefinition') return resource;
       crdVersions.push(resource.metadata?.resourceVersion ?? '');
       if (crdVersions.length === 1) {
         throw { statusCode: 409, message: 'conflict' };
@@ -98,12 +147,15 @@ describe('KRO artifact-binding migration', () => {
     });
 
     await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
-      api: { read, list, patch, replace } as never,
+      api: { read, list, replace } as never,
     });
 
     expect(crdVersions).toEqual(['10', '11']);
     expect(list).toHaveBeenCalledTimes(2);
-    const finalCrdPatch = replace.mock.calls.at(-1)?.[0] as KubernetesObject | undefined;
+    const finalCrdPatch = replace.mock.calls
+      .map(([resource]) => resource as KubernetesObject)
+      .reverse()
+      .find((resource) => resource.kind === 'CustomResourceDefinition');
     expect(finalCrdPatch).toMatchObject({
       apiVersion: 'apiextensions.k8s.io/v1',
       kind: 'CustomResourceDefinition',
@@ -124,13 +176,15 @@ describe('KRO artifact-binding migration', () => {
         additionalProperties: { type: 'string' },
       },
     });
+    expect(replacementKinds).toEqual([
+      'ResourceGraphDefinition',
+      'CustomResourceDefinition',
+      'CustomResourceDefinition',
+      'ResourceGraphDefinition',
+    ]);
+    const finalRgdReplacement = replace.mock.calls.at(-1)?.[0] as KubernetesObject | undefined;
     expect(
-      patch.mock.calls.some(
-        ([resource]) =>
-          (resource as KubernetesObject).metadata?.annotations?.[
-            'typekro.io/artifact-binding-migration-retry'
-          ] !== undefined
-      )
-    ).toBe(true);
+      finalRgdReplacement?.metadata?.annotations?.['typekro.io/artifact-binding-migration-retry']
+    ).toBeDefined();
   });
 });

--- a/test/core/kubernetes/errors.test.ts
+++ b/test/core/kubernetes/errors.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import { ApiException } from '@kubernetes/client-node/dist/gen/apis/exception.js';
 import * as fc from 'fast-check';
 import {
   getErrorStatusCode,
@@ -23,6 +24,11 @@ import {
 
 describe('Kubernetes Error Handling Utilities', () => {
   describe('getErrorStatusCode', () => {
+    it('extracts status codes from the pinned client ApiException', () => {
+      expect(getErrorStatusCode(new ApiException(404, 'Not Found', undefined, {}))).toBe(404);
+      expect(getErrorStatusCode(new ApiException(409, 'Conflict', undefined, {}))).toBe(409);
+    });
+
     /**
      * **Feature: upgrade-kubernetes-client, Property 1: Error Handling Consistency**
      * **Validates: Requirements 2.1, 2.4**
@@ -98,6 +104,7 @@ describe('Kubernetes Error Handling Utilities', () => {
 
   describe('isNotFoundError', () => {
     it('should return true for 404 errors', () => {
+      expect(isNotFoundError(new ApiException(404, 'Not Found', undefined, {}))).toBe(true);
       expect(isNotFoundError({ statusCode: 404 })).toBe(true);
       expect(isNotFoundError({ response: { statusCode: 404 } })).toBe(true);
       expect(isNotFoundError({ body: { code: 404 } })).toBe(true);
@@ -118,6 +125,7 @@ describe('Kubernetes Error Handling Utilities', () => {
 
   describe('isConflictError', () => {
     it('should return true for 409 errors', () => {
+      expect(isConflictError(new ApiException(409, 'Conflict', undefined, {}))).toBe(true);
       expect(isConflictError({ statusCode: 409 })).toBe(true);
       expect(isConflictError({ response: { statusCode: 409 } })).toBe(true);
       expect(isConflictError({ body: { code: 409 } })).toBe(true);

--- a/test/factories/nats/factory-modes.test.ts
+++ b/test/factories/nats/factory-modes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
+import { resourceFromDirectArtifactRecordForTest } from '../../../src/alchemy/resource-registration.js';
 import { kubernetesComposition } from '../../../src/core/composition/imperative.js';
 import { Cel } from '../../../src/core/references/cel.js';
 import { natsBootstrap } from '../../../src/factories/nats/compositions/nats-bootstrap.js';
@@ -200,6 +201,97 @@ describe('NATS and JetStream factories', () => {
     expect(controller?.dependsOn).toContain(repository?.id);
     expect(declarations.indexOf(repository!)).toBeLessThan(declarations.indexOf(server!));
     expect(declarations.indexOf(repository!)).toBeLessThan(declarations.indexOf(controller!));
+  });
+
+  it('materializes custom values in direct Alchemy without leaking the merge marker', async () => {
+    const customValues = {
+      config: {
+        jetstream: {
+          fileStore: {
+            pvc: {
+              storageClassName: 'local-path',
+            },
+          },
+        },
+      },
+    };
+    const declarations = await natsBootstrap
+      .factory('direct', { namespace: 'typekro-system', waitForReady: false })
+      .toAlchemyResources({
+        name: 'application-events',
+        namespace: 'application-system',
+        namespaceOwnership: 'external',
+        values: customValues,
+      });
+    const server = declarations.find(
+      (declaration) => declaration.props.resourceId === 'natsHelmRelease'
+    );
+    expect(server).toBeDefined();
+
+    const declaredValues = (
+      server!.props.resource as {
+        spec?: { values?: Record<string, unknown> };
+      }
+    ).spec?.values;
+    const rehydratedValues = (
+      resourceFromDirectArtifactRecordForTest({
+        ...server!.props,
+        dependencies: [{ resourceId: 'natsHelmRepository' } as never],
+      }) as {
+        spec?: { values?: Record<string, unknown> };
+      }
+    ).spec?.values;
+
+    for (const values of [declaredValues, rehydratedValues]) {
+      expect(values).toMatchObject({
+        config: {
+          jetstream: {
+            enabled: true,
+            fileStore: {
+              pvc: {
+                enabled: true,
+                size: '10Gi',
+                storageClassName: 'local-path',
+              },
+            },
+          },
+        },
+      });
+      expect(JSON.stringify(values)).not.toContain('__typekroValuesMerge');
+    }
+    expect(customValues).toEqual({
+      config: {
+        jetstream: {
+          fileStore: {
+            pvc: {
+              storageClassName: 'local-path',
+            },
+          },
+        },
+      },
+    });
+
+    const directYaml = natsBootstrap
+      .factory('direct', { namespace: 'typekro-system', waitForReady: false })
+      .toYaml({
+        name: 'application-events',
+        namespace: 'application-system',
+        namespaceOwnership: 'external',
+        values: customValues,
+      });
+    expect(directYaml).not.toContain('__typekroValuesMerge');
+    expect(directYaml).toMatch(
+      /jetstream:\s*\n\s+enabled: true\s*\n\s+fileStore:\s*\n\s+enabled: true\s*\n\s+pvc:\s*\n\s+enabled: true\s*\n\s+size: 10Gi\s*\n\s+storageClassName: local-path/
+    );
+
+    const kroYaml = natsBootstrap
+      .factory('kro', { namespace: 'typekro-system', waitForReady: false })
+      .toYaml();
+    expect(kroYaml).not.toContain('__typekroValuesMerge');
+    expect(kroYaml).toContain(
+      'has(schema.spec.values) ? json.unmarshal(json.marshal(schema.spec.values)) : {}'
+    );
+    expect(kroYaml).toContain('.merge({');
   });
 
   it('rejects non-positive and fractional replica counts', () => {

--- a/test/unit/values-merge-materialization.test.ts
+++ b/test/unit/values-merge-materialization.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  materializeValuesMergeExpressions,
+  mergeValuesExpression,
+} from '../../src/core/aspects/values-merge.js';
+
+describe('direct values merge materialization', () => {
+  it('deep-merges objects, replaces arrays and scalars, and preserves its inputs', () => {
+    const base = {
+      nested: { retained: true, replaced: 'base' },
+      list: ['base'],
+      scalar: 'base',
+    };
+    const overlay = {
+      nested: { replaced: 'overlay', added: true },
+      list: ['overlay'],
+      scalar: false,
+    };
+
+    expect(materializeValuesMergeExpressions(mergeValuesExpression(base, overlay))).toEqual({
+      nested: { retained: true, replaced: 'overlay', added: true },
+      list: ['overlay'],
+      scalar: false,
+    });
+    expect(base).toEqual({
+      nested: { retained: true, replaced: 'base' },
+      list: ['base'],
+      scalar: 'base',
+    });
+    expect(overlay).toEqual({
+      nested: { replaced: 'overlay', added: true },
+      list: ['overlay'],
+      scalar: false,
+    });
+  });
+
+  it('resolves nested and chained merge expressions anywhere in a value tree', () => {
+    const value = {
+      spec: {
+        values: mergeValuesExpression(
+          mergeValuesExpression({ first: 1, nested: { first: 1 } }, { second: 2 }),
+          {
+            nested: mergeValuesExpression({ second: 2 }, { third: 3 }),
+          }
+        ),
+      },
+    };
+
+    expect(materializeValuesMergeExpressions(value)).toEqual({
+      spec: {
+        values: {
+          first: 1,
+          second: 2,
+          nested: { first: 1, second: 2, third: 3 },
+        },
+      },
+    });
+    expect((value.spec.values as { __typekroValuesMerge?: boolean }).__typekroValuesMerge).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Materialize TypeKro `mergeValuesExpression()` nodes immutably before direct semantic compilation and before direct artifact runtime application.
- Preserve resource WeakMap metadata when materialization clones a manifest.
- Keep KRO serialization graph-aware; KRO continues to emit CEL map merges rather than concrete direct values.
- Resolve omitted KRO schema groups to the documented `kro.run` default during restart-safe artifact-binding migration.
- Replace complete `ResourceGraphDefinition` objects with resource-version concurrency during migration, avoiding `@kubernetes/client-node`'s unstructured list-field serializer failure and retrying conflicts from fresh state.
- Correct the Alchemy teardown contract comment to reflect the existing generated-CRD retention policy.

## Why

Concrete chart overrides could reach direct/Alchemy canonical artifacts as the internal `__typekroValuesMerge` marker. Flux then passed `base` and `overlays` literally to Helm, silently discarding integration defaults such as NATS JetStream enablement. The root fix belongs in TypeKro materialization, not in each chart mapper.

The live KRO redeploy then exposed two independent migration bugs:

1. Default-group compositions omit `spec.schema.group`, while the migration helper rejected the same omission instead of applying TypeKro/KRO's `kro.run` default.
2. `KubernetesObjectApi.patch()` tried to serialize the list-valued RGD schema through a generated model under Node and failed with `data is not iterable` before making an API request.

## User impact

Direct YAML and Alchemy deployments now preserve the same deep-merge semantics as authored TypeScript: objects merge recursively, arrays/scalars replace, inputs remain immutable, and the internal marker never reaches Kubernetes. KRO behavior remains dynamic and unchanged. Default-group KRO compositions can be deployed repeatedly through restart-safe, resource-version-safe artifact migration.

## Verification

- Exact-head `bun run test`: 5,273 passed, 13 skipped, 1 todo, 0 failed
- `bun run test:randomized`: 5,272 passed, 13 skipped, 1 todo, 0 failed before the additional deterministic migration regressions
- Exact-head `bun run typecheck`
- Exact-head `bun run lint`
- Exact-head `bun run build`
- Exact-head `git diff --check`
- Exact-head artifact-migration regression: 3 passed, including RGD and generated-CRD resource-version conflicts
- OrbStack direct NATS/NACK/JetStream integration: installed charts, reconciled Stream and Consumer, updated the Stream, published/read data, and cleaned all resources
- OrbStack KRO integration: same proof plus a second deployment through restart-safe artifact migration; all leased namespaces and RGDs were absent after cleanup
