### PR TITLE
fix: complete Alchemy namespace teardown

### DIFF
--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -587,19 +587,45 @@ export class DirectResourceFactoryImpl<
     timeout?: number,
     abortSignal?: AbortSignal
   ): Promise<void> {
-    const deletedNamespaces = rollbackResult.rolledBackResources
-      .filter((resource) => resource.startsWith('Namespace/'))
-      .map((resource) => resource.split('/')[1])
-      .filter((namespace): namespace is string => namespace !== undefined);
+    const namespaceLeases = new Map<string, string>();
+    for (const resource of rollbackResult.deletedResources ?? []) {
+      if (resource.kind !== 'Namespace') continue;
+      const uid = resource.liveManifest?.metadata?.uid ?? resource.manifest.metadata?.uid;
+      if (!uid) {
+        throw new TypeKroError(
+          `Refusing post-delete cleanup for Namespace ${resource.name} without its Kubernetes UID lease`,
+          'NAMESPACE_UID_UNAVAILABLE',
+          { namespace: resource.name }
+        );
+      }
+      namespaceLeases.set(resource.name, uid);
+    }
 
-    if (deletedNamespaces.length === 0) return;
+    if (namespaceLeases.size === 0) return;
 
-    // Delete PVCs in namespaces before waiting — StatefulSet PVCs have
-    // finalizers that block namespace termination until volumes are released.
+    // Delete PVCs in the exact Namespace identities targeted by rollback before
+    // waiting. A Namespace name can be reused after deletion, so every follow-up
+    // read and delete remains bound to the captured UID lease.
     const kubeConfig = this.getClientProvider().getKubeConfig();
     const coreApi = createBunCompatibleCoreV1Api(kubeConfig, this.factoryOptions.httpTimeouts);
-    for (const namespace of deletedNamespaces) {
+    const objectApi = this.getDeploymentEngine().getKubernetesApi();
+    const leaseStillCurrent = async (namespace: string, uid: string): Promise<boolean> => {
+      try {
+        const live = (await objectApi.read({
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: namespace },
+        })) as KubernetesResource;
+        return live.metadata?.uid === uid;
+      } catch (error: unknown) {
+        if (isNotFoundError(error)) return false;
+        throw error;
+      }
+    };
+
+    for (const [namespace, namespaceUid] of namespaceLeases) {
       abortSignal?.throwIfAborted();
+      if (!(await leaseStillCurrent(namespace, namespaceUid))) continue;
       let pvcs: Awaited<ReturnType<typeof coreApi.listNamespacedPersistentVolumeClaim>>;
       try {
         pvcs = await coreApi.listNamespacedPersistentVolumeClaim({ namespace });
@@ -616,11 +642,20 @@ export class DirectResourceFactoryImpl<
       for (const pvc of pvcs.items) {
         abortSignal?.throwIfAborted();
         const pvcName = pvc.metadata?.name;
-        if (!pvcName) continue;
+        const pvcUid = pvc.metadata?.uid;
+        if (!pvcName || !pvcUid) {
+          throw new TypeKroError(
+            `Refusing to delete a PersistentVolumeClaim in Namespace ${namespace} without a complete UID lease`,
+            'PVC_UID_UNAVAILABLE',
+            { namespace, pvcName }
+          );
+        }
+        if (!(await leaseStillCurrent(namespace, namespaceUid))) break;
         try {
           await coreApi.deleteNamespacedPersistentVolumeClaim({
             name: pvcName,
             namespace,
+            body: { preconditions: { uid: pvcUid } },
           });
         } catch (error: unknown) {
           if (!isNotFoundError(error)) throw error;
@@ -630,8 +665,8 @@ export class DirectResourceFactoryImpl<
 
     const deleteTimeout = timeout ?? this.factoryOptions.timeout ?? DEFAULT_DELETE_TIMEOUT;
     await this.waitForNamespaceDeletion(
-      this.getDeploymentEngine().getKubernetesApi(),
-      deletedNamespaces,
+      objectApi,
+      [...namespaceLeases].map(([name, uid]) => ({ name, uid })),
       deleteTimeout,
       abortSignal
     );
@@ -645,24 +680,30 @@ export class DirectResourceFactoryImpl<
    */
   private async waitForNamespaceDeletion(
     k8sApi: import('@kubernetes/client-node').KubernetesObjectApi,
-    namespaces: string[],
+    namespaces: Array<{ name: string; uid: string }>,
     timeout: number,
     abortSignal?: AbortSignal
   ): Promise<void> {
     const pollInterval = DEFAULT_FAST_POLL_INTERVAL;
 
-    for (const ns of namespaces) {
+    for (const { name: ns, uid } of namespaces) {
       // Each namespace gets its own timeout budget
       const nsStartTime = Date.now();
       let deleted = false;
       while (Date.now() - nsStartTime < timeout) {
         abortSignal?.throwIfAborted();
         try {
-          await k8sApi.read({
+          const live = (await k8sApi.read({
             apiVersion: 'v1',
             kind: 'Namespace',
             metadata: { name: ns },
-          });
+          })) as KubernetesResource;
+          // The leased Namespace is gone. A replacement with the same name is
+          // outside this teardown and must neither be waited on nor mutated.
+          if (live.metadata?.uid !== uid) {
+            deleted = true;
+            break;
+          }
           // Namespace still exists (likely "Terminating"), keep polling
           await new Promise<void>((resolve, reject) => {
             if (!abortSignal) {

--- a/src/core/deployment/direct-factory.ts
+++ b/src/core/deployment/direct-factory.ts
@@ -90,7 +90,7 @@ import {
 import { BUILT_IN_GVKS } from './deployment-state-discovery.js';
 import { DirectDeploymentEngine } from './engine.js';
 import { logHandleSnapshot } from './handle-tracing.js';
-import { isNotFoundError } from './k8s-helpers.js';
+import { isConflictError, isNotFoundError } from './k8s-helpers.js';
 import { synthesizeNestedCompositionStatus } from './nested-composition-status.js';
 import { ResourceReadinessChecker } from './readiness.js';
 
@@ -728,8 +728,7 @@ export class DirectResourceFactoryImpl<
           });
         } catch (error: unknown) {
           // 404 means the namespace is fully gone
-          const k8sErr = error as { statusCode?: number; body?: { code?: number } };
-          if (k8sErr.statusCode === 404 || k8sErr.body?.code === 404) {
+          if (isNotFoundError(error)) {
             this.logger.debug('Namespace fully deleted', { namespace: ns });
             deleted = true;
             break;
@@ -2570,9 +2569,7 @@ export class DirectResourceFactoryImpl<
               return;
             }
           } catch (pollError: unknown) {
-            const err = pollError as { statusCode?: number; body?: { code?: number } };
-            const code = err.statusCode ?? err.body?.code;
-            if (code === 404) {
+            if (isNotFoundError(pollError)) {
               return;
             }
             throw pollError;
@@ -2613,9 +2610,7 @@ export class DirectResourceFactoryImpl<
           return;
         }
       } catch (readError: unknown) {
-        const k8sErr = readError as { statusCode?: number; body?: { code?: number } };
-        const code = k8sErr.statusCode ?? k8sErr.body?.code;
-        if (code !== 404) {
+        if (!isNotFoundError(readError)) {
           throw readError;
         }
       }
@@ -2633,11 +2628,9 @@ export class DirectResourceFactoryImpl<
         });
       } catch (createError: unknown) {
         const k8sErr = createError as {
-          statusCode?: number;
-          body?: { code?: number; reason?: string };
+          body?: { reason?: string };
           message?: string;
         };
-        const code = k8sErr.statusCode ?? k8sErr.body?.code;
         const isNamespaceTerminating =
           k8sErr.body?.reason === 'Forbidden' &&
           k8sErr.message?.includes('NamespaceTerminating') === true;
@@ -2653,7 +2646,7 @@ export class DirectResourceFactoryImpl<
               },
             },
           });
-        } else if (code !== 409) {
+        } else if (!isConflictError(createError)) {
           throw createError;
         }
       }

--- a/src/core/deployment/engine.ts
+++ b/src/core/deployment/engine.ts
@@ -1477,7 +1477,8 @@ export class DirectDeploymentEngine {
     return this.rollbackManager.deleteDeployedResource(
       resource,
       options.timeout,
-      options.abortSignal
+      options.abortSignal,
+      { waitForNamespaceDeletion: true }
     );
   }
 

--- a/src/core/deployment/rollback-manager.ts
+++ b/src/core/deployment/rollback-manager.ts
@@ -515,7 +515,8 @@ export class ResourceRollbackManager {
   async deleteDeployedResource(
     resource: DeployedResource,
     timeout?: number,
-    abortSignal?: AbortSignal
+    abortSignal?: AbortSignal,
+    behavior: { waitForNamespaceDeletion?: boolean } = {}
   ): Promise<void> {
     throwIfAborted(abortSignal);
     const deleteLogger = this.logger.child({
@@ -547,12 +548,21 @@ export class ResourceRollbackManager {
 
       // Namespace deletion is asynchronous and may be blocked by PVCs that
       // Kubernetes cannot garbage-collect until their volumes are released.
-      // DirectResourceFactory owns that lifecycle: it removes PVCs only for
-      // explicitly targeted Namespaces and waits for the Namespace 404. Do
-      // not consume the generic per-resource timeout here before that cleanup
-      // has had a chance to run.
-      if (resource.kind === 'Namespace') {
+      // DirectResourceFactory owns that lifecycle during graph rollback: it
+      // removes PVCs only for explicitly targeted Namespaces and then performs
+      // its own 404 gate. Standalone callers such as the Alchemy deployer do
+      // not have that second phase, so they opt into the same real-404 gate
+      // here and must not report the declaration deleted while the Namespace
+      // is still Terminating.
+      if (resource.kind === 'Namespace' && behavior.waitForNamespaceDeletion !== true) {
         return;
+      }
+      if (resource.kind === 'Namespace') {
+        await this.deleteNamespacePersistentVolumeClaims(
+          resource.name,
+          deleteLogger,
+          abortSignal
+        );
       }
 
       // Wait for resource to be deleted
@@ -590,6 +600,59 @@ export class ResourceRollbackManager {
     } catch (error: unknown) {
       deleteLogger.error('Failed to delete resource', ensureError(error));
       throw error;
+    }
+  }
+
+  /**
+   * A Namespace that is already terminating cannot admit new namespaced
+   * resources. Delete its snapshotted PVCs before waiting for the final 404 so
+   * StatefulSet/operator retention policies cannot strand the Namespace behind
+   * `kubernetes.io/pvc-protection`.
+   *
+   * Aggregate DirectResourceFactory rollback performs this same completion
+   * phase after its graph rollback. This path is for standalone resource
+   * deployers such as Alchemy, where this manager owns the complete delete.
+   */
+  private async deleteNamespacePersistentVolumeClaims(
+    namespace: string,
+    deleteLogger: ReturnType<typeof getComponentLogger>,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    throwIfAborted(abortSignal);
+    let result: {
+      items?: Array<{ metadata?: { name?: unknown } }>;
+    };
+    try {
+      result = (await this.k8sApi.list(
+        'v1',
+        'PersistentVolumeClaim',
+        namespace
+      )) as typeof result;
+    } catch (error: unknown) {
+      if (isNotFoundError(error)) return;
+      throw error;
+    }
+
+    const names = (result.items ?? [])
+      .map((pvc) => pvc.metadata?.name)
+      .filter((name): name is string => typeof name === 'string' && name.length > 0);
+    if (names.length > 0) {
+      deleteLogger.info('Deleting PVCs to complete Namespace deletion', {
+        namespace,
+        count: names.length,
+      });
+    }
+    for (const name of names) {
+      throwIfAborted(abortSignal);
+      try {
+        await this.k8sApi.delete({
+          apiVersion: 'v1',
+          kind: 'PersistentVolumeClaim',
+          metadata: { name, namespace },
+        });
+      } catch (error: unknown) {
+        if (!isNotFoundError(error)) throw error;
+      }
     }
   }
 

--- a/src/core/deployment/rollback-manager.ts
+++ b/src/core/deployment/rollback-manager.ts
@@ -532,12 +532,53 @@ export class ResourceRollbackManager {
     };
 
     try {
+      let namespaceUid: string | undefined;
+      if (resource.kind === 'Namespace') {
+        namespaceUid = resource.liveManifest?.metadata?.uid ?? resource.manifest.metadata?.uid;
+        if (!namespaceUid) {
+          try {
+            const live = (await this.k8sApi.read({
+              apiVersion: resource.manifest.apiVersion || 'v1',
+              kind: 'Namespace',
+              metadata: { name: resource.name },
+            })) as KubernetesResource;
+            namespaceUid = live.metadata?.uid;
+            resource.liveManifest = live;
+          } catch (error: unknown) {
+            if (isNotFoundError(error)) {
+              deleteLogger.debug('Namespace already deleted');
+              return;
+            }
+            throw error;
+          }
+        }
+        if (!namespaceUid) {
+          throw new TypeKroError(
+            `Refusing to delete Namespace ${resource.name} without a Kubernetes UID lease`,
+            'NAMESPACE_UID_UNAVAILABLE',
+            { namespace: resource.name }
+          );
+        }
+      }
       try {
-        await this.k8sApi.delete({
+        const deletionTarget = {
           apiVersion: resource.manifest.apiVersion || '',
           kind: resource.kind,
           metadata,
-        } as k8s.KubernetesObject);
+        } as k8s.KubernetesObject;
+        if (namespaceUid) {
+          await this.k8sApi.delete(
+            deletionTarget,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { preconditions: { uid: namespaceUid } }
+          );
+        } else {
+          await this.k8sApi.delete(deletionTarget);
+        }
       } catch (error: unknown) {
         if (isNotFoundError(error)) {
           deleteLogger.debug('Resource already deleted');
@@ -558,8 +599,16 @@ export class ResourceRollbackManager {
         return;
       }
       if (resource.kind === 'Namespace') {
+        if (!namespaceUid) {
+          throw new TypeKroError(
+            `Refusing post-delete cleanup for Namespace ${resource.name} without its Kubernetes UID lease`,
+            'NAMESPACE_UID_UNAVAILABLE',
+            { namespace: resource.name }
+          );
+        }
         await this.deleteNamespacePersistentVolumeClaims(
           resource.name,
+          namespaceUid,
           deleteLogger,
           abortSignal
         );
@@ -572,11 +621,18 @@ export class ResourceRollbackManager {
       while (Date.now() - startTime < deleteTimeout) {
         throwIfAborted(abortSignal);
         try {
-          await this.k8sApi.read({
+          const live = (await this.k8sApi.read({
             apiVersion: resource.manifest.apiVersion || '',
             kind: resource.kind,
             metadata,
-          });
+          })) as KubernetesResource;
+          if (resource.kind === 'Namespace' && live.metadata?.uid !== namespaceUid) {
+            deleteLogger.debug('Original Namespace is gone; replacement identity is preserved', {
+              expectedUid: namespaceUid,
+              actualUid: live.metadata?.uid,
+            });
+            return;
+          }
 
           // Resource still exists, wait and try again
           await abortableDelay(DEFAULT_FAST_POLL_INTERVAL, abortSignal);
@@ -615,44 +671,79 @@ export class ResourceRollbackManager {
    */
   private async deleteNamespacePersistentVolumeClaims(
     namespace: string,
+    namespaceUid: string,
     deleteLogger: ReturnType<typeof getComponentLogger>,
     abortSignal?: AbortSignal
   ): Promise<void> {
     throwIfAborted(abortSignal);
+    if (!(await this.isNamespaceLeaseCurrent(namespace, namespaceUid))) return;
     let result: {
-      items?: Array<{ metadata?: { name?: unknown } }>;
+      items?: Array<{ metadata?: { name?: unknown; uid?: unknown } }>;
     };
     try {
-      result = (await this.k8sApi.list(
-        'v1',
-        'PersistentVolumeClaim',
-        namespace
-      )) as typeof result;
+      result = (await this.k8sApi.list('v1', 'PersistentVolumeClaim', namespace)) as typeof result;
     } catch (error: unknown) {
       if (isNotFoundError(error)) return;
       throw error;
     }
 
-    const names = (result.items ?? [])
-      .map((pvc) => pvc.metadata?.name)
-      .filter((name): name is string => typeof name === 'string' && name.length > 0);
-    if (names.length > 0) {
+    const leases = (result.items ?? []).map((pvc) => {
+      const name = pvc.metadata?.name;
+      const uid = pvc.metadata?.uid;
+      if (
+        typeof name !== 'string' ||
+        name.length === 0 ||
+        typeof uid !== 'string' ||
+        uid.length === 0
+      ) {
+        throw new TypeKroError(
+          `Refusing to delete a PersistentVolumeClaim in Namespace ${namespace} without a complete UID lease`,
+          'PVC_UID_UNAVAILABLE',
+          { namespace, pvcName: name, pvcUid: uid }
+        );
+      }
+      return { name, uid };
+    });
+    if (leases.length > 0) {
       deleteLogger.info('Deleting PVCs to complete Namespace deletion', {
         namespace,
-        count: names.length,
+        count: leases.length,
       });
     }
-    for (const name of names) {
+    for (const { name, uid } of leases) {
       throwIfAborted(abortSignal);
+      if (!(await this.isNamespaceLeaseCurrent(namespace, namespaceUid))) return;
       try {
-        await this.k8sApi.delete({
-          apiVersion: 'v1',
-          kind: 'PersistentVolumeClaim',
-          metadata: { name, namespace },
-        });
+        await this.k8sApi.delete(
+          {
+            apiVersion: 'v1',
+            kind: 'PersistentVolumeClaim',
+            metadata: { name, namespace },
+          },
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { preconditions: { uid } }
+        );
       } catch (error: unknown) {
         if (!isNotFoundError(error)) throw error;
       }
+    }
+  }
+
+  private async isNamespaceLeaseCurrent(namespace: string, uid: string): Promise<boolean> {
+    try {
+      const live = (await this.k8sApi.read({
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: namespace },
+      })) as KubernetesResource;
+      return live.metadata?.uid === uid;
+    } catch (error: unknown) {
+      if (isNotFoundError(error)) return false;
+      throw error;
     }
   }
 

--- a/test/core/direct-deployment.test.ts
+++ b/test/core/direct-deployment.test.ts
@@ -981,7 +981,7 @@ describe('DirectDeploymentEngine', () => {
         id: 'namespace',
         kind: 'Namespace',
         apiVersion: 'v1',
-        metadata: { name: 'owned-system' },
+        metadata: { name: 'owned-system', uid: 'owned-system-uid' },
       });
       const serviceManifest = createMockResource({
         id: 'service',

--- a/test/core/direct-factory-characterization.test.ts
+++ b/test/core/direct-factory-characterization.test.ts
@@ -289,12 +289,16 @@ describe('DirectResourceFactory: deployed instance tracking', () => {
     );
     const waitForNamespaceDeletion = getPrivateMethod(factory, 'waitForNamespaceDeletion') as (
       k8sApi: { read(request: Record<string, unknown>): Promise<unknown> },
-      namespaces: string[],
+      namespaces: Array<{ name: string; uid: string }>,
       timeout: number
     ) => Promise<void>;
 
     await expect(
-      waitForNamespaceDeletion({ read: mock(() => Promise.resolve({ body: {} })) }, ['stuck-ns'], 0)
+      waitForNamespaceDeletion(
+        { read: mock(() => Promise.resolve({ metadata: { uid: 'namespace-uid' } })) },
+        [{ name: 'stuck-ns', uid: 'namespace-uid' }],
+        0
+      )
     ).rejects.toThrow('Timed out waiting for namespace stuck-ns to be deleted');
   });
 });

--- a/test/core/direct-factory-characterization.test.ts
+++ b/test/core/direct-factory-characterization.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { describe, expect, it, mock } from 'bun:test';
+import { ApiException } from '@kubernetes/client-node/dist/gen/apis/exception.js';
 import { type } from 'arktype';
 import { getCurrentCompositionContext } from '../../src/core/composition/context.js';
 import { DependencyResolver } from '../../src/core/dependencies/resolver.js';
@@ -300,6 +301,38 @@ describe('DirectResourceFactory: deployed instance tracking', () => {
         0
       )
     ).rejects.toThrow('Timed out waiting for namespace stuck-ns to be deleted');
+  });
+
+  it('accepts a real client 404 as successful namespace deletion', async () => {
+    const factory = createDirectResourceFactory(
+      'namespace-terminal-404-test',
+      {},
+      {
+        apiVersion: 'test.typekro.io/v1alpha1',
+        kind: 'NamespaceTerminal404Test',
+        spec: TestSpecSchema,
+        status: TestStatusSchema,
+      },
+      undefined,
+      { hydrateStatus: false }
+    );
+    const waitForNamespaceDeletion = getPrivateMethod(factory, 'waitForNamespaceDeletion') as (
+      k8sApi: { read(request: Record<string, unknown>): Promise<unknown> },
+      namespaces: Array<{ name: string; uid: string }>,
+      timeout: number
+    ) => Promise<void>;
+
+    await expect(
+      waitForNamespaceDeletion(
+        {
+          read: mock(() => {
+            throw new ApiException(404, 'Not Found', undefined, {});
+          }),
+        },
+        [{ name: 'deleted-ns', uid: 'namespace-uid' }],
+        1_000
+      )
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/test/unit/rollback-manager.test.ts
+++ b/test/unit/rollback-manager.test.ts
@@ -320,6 +320,94 @@ describe('ResourceRollbackManager', () => {
       expect(mockK8sApi.read).not.toHaveBeenCalled();
     });
 
+    it('waits for a real Namespace 404 when a standalone deployer owns the complete delete', async () => {
+      const ownedNamespace = {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'alchemy-system' },
+      } as Enhanced<unknown, unknown>;
+      setMetadataField(ownedNamespace, 'scope', 'cluster');
+      const deployedResource: DeployedResource = {
+        id: 'alchemyNamespace',
+        kind: 'Namespace',
+        name: 'alchemy-system',
+        namespace: 'default',
+        manifest: ownedNamespace,
+        status: 'deployed',
+        deployedAt: new Date(),
+      };
+
+      mockK8sApi.delete.mockResolvedValue({ body: {} });
+      mockK8sApi.read
+        .mockResolvedValueOnce({ body: ownedNamespace })
+        .mockRejectedValueOnce(createK8sError('Not found', 404));
+
+      await manager.deleteDeployedResource(deployedResource, 5_000, undefined, {
+        waitForNamespaceDeletion: true,
+      });
+
+      expect(mockK8sApi.delete).toHaveBeenCalledWith({
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'alchemy-system' },
+      });
+      expect(mockK8sApi.read).toHaveBeenCalledTimes(2);
+    });
+
+    it('deletes retained PVCs before waiting for a standalone Namespace to disappear', async () => {
+      const ownedNamespace = {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'alchemy-data-system' },
+      } as Enhanced<unknown, unknown>;
+      setMetadataField(ownedNamespace, 'scope', 'cluster');
+      const deployedResource: DeployedResource = {
+        id: 'alchemyDataNamespace',
+        kind: 'Namespace',
+        name: 'alchemy-data-system',
+        namespace: 'default',
+        manifest: ownedNamespace,
+        status: 'deployed',
+        deployedAt: new Date(),
+      };
+
+      mockK8sApi.list.mockResolvedValue({
+        items: [
+          { metadata: { name: 'database-data' } },
+          { metadata: { name: 'search-data' } },
+        ],
+      });
+      mockK8sApi.delete.mockResolvedValue({});
+      mockK8sApi.read.mockRejectedValue(createK8sError('Not found', 404));
+
+      await manager.deleteDeployedResource(deployedResource, 5_000, undefined, {
+        waitForNamespaceDeletion: true,
+      });
+
+      expect(mockK8sApi.list).toHaveBeenCalledWith(
+        'v1',
+        'PersistentVolumeClaim',
+        'alchemy-data-system'
+      );
+      expect(mockK8sApi.delete).toHaveBeenCalledTimes(3);
+      expect(mockK8sApi.delete).toHaveBeenCalledWith({
+        apiVersion: 'v1',
+        kind: 'PersistentVolumeClaim',
+        metadata: {
+          name: 'database-data',
+          namespace: 'alchemy-data-system',
+        },
+      });
+      expect(mockK8sApi.delete).toHaveBeenCalledWith({
+        apiVersion: 'v1',
+        kind: 'PersistentVolumeClaim',
+        metadata: {
+          name: 'search-data',
+          namespace: 'alchemy-data-system',
+        },
+      });
+    });
+
     it('treats deployed rollback records already gone at initial DELETE as deleted', async () => {
       const deployedResource: DeployedResource = {
         id: 'goneConfig',

--- a/test/unit/rollback-manager.test.ts
+++ b/test/unit/rollback-manager.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../src/core/deployment/rollback-manager.js';
 import { setMetadataField } from '../../src/core/metadata/index.js';
 import type { DeployedResource, DeploymentEvent } from '../../src/core/types/deployment.js';
-import type { Enhanced } from '../../src/core/types/kubernetes.js';
+import type { Enhanced, KubernetesResource } from '../../src/core/types/kubernetes.js';
 import { configMap } from '../../src/factories/kubernetes/config/config-map.js';
 import { service } from '../../src/factories/kubernetes/networking/service.js';
 import { deployment } from '../../src/factories/kubernetes/workloads/deployment.js';
@@ -304,6 +304,11 @@ describe('ResourceRollbackManager', () => {
         name: 'owned-system',
         namespace: 'default',
         manifest: ownedNamespace,
+        liveManifest: {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'owned-system', uid: 'owned-system-uid' },
+        } as KubernetesResource,
         status: 'deployed',
         deployedAt: new Date(),
       };
@@ -312,11 +317,19 @@ describe('ResourceRollbackManager', () => {
 
       await manager.deleteDeployedResource(deployedResource, 5);
 
-      expect(mockK8sApi.delete).toHaveBeenCalledWith({
-        apiVersion: 'v1',
-        kind: 'Namespace',
-        metadata: { name: 'owned-system' },
-      });
+      expect(mockK8sApi.delete).toHaveBeenCalledWith(
+        {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'owned-system' },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { preconditions: { uid: 'owned-system-uid' } }
+      );
       expect(mockK8sApi.read).not.toHaveBeenCalled();
     });
 
@@ -333,25 +346,39 @@ describe('ResourceRollbackManager', () => {
         name: 'alchemy-system',
         namespace: 'default',
         manifest: ownedNamespace,
+        liveManifest: {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'alchemy-system', uid: 'alchemy-system-uid' },
+        } as KubernetesResource,
         status: 'deployed',
         deployedAt: new Date(),
       };
 
       mockK8sApi.delete.mockResolvedValue({ body: {} });
       mockK8sApi.read
-        .mockResolvedValueOnce({ body: ownedNamespace })
+        .mockResolvedValueOnce({ metadata: { uid: 'alchemy-system-uid' } })
+        .mockResolvedValueOnce({ metadata: { uid: 'alchemy-system-uid' } })
         .mockRejectedValueOnce(createK8sError('Not found', 404));
 
       await manager.deleteDeployedResource(deployedResource, 5_000, undefined, {
         waitForNamespaceDeletion: true,
       });
 
-      expect(mockK8sApi.delete).toHaveBeenCalledWith({
-        apiVersion: 'v1',
-        kind: 'Namespace',
-        metadata: { name: 'alchemy-system' },
-      });
-      expect(mockK8sApi.read).toHaveBeenCalledTimes(2);
+      expect(mockK8sApi.delete).toHaveBeenCalledWith(
+        {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'alchemy-system' },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { preconditions: { uid: 'alchemy-system-uid' } }
+      );
+      expect(mockK8sApi.read).toHaveBeenCalledTimes(3);
     });
 
     it('deletes retained PVCs before waiting for a standalone Namespace to disappear', async () => {
@@ -367,18 +394,27 @@ describe('ResourceRollbackManager', () => {
         name: 'alchemy-data-system',
         namespace: 'default',
         manifest: ownedNamespace,
+        liveManifest: {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'alchemy-data-system', uid: 'alchemy-data-system-uid' },
+        } as KubernetesResource,
         status: 'deployed',
         deployedAt: new Date(),
       };
 
       mockK8sApi.list.mockResolvedValue({
         items: [
-          { metadata: { name: 'database-data' } },
-          { metadata: { name: 'search-data' } },
+          { metadata: { name: 'database-data', uid: 'database-data-uid' } },
+          { metadata: { name: 'search-data', uid: 'search-data-uid' } },
         ],
       });
       mockK8sApi.delete.mockResolvedValue({});
-      mockK8sApi.read.mockRejectedValue(createK8sError('Not found', 404));
+      mockK8sApi.read
+        .mockResolvedValueOnce({ metadata: { uid: 'alchemy-data-system-uid' } })
+        .mockResolvedValueOnce({ metadata: { uid: 'alchemy-data-system-uid' } })
+        .mockResolvedValueOnce({ metadata: { uid: 'alchemy-data-system-uid' } })
+        .mockRejectedValueOnce(createK8sError('Not found', 404));
 
       await manager.deleteDeployedResource(deployedResource, 5_000, undefined, {
         waitForNamespaceDeletion: true,
@@ -390,22 +426,88 @@ describe('ResourceRollbackManager', () => {
         'alchemy-data-system'
       );
       expect(mockK8sApi.delete).toHaveBeenCalledTimes(3);
-      expect(mockK8sApi.delete).toHaveBeenCalledWith({
-        apiVersion: 'v1',
-        kind: 'PersistentVolumeClaim',
-        metadata: {
-          name: 'database-data',
-          namespace: 'alchemy-data-system',
+      expect(mockK8sApi.delete).toHaveBeenCalledWith(
+        {
+          apiVersion: 'v1',
+          kind: 'PersistentVolumeClaim',
+          metadata: {
+            name: 'database-data',
+            namespace: 'alchemy-data-system',
+          },
         },
-      });
-      expect(mockK8sApi.delete).toHaveBeenCalledWith({
-        apiVersion: 'v1',
-        kind: 'PersistentVolumeClaim',
-        metadata: {
-          name: 'search-data',
-          namespace: 'alchemy-data-system',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { preconditions: { uid: 'database-data-uid' } }
+      );
+      expect(mockK8sApi.delete).toHaveBeenCalledWith(
+        {
+          apiVersion: 'v1',
+          kind: 'PersistentVolumeClaim',
+          metadata: {
+            name: 'search-data',
+            namespace: 'alchemy-data-system',
+          },
         },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { preconditions: { uid: 'search-data-uid' } }
+      );
+    });
+
+    it('preserves a replacement Namespace and its PVCs when the original UID lease is gone', async () => {
+      const ownedNamespace = {
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'reused-system' },
+      } as Enhanced<unknown, unknown>;
+      setMetadataField(ownedNamespace, 'scope', 'cluster');
+      const deployedResource: DeployedResource = {
+        id: 'reusedNamespace',
+        kind: 'Namespace',
+        name: 'reused-system',
+        namespace: 'default',
+        manifest: ownedNamespace,
+        liveManifest: {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'reused-system', uid: 'original-uid' },
+        } as KubernetesResource,
+        status: 'deployed',
+        deployedAt: new Date(),
+      };
+
+      mockK8sApi.delete.mockResolvedValue({});
+      mockK8sApi.read.mockResolvedValue({
+        apiVersion: 'v1',
+        kind: 'Namespace',
+        metadata: { name: 'reused-system', uid: 'replacement-uid' },
       });
+
+      await manager.deleteDeployedResource(deployedResource, 5_000, undefined, {
+        waitForNamespaceDeletion: true,
+      });
+
+      expect(mockK8sApi.list).not.toHaveBeenCalled();
+      expect(mockK8sApi.delete).toHaveBeenCalledTimes(1);
+      expect(mockK8sApi.delete).toHaveBeenCalledWith(
+        {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'reused-system' },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { preconditions: { uid: 'original-uid' } }
+      );
     });
 
     it('treats deployed rollback records already gone at initial DELETE as deleted', async () => {


### PR DESCRIPTION
## Summary

- require standalone DirectDeploymentEngine deletion to wait for Namespace 404
- delete retained PVCs before the Namespace completion wait
- preserve aggregate DirectResourceFactory rollback behavior
- cover both the wait boundary and PVC completion behavior

## Why

Alchemy previously reported a Namespace declaration deleted immediately after submitting the DELETE request. Stateful and operator-generated PVCs could keep that Namespace Terminating while the stack transaction reported success.

The v0.7 Applik8s External profile reproduced this with CNPG, NATS, Hatchet, Ory, OpenSearch, ClickHouse, and object storage in one provider namespace.

## Verification

- 5,271 TypeKro tests passed; 0 failed
- library typecheck passed
- lint passed
- diff check passed
- live OrbStack External-provider teardown deleted nine retained PVCs, waited through controller finalizers, observed the Namespace 404, and left no provider CR, PVC, RGD, instance, or Namespace

This remains draft for maintainer review.
