### PR TITLE
fix: make default Ory password login usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The managed Ory identity stack's default Kratos schema now marks its email
+  trait as a password-credential identifier. Identities created through the
+  Admin API can therefore complete password login without requiring consumers
+  to replace the otherwise usable default schema.
 - Direct Alchemy singleton owners now gate consumer scheduling through a dedicated barrier instead
   of being injected into each consumer's canonical live-resource dependencies. This preserves
   singleton readiness ordering without making direct artifact execution records fail dependency

--- a/src/factories/ory/utils/helm-values-mapper.ts
+++ b/src/factories/ory/utils/helm-values-mapper.ts
@@ -195,7 +195,17 @@ function defaultKratosIdentitySchema(): string {
       traits: {
         type: 'object',
         properties: {
-          email: { type: 'string', format: 'email' },
+          email: {
+            type: 'string',
+            format: 'email',
+            'ory.sh/kratos': {
+              credentials: {
+                password: {
+                  identifier: true,
+                },
+              },
+            },
+          },
         },
       },
     },

--- a/test/factories/ory/values-mapper.test.ts
+++ b/test/factories/ory/values-mapper.test.ts
@@ -215,6 +215,17 @@ describe('Ory Helm values mapper', () => {
     expect(values.kratos.kratos?.identitySchemas?.['identity.default.schema.json']).toContain(
       'Default Identity'
     );
+    expect(
+      JSON.parse(
+        values.kratos.kratos?.identitySchemas?.['identity.default.schema.json'] ?? '{}'
+      ).properties.traits.properties.email['ory.sh/kratos']
+    ).toEqual({
+      credentials: {
+        password: {
+          identifier: true,
+        },
+      },
+    });
   });
 
   it('Mounts a custom Kratos default identity schema without duplicate refs', () => {


### PR DESCRIPTION
## Summary

- mark the default Kratos email trait as a password credential identifier
- retain the existing schema-first Ory configuration surface
- add regression coverage for the emitted default identity schema

## Why

The managed Ory stack's default identity schema accepted an email trait but did not register that trait as a password identifier. Admin-created identities therefore existed, but password login could not resolve them and returned invalid credentials.

## Verification

- focused Ory mapper suite: 17 passed
- full TypeKro suite: 5,269 passed; 0 failed
- all TypeScript project checks passed
- lint, library build, example build, and diff check passed
- the live OrbStack Applik8s External profile created a real Ory session and passed both maintained Agentic Start browser journeys

This remains draft for maintainer review.
