### PR TITLE
fix: replace RGD during artifact migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic KRO artifact-binding migration now replaces the complete generated CRD with
   resource-version concurrency rather than sending a partial merge patch through
   `KubernetesObjectApi`. This avoids the client serializer's `data is not iterable` failure while
-  retaining restart-safe conflict retries.
+  retaining restart-safe conflict retries. Version-only schemas correctly resolve to KRO's default
+  `kro.run` API group during migration.
 - Artifact-binding migration now also replaces the complete ResourceGraphDefinition with
   resource-version concurrency. This avoids the same client serializer failure when an RGD update
   contains array-valued resources, while preserving live metadata and omitting status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resource-version concurrency rather than sending a partial merge patch through
   `KubernetesObjectApi`. This avoids the client serializer's `data is not iterable` failure while
   retaining restart-safe conflict retries.
+- Artifact-binding migration now also replaces the complete ResourceGraphDefinition with
+  resource-version concurrency. This avoids the same client serializer failure when an RGD update
+  contains array-valued resources, while preserving live metadata and omitting status.
 - Semantic planning now represents ArkType's explicitly open `object` and
   `object[]` nodes—including root `type('object')` schemas and ordinary or
   `ignore` undeclared-key policies—without falsely opening `reject`/`delete`

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -263,12 +263,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
 
   const group =
     desiredRgd.spec.schema.group ??
-    (apiVersion.includes('/') ? apiVersion.slice(0, apiVersion.lastIndexOf('/')) : undefined);
-  if (!group) {
-    throw new Error(
-      `Cannot migrate artifact bindings for ${rgdName}: the desired RGD schema has no API group`
-    );
-  }
+    (apiVersion.includes('/') ? apiVersion.slice(0, apiVersion.lastIndexOf('/')) : 'kro.run');
   // Put the desired RGD in place before broadening the generated CRD. If the
   // legacy RGD remains live, KRO can immediately reconcile and restore its old
   // topology-shaped schema between this patch and the caller's normal apply.

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -1,6 +1,9 @@
 import type { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
 import { ensureError } from '../errors.js';
-import { createBunCompatibleKubernetesObjectApi } from '../kubernetes/index.js';
+import {
+  createBunCompatibleKubernetesObjectApi,
+  getErrorStatusCode,
+} from '../kubernetes/index.js';
 import { KRO_ARTIFACT_BINDINGS_SPEC_FIELD } from '../planning/values.js';
 
 const STABLE_BINDING_SCHEMA = 'map[string]map[string]string';
@@ -42,15 +45,6 @@ interface CustomResourceDefinition extends KubernetesObject {
       [key: string]: unknown;
     }>;
   };
-}
-
-function statusCode(error: unknown): number | undefined {
-  const candidate = error as {
-    statusCode?: number;
-    code?: number;
-    body?: { code?: number };
-  };
-  return candidate.statusCode ?? candidate.code ?? candidate.body?.code;
 }
 
 async function findGeneratedCrd(
@@ -167,6 +161,14 @@ async function replaceRgdWithRetry(
       metadata: {
         ...live.metadata,
         ...desired?.metadata,
+        labels: {
+          ...live.metadata?.labels,
+          ...desired?.metadata?.labels,
+        },
+        annotations: {
+          ...live.metadata?.annotations,
+          ...desired?.metadata?.annotations,
+        },
         name: rgdName,
         resourceVersion,
       },
@@ -175,7 +177,7 @@ async function replaceRgdWithRetry(
     try {
       return (await api.replace(replacement)) as ResourceGraphDefinition;
     } catch (error: unknown) {
-      if (statusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+      if (getErrorStatusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
         throw new Error(
           `Could not replace ResourceGraphDefinition ${rgdName} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
         );
@@ -242,7 +244,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
       metadata: { name: rgdName },
     })) as ResourceGraphDefinition;
   } catch (error: unknown) {
-    if (statusCode(error) === 404) return;
+    if (getErrorStatusCode(error) === 404) return;
     throw new Error(
       `Could not inspect ResourceGraphDefinition ${rgdName} before artifact-binding migration: ${ensureError(error).message}`
     );
@@ -324,7 +326,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
       await requestRgdReconcile(api, rgdName);
       return;
     } catch (error: unknown) {
-      if (statusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+      if (getErrorStatusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
         throw new Error(
           `Could not migrate generated CRD ${crd.metadata.name} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
         );

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -7,7 +7,7 @@ const STABLE_BINDING_SCHEMA = 'map[string]map[string]string';
 const MAX_CRD_PATCH_ATTEMPTS = 5;
 type MigrationApi = Pick<
   ReturnType<typeof createBunCompatibleKubernetesObjectApi>,
-  'read' | 'list' | 'patch' | 'replace'
+  'read' | 'list' | 'replace'
 >;
 
 interface ResourceGraphDefinition extends KubernetesObject {
@@ -138,23 +138,77 @@ function needsRgdReconcileRetry(rgd: ResourceGraphDefinition): boolean {
   );
 }
 
-async function requestRgdReconcile(api: MigrationApi, rgdName: string): Promise<void> {
-  await api.patch(
-    {
+async function replaceRgdWithRetry(
+  api: MigrationApi,
+  rgdName: string,
+  desired: ResourceGraphDefinition | undefined,
+  initialLive?: ResourceGraphDefinition
+): Promise<ResourceGraphDefinition> {
+  let live =
+    initialLive ??
+    ((await api.read({
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'ResourceGraphDefinition',
+      metadata: { name: rgdName },
+    })) as ResourceGraphDefinition);
+  for (let attempt = 1; attempt <= MAX_CRD_PATCH_ATTEMPTS; attempt += 1) {
+    const resourceVersion = live.metadata?.resourceVersion;
+    if (!resourceVersion) {
+      throw new Error(
+        `Cannot safely replace ResourceGraphDefinition ${rgdName}: the live resource has no resourceVersion`
+      );
+    }
+    const { status: _status, ...writableLive } = live;
+    const replacement: ResourceGraphDefinition = {
+      ...writableLive,
+      ...desired,
       apiVersion: 'kro.run/v1alpha1',
       kind: 'ResourceGraphDefinition',
       metadata: {
+        ...live.metadata,
+        ...desired?.metadata,
+        name: rgdName,
+        resourceVersion,
+      },
+      ...(desired?.spec ? { spec: desired.spec } : {}),
+    };
+    try {
+      return (await api.replace(replacement)) as ResourceGraphDefinition;
+    } catch (error: unknown) {
+      if (statusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+        throw new Error(
+          `Could not replace ResourceGraphDefinition ${rgdName} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
+        );
+      }
+      live = (await api.read({
+        apiVersion: 'kro.run/v1alpha1',
+        kind: 'ResourceGraphDefinition',
+        metadata: { name: rgdName },
+      })) as ResourceGraphDefinition;
+    }
+  }
+  throw new Error(`Could not replace ResourceGraphDefinition ${rgdName}`);
+}
+
+async function requestRgdReconcile(api: MigrationApi, rgdName: string): Promise<void> {
+  const live = (await api.read({
+    apiVersion: 'kro.run/v1alpha1',
+    kind: 'ResourceGraphDefinition',
+    metadata: { name: rgdName },
+  })) as ResourceGraphDefinition;
+  await replaceRgdWithRetry(
+    api,
+    rgdName,
+    {
+      metadata: {
         name: rgdName,
         annotations: {
+          ...live.metadata?.annotations,
           'typekro.io/artifact-binding-migration-retry': new Date().toISOString(),
         },
       },
     },
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    'application/merge-patch+json'
+    live
   );
 }
 
@@ -221,14 +275,7 @@ export async function migrateLegacyKroArtifactBindingCrd(
   // Applying the desired RGD first may briefly produce KindReady=False; the CRD
   // broadening below removes that incompatibility and the normal deployment
   // readiness gate waits for the same generation to become ready.
-  await api.patch(
-    desiredRgd,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    'application/merge-patch+json'
-  );
+  liveRgd = await replaceRgdWithRetry(api, rgdName, desiredRgd, liveRgd);
 
   for (let attempt = 1; attempt <= MAX_CRD_PATCH_ATTEMPTS; attempt += 1) {
     const crd = await findGeneratedCrd(api, group, kind);

--- a/src/core/kubernetes/errors.ts
+++ b/src/core/kubernetes/errors.ts
@@ -16,9 +16,11 @@ const logger = getComponentLogger('kubernetes-errors');
  * Interface representing a Kubernetes API error with various possible structures.
  * The error structure varies between client versions:
  * - 0.x (request-based): error.statusCode, error.body
- * - 1.x+ (fetch-based): error.response?.statusCode, error.statusCode, error.body?.code
+ * - 1.x+ generated ApiException: error.code, error.body
+ * - fetch wrappers: error.response?.statusCode, error.statusCode, error.body?.code
  */
 export interface KubernetesApiError {
+  code?: number;
   statusCode?: number;
   response?: {
     statusCode?: number;
@@ -38,6 +40,7 @@ export interface KubernetesApiError {
  * Extract the HTTP status code from a Kubernetes API error.
  *
  * Handles multiple error structures from different client versions:
+ * - Direct code property (@kubernetes/client-node 1.x ApiException)
  * - Direct statusCode property (0.x style)
  * - Nested response.statusCode (1.x+ fetch style)
  * - Nested body.code (some error responses)
@@ -63,6 +66,12 @@ export function getErrorStatusCode(error: unknown): number | undefined {
   }
 
   const err = error as KubernetesApiError;
+
+  // Generated @kubernetes/client-node 1.x ApiException instances expose the
+  // HTTP status on `code`, not `statusCode`.
+  if (typeof err.code === 'number') {
+    return err.code;
+  }
 
   // Try direct statusCode first (0.x style and some 1.x errors)
   if (typeof err.statusCode === 'number') {

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -27,6 +27,16 @@ function desiredRgd(): KubernetesObject {
   } as unknown as KubernetesObject;
 }
 
+function defaultGroupDesiredRgd(): KubernetesObject {
+  const resource = structuredClone(desiredRgd());
+  const schema = Reflect.get(Reflect.get(resource, 'spec'), 'schema') as Record<
+    string,
+    unknown
+  >;
+  Reflect.deleteProperty(schema, 'group');
+  return resource;
+}
+
 function legacyCrd(resourceVersion: string): KubernetesObject {
   return {
     // Match KubernetesObjectApi list deserialization: TypeMeta may be omitted
@@ -70,6 +80,34 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('uses KRO default group when the RGD schema declares a version only', async () => {
+    const desired = defaultGroupDesiredRgd();
+    const live = structuredClone(desired);
+    live.metadata = {
+      name: 'application',
+      generation: 1,
+      resourceVersion: '20',
+    };
+    const crd = legacyCrd('10');
+    const crdSpec = Reflect.get(crd, 'spec') as Record<string, unknown>;
+    crdSpec.group = 'kro.run';
+    crd.metadata = {
+      ...crd.metadata,
+      name: 'applications.kro.run',
+    };
+    const list = mock(async () => ({ items: [crd] }));
+
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desired, {
+      api: {
+        read: mock(async () => live),
+        list,
+        replace: mock(async (resource: KubernetesObject) => resource),
+      } as never,
+    });
+
+    expect(list).toHaveBeenCalledTimes(1);
+  });
+
   test('retries complete RGD replacements and never serializes them as generic patches', async () => {
     let readCount = 0;
     const read = mock(async () => ({

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
 import type { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
+import { ApiException } from '@kubernetes/client-node/dist/gen/apis/exception.js';
 import { migrateLegacyKroArtifactBindingCrd } from '../../src/core/deployment/kro-artifact-binding-migration.js';
 import {
   kroArtifactOutputField,
@@ -80,6 +81,22 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('treats a real client 404 as an absent RGD', async () => {
+    const read = mock(async () => {
+      throw new ApiException(404, 'Not Found', undefined, {});
+    });
+
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
+      api: {
+        read,
+        list: mock(async () => ({ items: [] })),
+        replace: mock(async (resource: KubernetesObject) => resource),
+      } as never,
+    });
+
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
   test('uses KRO default group when the RGD schema declares a version only', async () => {
     const desired = defaultGroupDesiredRgd();
     const live = structuredClone(desired);
@@ -134,7 +151,7 @@ describe('KRO artifact-binding migration', () => {
         resource.kind === 'ResourceGraphDefinition' &&
         resource.metadata?.resourceVersion === '20'
       ) {
-        throw { response: { statusCode: 409 }, message: 'conflict' };
+        throw new ApiException(409, 'Conflict', undefined, {});
       }
       return resource;
     });

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -109,6 +109,12 @@ describe('KRO artifact-binding migration', () => {
   });
 
   test('retries complete RGD replacements and never serializes them as generic patches', async () => {
+    const desired = desiredRgd();
+    desired.metadata = {
+      ...desired.metadata,
+      labels: { shared: 'desired', desired: 'true' },
+      annotations: { shared: 'desired', desired: 'true' },
+    };
     let readCount = 0;
     const read = mock(async () => ({
       ...desiredRgd(),
@@ -116,7 +122,8 @@ describe('KRO artifact-binding migration', () => {
         name: 'application',
         generation: 2,
         resourceVersion: readCount++ === 0 ? '20' : '21',
-        labels: { retained: 'true' },
+        labels: { retained: 'true', shared: 'live' },
+        annotations: { retained: 'true', shared: 'live' },
       },
       status: {
         conditions: [{ type: 'KindReady', status: 'False', observedGeneration: 2 }],
@@ -127,12 +134,12 @@ describe('KRO artifact-binding migration', () => {
         resource.kind === 'ResourceGraphDefinition' &&
         resource.metadata?.resourceVersion === '20'
       ) {
-        throw { statusCode: 409, message: 'conflict' };
+        throw { response: { statusCode: 409 }, message: 'conflict' };
       }
       return resource;
     });
 
-    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desired, {
       api: {
         read,
         list: mock(async () => ({ items: [legacyCrd('10')] })),
@@ -149,8 +156,19 @@ describe('KRO artifact-binding migration', () => {
       '21',
     ]);
     expect(rgdReplacements[1]).toMatchObject({
-      metadata: { labels: { retained: 'true' } },
-      spec: Reflect.get(desiredRgd(), 'spec'),
+      metadata: {
+        labels: {
+          retained: 'true',
+          shared: 'desired',
+          desired: 'true',
+        },
+        annotations: {
+          retained: 'true',
+          shared: 'desired',
+          desired: 'true',
+        },
+      },
+      spec: Reflect.get(desired, 'spec'),
     });
     expect(Reflect.has(rgdReplacements[1] ?? {}, 'status')).toBe(false);
   });
@@ -179,7 +197,7 @@ describe('KRO artifact-binding migration', () => {
       if (resource.kind === 'ResourceGraphDefinition') return resource;
       crdVersions.push(resource.metadata?.resourceVersion ?? '');
       if (crdVersions.length === 1) {
-        throw { statusCode: 409, message: 'conflict' };
+        throw { response: { statusCode: 409 }, message: 'conflict' };
       }
       return resource;
     });

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -70,10 +70,57 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('retries complete RGD replacements and never serializes them as generic patches', async () => {
+    let readCount = 0;
+    const read = mock(async () => ({
+      ...desiredRgd(),
+      metadata: {
+        name: 'application',
+        generation: 2,
+        resourceVersion: readCount++ === 0 ? '20' : '21',
+        labels: { retained: 'true' },
+      },
+      status: {
+        conditions: [{ type: 'KindReady', status: 'False', observedGeneration: 2 }],
+      },
+    }));
+    const replace = mock(async (resource: KubernetesObject) => {
+      if (
+        resource.kind === 'ResourceGraphDefinition' &&
+        resource.metadata?.resourceVersion === '20'
+      ) {
+        throw { statusCode: 409, message: 'conflict' };
+      }
+      return resource;
+    });
+
+    await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
+      api: {
+        read,
+        list: mock(async () => ({ items: [legacyCrd('10')] })),
+        replace,
+      } as never,
+    });
+
+    const rgdReplacements = replace.mock.calls
+      .map(([resource]) => resource as KubernetesObject)
+      .filter((resource) => resource.kind === 'ResourceGraphDefinition');
+    expect(rgdReplacements.map((resource) => resource.metadata?.resourceVersion)).toEqual([
+      '20',
+      '21',
+      '21',
+    ]);
+    expect(rgdReplacements[1]).toMatchObject({
+      metadata: { labels: { retained: 'true' } },
+      spec: Reflect.get(desiredRgd(), 'spec'),
+    });
+    expect(Reflect.has(rgdReplacements[1] ?? {}, 'status')).toBe(false);
+  });
+
   test('resumes an interrupted stable-RGD migration and retries CRD conflicts from fresh state', async () => {
     const read = mock(async () => ({
       ...desiredRgd(),
-      metadata: { name: 'application', generation: 2 },
+      metadata: { name: 'application', generation: 2, resourceVersion: '20' },
       status: {
         conditions: [
           {
@@ -88,8 +135,10 @@ describe('KRO artifact-binding migration', () => {
       .mockResolvedValueOnce({ items: [legacyCrd('10')] })
       .mockResolvedValueOnce({ items: [legacyCrd('11')] });
     const crdVersions: string[] = [];
-    const patch = mock(async (resource: KubernetesObject) => resource);
+    const replacementKinds: string[] = [];
     const replace = mock(async (resource: KubernetesObject) => {
+      replacementKinds.push(resource.kind ?? '');
+      if (resource.kind === 'ResourceGraphDefinition') return resource;
       crdVersions.push(resource.metadata?.resourceVersion ?? '');
       if (crdVersions.length === 1) {
         throw { statusCode: 409, message: 'conflict' };
@@ -98,12 +147,15 @@ describe('KRO artifact-binding migration', () => {
     });
 
     await migrateLegacyKroArtifactBindingCrd({} as KubeConfig, desiredRgd(), {
-      api: { read, list, patch, replace } as never,
+      api: { read, list, replace } as never,
     });
 
     expect(crdVersions).toEqual(['10', '11']);
     expect(list).toHaveBeenCalledTimes(2);
-    const finalCrdPatch = replace.mock.calls.at(-1)?.[0] as KubernetesObject | undefined;
+    const finalCrdPatch = replace.mock.calls
+      .map(([resource]) => resource as KubernetesObject)
+      .reverse()
+      .find((resource) => resource.kind === 'CustomResourceDefinition');
     expect(finalCrdPatch).toMatchObject({
       apiVersion: 'apiextensions.k8s.io/v1',
       kind: 'CustomResourceDefinition',
@@ -124,13 +176,15 @@ describe('KRO artifact-binding migration', () => {
         additionalProperties: { type: 'string' },
       },
     });
+    expect(replacementKinds).toEqual([
+      'ResourceGraphDefinition',
+      'CustomResourceDefinition',
+      'CustomResourceDefinition',
+      'ResourceGraphDefinition',
+    ]);
+    const finalRgdReplacement = replace.mock.calls.at(-1)?.[0] as KubernetesObject | undefined;
     expect(
-      patch.mock.calls.some(
-        ([resource]) =>
-          (resource as KubernetesObject).metadata?.annotations?.[
-            'typekro.io/artifact-binding-migration-retry'
-          ] !== undefined
-      )
-    ).toBe(true);
+      finalRgdReplacement?.metadata?.annotations?.['typekro.io/artifact-binding-migration-retry']
+    ).toBeDefined();
   });
 });

--- a/test/core/kubernetes/errors.test.ts
+++ b/test/core/kubernetes/errors.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import { ApiException } from '@kubernetes/client-node/dist/gen/apis/exception.js';
 import * as fc from 'fast-check';
 import {
   getErrorStatusCode,
@@ -23,6 +24,11 @@ import {
 
 describe('Kubernetes Error Handling Utilities', () => {
   describe('getErrorStatusCode', () => {
+    it('extracts status codes from the pinned client ApiException', () => {
+      expect(getErrorStatusCode(new ApiException(404, 'Not Found', undefined, {}))).toBe(404);
+      expect(getErrorStatusCode(new ApiException(409, 'Conflict', undefined, {}))).toBe(409);
+    });
+
     /**
      * **Feature: upgrade-kubernetes-client, Property 1: Error Handling Consistency**
      * **Validates: Requirements 2.1, 2.4**
@@ -98,6 +104,7 @@ describe('Kubernetes Error Handling Utilities', () => {
 
   describe('isNotFoundError', () => {
     it('should return true for 404 errors', () => {
+      expect(isNotFoundError(new ApiException(404, 'Not Found', undefined, {}))).toBe(true);
       expect(isNotFoundError({ statusCode: 404 })).toBe(true);
       expect(isNotFoundError({ response: { statusCode: 404 } })).toBe(true);
       expect(isNotFoundError({ body: { code: 404 } })).toBe(true);
@@ -118,6 +125,7 @@ describe('Kubernetes Error Handling Utilities', () => {
 
   describe('isConflictError', () => {
     it('should return true for 409 errors', () => {
+      expect(isConflictError(new ApiException(409, 'Conflict', undefined, {}))).toBe(true);
       expect(isConflictError({ statusCode: 409 })).toBe(true);
       expect(isConflictError({ response: { statusCode: 409 } })).toBe(true);
       expect(isConflictError({ body: { code: 409 } })).toBe(true);


### PR DESCRIPTION
## What changed

- replace `ResourceGraphDefinition` objects during artifact-binding migration instead of sending them through `KubernetesObjectApi.patch()`
- preserve live metadata and `resourceVersion`, omit status, and retry optimistic-concurrency conflicts from a fresh read
- use the same safe replacement path when requesting KRO reconciliation
- resolve version-only RGD schemas through KRO's default `kro.run` API group
- add regression coverage for metadata preservation, status omission, replacement ordering, and conflict recovery

## Why

With `@kubernetes/client-node` 1.3, the generic `KubernetesObjectApi.patch()` path tries to serialize the custom resource through a generated type. An artifact-backed RGD containing array-valued resources then fails client-side with `TypeError: data is not iterable`, so an otherwise valid KRO application cannot update or delete through Applik8s.

Full replacement is already the reliable strategy used for the generated CRD portion of this migration. Applying it to the RGD avoids the generated serializer while retaining Kubernetes optimistic concurrency and fail-closed diagnostics.

KRO also permits `spec.schema.apiVersion` to contain only a version, in which case the generated API group is `kro.run`. Treating the absent explicit `group` field as invalid prevented ordinary TypeKro factory RGDs from deploying through this migration.

## Impact

Artifact-backed KRO graphs can migrate and reconcile through imperative/Alchemy deployment paths without failing inside the Kubernetes client serializer. Direct deployment behavior is unchanged.

## Verification

- focused migration tests: 3 passed
- full unit suite: 5,271 passed, 13 skipped, 1 todo
- full TypeKro typecheck: passed
- lint: passed
- build: passed
- `git diff --check`: passed
- OrbStack lifecycle: Applik8s KRO create, no-op, update, and destroy passed; the graph-owned Namespace reached absence after teardown
- OrbStack product gate: the complete 33-resource Agentic Starter graph deployed, passed both maintained browser journeys, and destroyed its instance, RGDs, and owned Namespace
