### PR TITLE
fix: align Rook OBC provisioner identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rook managed platforms now pin one OBC provisioner prefix on both the
+  operator and StorageClass instead of disabling namespace scoping on only the
+  operator. External-operator platforms accept either the matching prefix or
+  an exact provisioner identity, preventing permanently pending OBCs across
+  namespace-scoped, custom-prefix, and global Rook configurations.
 - Direct Alchemy singleton owners now gate consumer scheduling through a dedicated barrier instead
   of being injected into each consumer's canonical live-resource dependencies. This preserves
   singleton readiness ordering without making direct artifact execution records fail dependency

--- a/docs/api/rook/index.md
+++ b/docs/api/rook/index.md
@@ -283,12 +283,20 @@ const buckets = rookBucketStorageClass({
 ```
 
 The generated provisioner is
-`<provisionerNamePrefix>.ceph.rook.io/bucket`. By default, the prefix is the
-Ceph cluster/object-store namespace because Rook registers one bucket
-provisioner for each Ceph cluster. This remains true when the shared operator
-runs in a different namespace. If the operator bootstrap configures
-`obcProvisionerNamePrefix`, pass the same value explicitly as
-`provisionerNamePrefix` here.
+`<provisionerNamePrefix>.ceph.rook.io/bucket`. Rook's chart enables
+namespace-scoped OBC provisioners by default, so TypeKro defaults the prefix to
+the Ceph cluster/object-store namespace. Complete managed platform
+compositions pin that prefix on both the operator and StorageClass. If an
+external operator configures `obcProvisionerNamePrefix`, pass the same value as
+`bucketProvisionerNamePrefix` on the platform or `provisionerNamePrefix` on
+this resource factory. If the external operator disables namespace scoping and
+uses Rook's global `ceph.rook.io/bucket` identity, pass that exact value as
+`bucketProvisionerName` on the platform or `provisionerName` here.
+
+These rules follow Rook's tagged
+[`GetObjectBucketProvisioner()` implementation](https://github.com/rook/rook/blob/v1.20.2/pkg/operator/ceph/object/objectstore.go#L1086-L1100)
+and the
+[`rook-ceph` chart defaults](https://github.com/rook/rook/blob/v1.20.2/deploy/charts/rook-ceph/values.yaml#L223-L228).
 
 For a brownfield bucket, set `existingBucketName` on the StorageClass and omit
 both bucket-name fields on the application claim. Rook's API places the

--- a/src/core/references/cel.ts
+++ b/src/core/references/cel.ts
@@ -526,7 +526,10 @@ function concat(...parts: RefOrValue<CelValue>[]): CelExpression<string> & strin
     }
 
     if (isCelExpression(part)) {
-      return part.expression;
+      // A nested expression may be a conditional or another lower-precedence
+      // operator. Parenthesize it so concatenation cannot bind only to its
+      // final branch (`condition ? prefix : fallback + suffix`).
+      return `(${part.expression})`;
     }
 
     if (typeof part === 'string') {

--- a/src/factories/rook/compositions/rook-ceph-platform.ts
+++ b/src/factories/rook/compositions/rook-ceph-platform.ts
@@ -61,6 +61,8 @@ export const rookCephSingleNodePlatform = kubernetesComposition(
     const repositoryUrl = spec.repositoryUrl ?? DEFAULT_ROOK_CEPH_REPO_URL;
     const objectStoreName = spec.objectStoreName ?? 'harbor-object-store';
     const bucketStorageClassName = spec.bucketStorageClassName ?? 'harbor-ceph-bucket-retain';
+    const bucketProvisionerNamePrefix =
+      spec.bucketProvisionerNamePrefix ?? platformNamespace;
     const profile: 'single-node-development' = 'single-node-development';
 
     namespace({
@@ -100,7 +102,8 @@ export const rookCephSingleNodePlatform = kubernetesComposition(
       repositoryNamespace,
       repositoryUrl,
       values: {
-        enableOBCWatchOperatorNamespace: false,
+        enableOBCWatchOperatorNamespace: true,
+        obcProvisionerNamePrefix: bucketProvisionerNamePrefix,
         resources: { requests: { cpu: '100m', memory: '128Mi' } },
       },
       id: 'operatorRelease',
@@ -146,6 +149,7 @@ export const rookCephSingleNodePlatform = kubernetesComposition(
       objectStoreName,
       objectStoreNamespace: platformNamespace,
       operatorNamespace,
+      provisionerNamePrefix: bucketProvisionerNamePrefix,
       reclaimPolicy: 'Retain',
       id: 'bucketStorageClass',
     });
@@ -200,6 +204,8 @@ export const rookCephProductionPlatform = kubernetesComposition(
     const repositoryUrl = spec.repositoryUrl ?? DEFAULT_ROOK_CEPH_REPO_URL;
     const objectStoreName = spec.objectStoreName ?? 'harbor-object-store';
     const bucketStorageClassName = spec.bucketStorageClassName ?? 'harbor-ceph-bucket-retain';
+    const bucketProvisionerNamePrefix =
+      spec.bucketProvisionerNamePrefix ?? platformNamespace;
     const profile: 'production' = 'production';
 
     namespace({
@@ -238,6 +244,10 @@ export const rookCephProductionPlatform = kubernetesComposition(
       repositoryName,
       repositoryNamespace,
       repositoryUrl,
+      values: {
+        enableOBCWatchOperatorNamespace: true,
+        obcProvisionerNamePrefix: bucketProvisionerNamePrefix,
+      },
       id: 'operatorRelease',
     });
     operatorRelease.dependsOn(repository);
@@ -277,6 +287,7 @@ export const rookCephProductionPlatform = kubernetesComposition(
       objectStoreName,
       objectStoreNamespace: platformNamespace,
       operatorNamespace,
+      provisionerNamePrefix: bucketProvisionerNamePrefix,
       reclaimPolicy: 'Retain',
       id: 'bucketStorageClass',
     });
@@ -326,7 +337,12 @@ export const rookCephExternalOperatorSingleNodePlatform = kubernetesComposition(
   (spec: RookCephExternalOperatorSingleNodePlatformConfig) => {
     const platformNamespace = spec.namespace ?? 'rook-ceph';
     const operatorNamespace = spec.operatorNamespace;
-    const operatorDeploymentName = spec.operatorDeploymentName ?? 'rook-ceph-operator';
+    // External-reference identities are part of the portable artifact plan.
+    // Give the optional default explicit provenance so direct materialization
+    // and KRO serialization resolve the same concrete Deployment name.
+    const operatorDeploymentName = isKubernetesRef(spec.operatorDeploymentName)
+      ? (Cel.default(spec.operatorDeploymentName, 'rook-ceph-operator') as string)
+      : (spec.operatorDeploymentName ?? 'rook-ceph-operator');
     const version = spec.version ?? DEFAULT_ROOK_CEPH_VERSION;
     const cephVersion = spec.cephImageTag ?? 'v20.2.2';
     const storageSize = spec.storageSize ?? '8Gi';
@@ -335,6 +351,8 @@ export const rookCephExternalOperatorSingleNodePlatform = kubernetesComposition(
     const repositoryUrl = spec.repositoryUrl ?? DEFAULT_ROOK_CEPH_REPO_URL;
     const objectStoreName = spec.objectStoreName ?? 'harbor-object-store';
     const bucketStorageClassName = spec.bucketStorageClassName ?? 'harbor-ceph-bucket-retain';
+    const bucketProvisionerNamePrefix =
+      spec.bucketProvisionerNamePrefix ?? platformNamespace;
     const profile: 'single-node-development' = 'single-node-development';
 
     namespace({
@@ -402,6 +420,8 @@ export const rookCephExternalOperatorSingleNodePlatform = kubernetesComposition(
       objectStoreName,
       objectStoreNamespace: platformNamespace,
       operatorNamespace,
+      provisionerName: spec.bucketProvisionerName,
+      provisionerNamePrefix: bucketProvisionerNamePrefix,
       reclaimPolicy: 'Retain',
       id: 'bucketStorageClass',
     });

--- a/src/factories/rook/compositions/rook-ceph-platform.ts
+++ b/src/factories/rook/compositions/rook-ceph-platform.ts
@@ -351,8 +351,24 @@ export const rookCephExternalOperatorSingleNodePlatform = kubernetesComposition(
     const repositoryUrl = spec.repositoryUrl ?? DEFAULT_ROOK_CEPH_REPO_URL;
     const objectStoreName = spec.objectStoreName ?? 'harbor-object-store';
     const bucketStorageClassName = spec.bucketStorageClassName ?? 'harbor-ceph-bucket-retain';
-    const bucketProvisionerNamePrefix =
-      spec.bucketProvisionerNamePrefix ?? platformNamespace;
+    const bucketProvisionerNamePrefix = isKubernetesRef(spec.bucketProvisionerNamePrefix)
+      ? (Cel.default(spec.bucketProvisionerNamePrefix, platformNamespace) as string)
+      : (spec.bucketProvisionerNamePrefix ?? platformNamespace);
+    const inferredBucketProvisionerName =
+      isKubernetesRef(bucketProvisionerNamePrefix) ||
+      isCelExpression(bucketProvisionerNamePrefix)
+        ? (Cel.concat(bucketProvisionerNamePrefix, '.ceph.rook.io/bucket') as string)
+        : `${bucketProvisionerNamePrefix}.ceph.rook.io/bucket`;
+    // `bucketProvisionerName` has a computed, cross-field default. Giving that
+    // choice explicit CEL provenance prevents KRO schema-default inference from
+    // freezing the all-defaults namespace (`rook-ceph`) into every instance.
+    // Direct mode still executes ordinary JavaScript nullish semantics.
+    const bucketProvisionerName = isKubernetesRef(spec.bucketProvisionerName)
+      ? (Cel.default(
+          spec.bucketProvisionerName,
+          inferredBucketProvisionerName
+        ) as string)
+      : (spec.bucketProvisionerName ?? inferredBucketProvisionerName);
     const profile: 'single-node-development' = 'single-node-development';
 
     namespace({
@@ -420,7 +436,7 @@ export const rookCephExternalOperatorSingleNodePlatform = kubernetesComposition(
       objectStoreName,
       objectStoreNamespace: platformNamespace,
       operatorNamespace,
-      provisionerName: spec.bucketProvisionerName,
+      provisionerName: bucketProvisionerName,
       provisionerNamePrefix: bucketProvisionerNamePrefix,
       reclaimPolicy: 'Retain',
       id: 'bucketStorageClass',

--- a/src/factories/rook/resources/bucket-storage-class.ts
+++ b/src/factories/rook/resources/bucket-storage-class.ts
@@ -14,10 +14,14 @@ import type { RookBucketStorageClassConfig } from '../types.js';
 export function rookBucketStorageClass(
   config: Composable<RookBucketStorageClassConfig>
 ): V1StorageClass & Enhanced<V1StorageClass, object> {
-  // Rook registers one bucket provisioner per Ceph cluster namespace. The
-  // operator namespace only happens to match in the common single-namespace
-  // installation. `obcProvisionerNamePrefix` is the explicit override.
+  // Rook's chart defaults namespace-scoped OBC provisioners on. The operator
+  // therefore registers `<ceph-cluster-namespace>.ceph.rook.io/bucket` unless
+  // `obcProvisionerNamePrefix` overrides the prefix. External operators that
+  // deliberately use the unprefixed global provisioner can supply the exact
+  // `ceph.rook.io/bucket` identity through `provisionerName`.
   const provisionerNamePrefix = config.provisionerNamePrefix ?? config.objectStoreNamespace;
+  const provisionerName =
+    config.provisionerName ?? `${provisionerNamePrefix}.ceph.rook.io/bucket`;
 
   return storageClass({
     apiVersion: 'storage.k8s.io/v1',
@@ -27,7 +31,7 @@ export function rookBucketStorageClass(
       ...(config.labels && { labels: config.labels }),
       ...(config.annotations && { annotations: config.annotations }),
     },
-    provisioner: `${provisionerNamePrefix}.ceph.rook.io/bucket`,
+    provisioner: provisionerName,
     reclaimPolicy: config.reclaimPolicy ?? 'Retain',
     parameters: {
       objectStoreName: config.objectStoreName,

--- a/src/factories/rook/types.ts
+++ b/src/factories/rook/types.ts
@@ -251,6 +251,8 @@ export const RookBucketStorageClassConfigSchema = type({
   objectStoreNamespace: 'string',
   /** @deprecated Kept for source compatibility; Rook's default provisioner identity uses the cluster namespace. */
   'operatorNamespace?': 'string',
+  /** Exact external provisioner identity; overrides `provisionerNamePrefix`. */
+  'provisionerName?': 'string',
   'provisionerNamePrefix?': 'string',
   'reclaimPolicy?': '"Delete" | "Retain"',
   'existingBucketName?': 'string',
@@ -347,6 +349,7 @@ const rookCephClusterCommonSchemaShape = {
   storageClassName: 'string',
   'objectStoreName?': 'string',
   'bucketStorageClassName?': 'string',
+  'bucketProvisionerNamePrefix?': 'string',
   'cephImageRepository?': 'string',
   'cephImageTag?': 'string',
   'values?': 'Record<string, unknown>',
@@ -379,6 +382,8 @@ export const RookCephExternalOperatorSingleNodePlatformConfigSchema = type({
   profile: '"single-node-development"',
   operatorNamespace: 'string',
   'operatorDeploymentName?': 'string',
+  /** Exact OBC provisioner registered by the external operator. */
+  'bucketProvisionerName?': 'string',
   'storageSize?': 'string',
   'resources?': optionalCephDaemonResourcesSchemaShape,
 });

--- a/test/core/cel.test.ts
+++ b/test/core/cel.test.ts
@@ -119,6 +119,14 @@ describe('CEL Expression Builder', () => {
       expect(result.expression).toBe('"say \\\\\\"hi\\\\\\""');
     });
 
+    it('parenthesizes nested CEL expressions before concatenation', () => {
+      const selected = Cel.default(Cel.expr<string>('schema.spec.prefix'), 'fallback');
+
+      expect(Cel.concat(selected, '-suffix').expression).toBe(
+        '(has(schema.spec.prefix) && dyn((schema.spec.prefix)) != null ? (schema.spec.prefix) : "fallback") + "-suffix"'
+      );
+    });
+
     it('should escape double quotes in cel template tag string segments', () => {
       const result = cel`prefix "quoted" suffix`;
       expect(result.expression).toBe('"prefix \\"quoted\\" suffix"');

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -231,6 +231,9 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(yaml).toContain(
       `provisioner: '\${has(schema.spec.bucketProvisionerNamePrefix) ? string(schema.spec.bucketProvisionerNamePrefix) + ".ceph.rook.io/bucket" : string(schema.spec.namespace) + ".ceph.rook.io/bucket"}'`
     );
+    expect(yaml).not.toContain(
+      'bucketProvisionerName: string | default="rook-ceph.ceph.rook.io/bucket"'
+    );
     expectCleanYaml(yaml);
   });
 

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -167,6 +167,8 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(yaml).toMatch(/name: rook-release\n {2}namespace: ceph-sources/);
     expect(yaml).toContain('chart: rook-ceph-cluster');
     expect(yaml).toContain('operatorNamespace: ceph-operator');
+    expect(yaml).toContain('obcProvisionerNamePrefix: ceph-data');
+    expect(yaml).toContain('provisioner: ceph-data.ceph.rook.io/bucket');
     expect(yaml).toContain('storageClassName: local-path');
     expect(yaml).toContain('name: harbor-retain');
     expect(yaml).toContain('reclaimPolicy: Retain');
@@ -223,6 +225,12 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(yaml).toContain('kind: CephCluster');
     expect(yaml).toContain('kind: CephObjectStore');
     expect(yaml).toContain('kind: StorageClass');
+    expect(yaml).toContain(
+      `obcProvisionerNamePrefix: '\${has(schema.spec.bucketProvisionerNamePrefix) ? schema.spec.bucketProvisionerNamePrefix : schema.spec.namespace}'`
+    );
+    expect(yaml).toContain(
+      `provisioner: '\${has(schema.spec.bucketProvisionerNamePrefix) ? string(schema.spec.bucketProvisionerNamePrefix) + ".ceph.rook.io/bucket" : string(schema.spec.namespace) + ".ceph.rook.io/bucket"}'`
+    );
     expectCleanYaml(yaml);
   });
 
@@ -345,6 +353,7 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(directYaml).toContain('cephObjectStores: []');
     expect(directYaml.match(/kind: CephObjectStore/g)).toHaveLength(1);
     expect(directYaml.match(/kind: StorageClass/g)).toHaveLength(1);
+    expect(directYaml).toContain('provisioner: ceph-data.ceph.rook.io/bucket');
     expectCleanYaml(directYaml);
 
     const kroYaml = rookCephExternalOperatorSingleNodePlatform
@@ -354,6 +363,40 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(kroYaml).toContain('availableReplicas');
     expect(kroYaml).not.toContain('id: operatorRelease');
     expectCleanYaml(kroYaml);
+  });
+
+  it('uses an explicit external-operator bucket provisioner prefix without guessing namespaces', () => {
+    const yaml = rookCephExternalOperatorSingleNodePlatform
+      .factory('direct', { namespace: 'control' })
+      .toYaml({
+        name: 'rook-local',
+        profile: 'single-node-development',
+        namespace: 'ceph-data',
+        operatorNamespace: 'shared-rook-operator',
+        bucketProvisionerNamePrefix: 'platform-buckets',
+        storageClassName: 'csi-hostpath-sc',
+      });
+
+    expect(yaml).toContain(
+      'provisioner: platform-buckets.ceph.rook.io/bucket'
+    );
+    expectCleanYaml(yaml);
+  });
+
+  it('accepts the exact global bucket provisioner registered by an external operator', () => {
+    const yaml = rookCephExternalOperatorSingleNodePlatform
+      .factory('direct', { namespace: 'control-global' })
+      .toYaml({
+        name: 'rook-global',
+        profile: 'single-node-development',
+        namespace: 'ceph-global',
+        operatorNamespace: 'shared-rook-operator',
+        bucketProvisionerName: 'ceph.rook.io/bucket',
+        storageClassName: 'csi-hostpath-sc',
+      });
+
+    expect(yaml).toContain('provisioner: ceph.rook.io/bucket');
+    expectCleanYaml(yaml);
   });
 
   it('renders the mandatory production safety controls into official chart values', () => {

--- a/test/factories/rook/resources.test.ts
+++ b/test/factories/rook/resources.test.ts
@@ -233,7 +233,7 @@ describe('Rook object storage resource factories', () => {
       expect(storageClass.reclaimPolicy).toBe('Retain');
     });
 
-    it('defaults the provisioner prefix to the Ceph cluster/object-store namespace', () => {
+    it('defaults the provisioner prefix to the Ceph cluster namespace like the Rook chart', () => {
       const storageClass = rookBucketStorageClass({
         name: 'cross-namespace-assets',
         objectStoreName: 'assets',
@@ -243,6 +243,17 @@ describe('Rook object storage resource factories', () => {
 
       expect(String(storageClass.provisioner)).toBe('rook-storage.ceph.rook.io/bucket');
       expect(storageClass.parameters?.objectStoreNamespace).toBe('rook-storage');
+    });
+
+    it('accepts the exact unprefixed identity used by a global external provisioner', () => {
+      const storageClass = rookBucketStorageClass({
+        name: 'global-assets',
+        objectStoreName: 'assets',
+        objectStoreNamespace: 'rook-storage',
+        provisionerName: 'ceph.rook.io/bucket',
+      });
+
+      expect(String(storageClass.provisioner)).toBe('ceph.rook.io/bucket');
     });
   });
 });

--- a/test/integration/harbor/harbor-platform.test.ts
+++ b/test/integration/harbor/harbor-platform.test.ts
@@ -284,10 +284,12 @@ describeOrSkip(
           metadata: { name: storageClassName },
         })
         .catch(() => undefined);
+      const expectedProvisioner =
+        process.env.TYPEKRO_HARBOR_BUCKET_PROVISIONER ??
+        'typekro-harbor-ceph.ceph.rook.io/bucket';
       if (
         !storageClass ||
-        (storageClass as { provisioner?: string }).provisioner !==
-          'typekro-harbor-ceph.ceph.rook.io/bucket'
+        (storageClass as { provisioner?: string }).provisioner !== expectedProvisioner
       ) {
         throw new Error(
           `Harbor integration requires the retained Rook platform StorageClass ${storageClassName}; ` +

--- a/test/integration/harbor/harbor-platform.test.ts
+++ b/test/integration/harbor/harbor-platform.test.ts
@@ -24,7 +24,7 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from 'bun:test';
 import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
-import type { V1Secret } from '@kubernetes/client-node';
+import type { KubernetesObject, V1Secret } from '@kubernetes/client-node';
 import { type } from 'arktype';
 
 import { kubernetesComposition } from '../../../src/core/composition/imperative.js';
@@ -34,6 +34,7 @@ import {
   harbor as harborRegistry,
   kubernetesSecretRegistryCredentials,
 } from '../../../src/core/containers/index.js';
+import { patchResourceWithCorrectContentType } from '../../../src/core/deployment/k8s-helpers.js';
 import { getKubeConfig } from '../../../src/core/kubernetes/client-provider.js';
 import {
   createHarborKubernetesStore,
@@ -511,10 +512,12 @@ describeOrSkip(
       // Restart one official Harbor component and prove bounded recovery.
       const appsApi = createAppsV1ApiClient(kubeConfig);
       const deploymentName = `${installationName}-core`;
-      await appsApi.patchNamespacedDeployment({
-        name: deploymentName,
-        namespace: harborNamespace,
-        body: {
+      await patchResourceWithCorrectContentType(
+        createKubernetesObjectApiClient(kubeConfig),
+        {
+          apiVersion: 'apps/v1',
+          kind: 'Deployment',
+          metadata: { name: deploymentName, namespace: harborNamespace },
           spec: {
             template: {
               metadata: {
@@ -522,8 +525,9 @@ describeOrSkip(
               },
             },
           },
-        },
-      });
+        } as KubernetesObject,
+        'strategic'
+      );
       const restartDeadline = Date.now() + 300_000;
       let deploymentReady = false;
       while (Date.now() < restartDeadline) {


### PR DESCRIPTION
## What changed

- align managed single-node and production Rook platforms on one explicit OBC provisioner prefix for both the operator and generated StorageClass
- preserve Rook's official namespace-scoped default in the low-level StorageClass factory
- allow external-operator platforms to supply either a custom prefix or the exact provisioner identity, including the unprefixed global `ceph.rook.io/bucket` form
- give the optional external operator Deployment name explicit portable-default provenance so omitted defaults work in both direct artifact materialization and KRO serialization
- document the behavior against the tagged Rook v1.20.2 chart and operator sources

## Root cause

The managed single-node platform set `enableOBCWatchOperatorNamespace: false`, causing Rook to register the global `ceph.rook.io/bucket` provisioner, while its StorageClass still used `<object-store-namespace>.ceph.rook.io/bucket`. ObjectBucketClaims therefore remained Pending forever. The existing tests rendered only the StorageClass shape and did not prove that the operator and StorageClass identities agreed.

## Impact

Managed Rook/Ceph object storage now provisions OBCs instead of leaving them permanently Pending when operator and cluster namespaces differ. External operators can express all three upstream identities: namespace-scoped, custom-prefix, and global.

## Validation

- `./scripts/run-unit-tests.sh`: 5,272 passed, 13 skipped, 1 todo, 0 failed
- focused Rook suites: 45 passed
- `bun run build` (includes lint and all TypeScript typechecks): passed
- `git diff --check`: passed

A full Applik8s Dedicated-profile OrbStack deployment will exercise the corrected managed OBC path while this PR remains draft.