### PR TITLE
fix: preserve external Ory secret bindings

### DIFF
--- a/docs/api/ory/index.md
+++ b/docs/api/ory/index.md
@@ -89,7 +89,12 @@ await stack.deploy({
 });
 ```
 
-Explicit literal value sources are supported for controlled environments, but TypeKro rejects unsafe literals supplied through unapproved chart escape hatches.
+Explicit literal value sources are supported for controlled direct-mode environments, but the
+KRO factory requires Secret-backed Hydra system and Kratos cookie/cipher sources. KRO admission
+rejects literal values for those three secret-bearing fields because an opaque Helm post-renderer
+cannot safely change an environment entry between `value` and `valueFrom` at reconciliation time.
+This fails closed instead of replacing a literal with a nonexistent managed Secret. TypeKro also
+rejects unsafe literals supplied through unapproved chart escape hatches.
 
 `oryIdentityStack` owns the Hydra and Kratos workload names used by its
 external-secret post-renderers. It therefore protects `nameOverride` and

--- a/src/factories/ory/compositions/ory-identity-stack.ts
+++ b/src/factories/ory/compositions/ory-identity-stack.ts
@@ -28,6 +28,20 @@ import {
 } from '../types.js';
 import { mapOryConfigToHelmValues } from '../utils/helm-values-mapper.js';
 
+/**
+ * KRO cannot vary a post-renderer environment entry between `value` and
+ * `valueFrom` from a runtime schema branch. Keep the admission boundary
+ * shared by every root composition that exposes the Ory identity schema so a
+ * nested identity stack cannot bypass the restriction.
+ */
+export const oryKroLiteralSecretSchemaFieldValidations = Object.freeze({
+  hydra: '!has(self.systemSecret) || !has(self.systemSecret.value)',
+  kratos:
+    '(!has(self.secrets) || !has(self.secrets.cookie) || !has(self.secrets.cookie.value)) && (!has(self.secrets) || !has(self.secrets.cipher) || !has(self.secrets.cipher.value))',
+  dependencySources:
+    '(!has(self.hydra) || !has(self.hydra.systemSecret) || !has(self.hydra.systemSecret.value) || !has(self.hydra.systemSecret.value.value)) && (!has(self.kratos) || !has(self.kratos.secrets) || !has(self.kratos.secrets.cookie) || !has(self.kratos.secrets.cookie.value) || !has(self.kratos.secrets.cookie.value.value)) && (!has(self.kratos) || !has(self.kratos.secrets) || !has(self.kratos.secrets.cipher) || !has(self.kratos.secrets.cipher.value) || !has(self.kratos.secrets.cipher.value.value))',
+} as const);
+
 function readyCondition(conditions: unknown): boolean {
   return Cel.expr<boolean>(conditions, '.exists(c, c.type == "Ready" && c.status == "True")');
 }
@@ -765,12 +779,6 @@ export const oryIdentityStack = kubernetesComposition(
     // YAML patch shape between `value` and `valueFrom` at reconciliation time,
     // so reject literal sources at admission instead of silently rewiring them
     // to nonexistent managed Secrets.
-    schemaFieldValidations: {
-      hydra: '!has(self.systemSecret) || !has(self.systemSecret.value)',
-      kratos:
-        '(!has(self.secrets) || !has(self.secrets.cookie) || !has(self.secrets.cookie.value)) && (!has(self.secrets) || !has(self.secrets.cipher) || !has(self.secrets.cipher.value))',
-      dependencySources:
-        '(!has(self.hydra) || !has(self.hydra.systemSecret) || !has(self.hydra.systemSecret.value) || !has(self.hydra.systemSecret.value.value)) && (!has(self.kratos) || !has(self.kratos.secrets) || !has(self.kratos.secrets.cookie) || !has(self.kratos.secrets.cookie.value) || !has(self.kratos.secrets.cookie.value.value)) && (!has(self.kratos) || !has(self.kratos.secrets) || !has(self.kratos.secrets.cipher) || !has(self.kratos.secrets.cipher.value) || !has(self.kratos.secrets.cipher.value.value))',
-    },
+    schemaFieldValidations: oryKroLiteralSecretSchemaFieldValidations,
   }
 );

--- a/src/factories/ory/compositions/ory-identity-stack.ts
+++ b/src/factories/ory/compositions/ory-identity-stack.ts
@@ -117,11 +117,55 @@ function withStackOwnedChartNames<T extends object>(
   ) as T;
 }
 
-function removeChartOwnedSecretEnv(
+interface OrySecretEnvReplacement {
+  readonly name: string;
+  readonly secretName: unknown;
+  readonly secretKey: unknown;
+}
+
+function secretEnvReplacement(
+  values: unknown,
+  target: 'deployment' | 'statefulSet',
+  name: string
+): OrySecretEnvReplacement | undefined {
+  if (isValuesMergeExpression(values)) {
+    return secretEnvReplacement(values.base, target, name);
+  }
+  if (!isPlainObject(values)) return undefined;
+  const workload = values[target];
+  if (!isPlainObject(workload) || !Array.isArray(workload.extraEnv)) return undefined;
+  const entry = workload.extraEnv.find(
+    (candidate) => isPlainObject(candidate) && candidate.name === name
+  );
+  if (!isPlainObject(entry) || !isPlainObject(entry.valueFrom)) return undefined;
+  const secretKeyRef = entry.valueFrom.secretKeyRef;
+  if (
+    !isPlainObject(secretKeyRef) ||
+    secretKeyRef.name === undefined ||
+    secretKeyRef.key === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    name,
+    secretName: secretKeyRef.name,
+    secretKey: secretKeyRef.key,
+  };
+}
+
+/**
+ * The Ory charts add their generated-Secret environment entries before
+ * `deployment.extraEnv` / `statefulSet.extraEnv`. A delete-by-name strategic
+ * merge patch removes both entries because `name` is the list merge key,
+ * including the external replacement TypeKro authored. Replace the merge-keyed
+ * entry instead: Kustomize collapses duplicates to one environment variable
+ * whose value comes from the declared external Secret.
+ */
+function replaceChartOwnedSecretEnv(
   kind: 'Deployment' | 'StatefulSet',
   releaseName: string,
   containerName: 'hydra' | 'kratos' | 'kratos-courier',
-  names: string[]
+  replacements: readonly OrySecretEnvReplacement[]
 ) {
   return {
     kustomize: {
@@ -144,9 +188,12 @@ function removeChartOwnedSecretEnv(
             '      containers:',
             `        - name: ${containerName}`,
             '          env:',
-            ...names.flatMap((name) => [
-              `            - name: ${name}`,
-              '              $patch: delete',
+            ...replacements.flatMap((replacement) => [
+              `            - name: ${replacement.name}`,
+              '              valueFrom:',
+              '                secretKeyRef:',
+              `                  name: ${String(replacement.secretName)}`,
+              `                  key: ${String(replacement.secretKey)}`,
             ]),
           ].join('\n'),
         },
@@ -511,13 +558,25 @@ export const oryIdentityStack = kubernetesComposition(
       repositoryName: 'ory',
       repositoryNamespace: resolvedNamespace,
       values: withMaesterSubchartValues(values.hydra, 'hydra-maester', values.hydraMaester),
-      postRenderers: [
-        removeChartOwnedSecretEnv('Deployment', `${typedSpec.name}-hydra`, 'hydra', [
-          'SECRETS_SYSTEM',
-        ]),
-      ],
+      postRenderers: (() => {
+        const system = secretEnvReplacement(values.hydra, 'deployment', 'SECRETS_SYSTEM');
+        return system
+          ? [
+              replaceChartOwnedSecretEnv(
+                'Deployment',
+                `${typedSpec.name}-hydra`,
+                'hydra',
+                [system]
+              ),
+            ]
+          : [];
+      })(),
     });
 
+    const kratosSecretReplacements = ['SECRETS_COOKIE', 'SECRETS_CIPHER'].flatMap((name) => {
+      const replacement = secretEnvReplacement(values.kratos, 'deployment', name);
+      return replacement ? [replacement] : [];
+    });
     const kratos = kratosHelmRelease({
       id: 'kratosHelmRelease',
       name: `${typedSpec.name}-kratos`,
@@ -526,18 +585,23 @@ export const oryIdentityStack = kubernetesComposition(
       repositoryName: 'ory',
       repositoryNamespace: resolvedNamespace,
       values: values.kratos,
-      postRenderers: [
-        removeChartOwnedSecretEnv('Deployment', `${typedSpec.name}-kratos`, 'kratos', [
-          'SECRETS_COOKIE',
-          'SECRETS_CIPHER',
-        ]),
-        removeChartOwnedSecretEnv(
-          'StatefulSet',
-          `${typedSpec.name}-kratos-courier`,
-          'kratos-courier',
-          ['SECRETS_COOKIE', 'SECRETS_CIPHER']
-        ),
-      ],
+      postRenderers:
+        kratosSecretReplacements.length > 0
+          ? [
+              replaceChartOwnedSecretEnv(
+                'Deployment',
+                `${typedSpec.name}-kratos`,
+                'kratos',
+                kratosSecretReplacements
+              ),
+              replaceChartOwnedSecretEnv(
+                'StatefulSet',
+                `${typedSpec.name}-kratos-courier`,
+                'kratos-courier',
+                kratosSecretReplacements
+              ),
+            ]
+          : [],
     });
 
     const keto = ketoHelmRelease({

--- a/src/factories/ory/compositions/ory-identity-stack.ts
+++ b/src/factories/ory/compositions/ory-identity-stack.ts
@@ -758,5 +758,19 @@ export const oryIdentityStack = kubernetesComposition(
       },
       version: Cel.template('%s', resolvedVersion),
     };
+  },
+  {
+    // Direct mode can preserve literal secret values in the chart-generated
+    // environment. KRO post-renderer patches cannot safely switch the opaque
+    // YAML patch shape between `value` and `valueFrom` at reconciliation time,
+    // so reject literal sources at admission instead of silently rewiring them
+    // to nonexistent managed Secrets.
+    schemaFieldValidations: {
+      hydra: '!has(self.systemSecret) || !has(self.systemSecret.value)',
+      kratos:
+        '(!has(self.secrets) || !has(self.secrets.cookie) || !has(self.secrets.cookie.value)) && (!has(self.secrets) || !has(self.secrets.cipher) || !has(self.secrets.cipher.value))',
+      dependencySources:
+        '(!has(self.hydra) || !has(self.hydra.systemSecret) || !has(self.hydra.systemSecret.value) || !has(self.hydra.systemSecret.value.value)) && (!has(self.kratos) || !has(self.kratos.secrets) || !has(self.kratos.secrets.cookie) || !has(self.kratos.secrets.cookie.value) || !has(self.kratos.secrets.cookie.value.value)) && (!has(self.kratos) || !has(self.kratos.secrets) || !has(self.kratos.secrets.cipher) || !has(self.kratos.secrets.cipher.value) || !has(self.kratos.secrets.cipher.value.value))',
+    },
   }
 );

--- a/src/factories/ory/compositions/ory-identity-stack.ts
+++ b/src/factories/ory/compositions/ory-identity-stack.ts
@@ -123,6 +123,54 @@ interface OrySecretEnvReplacement {
   readonly secretKey: unknown;
 }
 
+function hasSchemaPath(path: string): string {
+  const parts = path.split('.');
+  return parts
+    .slice(2)
+    .map((_, index) => `has(${parts.slice(0, index + 3).join('.')})`)
+    .join(' && ');
+}
+
+function graphSecretField(paths: readonly string[], fallbackExpression: string): string {
+  const expression = paths.reduceRight(
+    (fallback, path) => `(${hasSchemaPath(path)} ? ${path} : ${fallback})`,
+    fallbackExpression
+  );
+  // The post-renderer patch is itself an opaque YAML string. Embed the KRO
+  // marker in that string rather than handing the serializer a CelExpression
+  // object, which String() would flatten to "[object Object]".
+  return `\${${expression}}`;
+}
+
+function graphSecretEnvReplacement(
+  name: string,
+  explicitSecretRefPath: string,
+  dependencySourcePath: string,
+  fallbackNameExpression: string,
+  fallbackKey: string
+): OrySecretEnvReplacement {
+  return {
+    name,
+    secretName: graphSecretField(
+      [
+        `${explicitSecretRefPath}.name`,
+        `${dependencySourcePath}.value.secretRef.name`,
+        `${dependencySourcePath}.secretName`,
+        `${dependencySourcePath}.resourceName`,
+      ],
+      fallbackNameExpression
+    ),
+    secretKey: graphSecretField(
+      [
+        `${explicitSecretRefPath}.key`,
+        `${dependencySourcePath}.value.secretRef.key`,
+        `${dependencySourcePath}.secretKey`,
+      ],
+      JSON.stringify(fallbackKey)
+    ),
+  };
+}
+
 function secretEnvReplacement(
   values: unknown,
   target: 'deployment' | 'statefulSet',
@@ -559,7 +607,15 @@ export const oryIdentityStack = kubernetesComposition(
       repositoryNamespace: resolvedNamespace,
       values: withMaesterSubchartValues(values.hydra, 'hydra-maester', values.hydraMaester),
       postRenderers: (() => {
-        const system = secretEnvReplacement(values.hydra, 'deployment', 'SECRETS_SYSTEM');
+        const system = concreteSpec
+          ? secretEnvReplacement(values.hydra, 'deployment', 'SECRETS_SYSTEM')
+          : graphSecretEnvReplacement(
+              'SECRETS_SYSTEM',
+              'schema.spec.hydra.systemSecret.secretRef',
+              'schema.spec.dependencySources.hydra.systemSecret',
+              'string(schema.spec.name) + "-hydra-secrets"',
+              'system'
+            );
         return system
           ? [
               replaceChartOwnedSecretEnv(
@@ -573,10 +629,27 @@ export const oryIdentityStack = kubernetesComposition(
       })(),
     });
 
-    const kratosSecretReplacements = ['SECRETS_COOKIE', 'SECRETS_CIPHER'].flatMap((name) => {
-      const replacement = secretEnvReplacement(values.kratos, 'deployment', name);
-      return replacement ? [replacement] : [];
-    });
+    const kratosSecretReplacements = concreteSpec
+      ? (['SECRETS_COOKIE', 'SECRETS_CIPHER'] as const).flatMap((name) => {
+          const replacement = secretEnvReplacement(values.kratos, 'deployment', name);
+          return replacement ? [replacement] : [];
+        })
+      : [
+          graphSecretEnvReplacement(
+            'SECRETS_COOKIE',
+            'schema.spec.kratos.secrets.cookie.secretRef',
+            'schema.spec.dependencySources.kratos.secrets.cookie',
+            'string(schema.spec.name) + "-kratos-secrets"',
+            'cookie'
+          ),
+          graphSecretEnvReplacement(
+            'SECRETS_CIPHER',
+            'schema.spec.kratos.secrets.cipher.secretRef',
+            'schema.spec.dependencySources.kratos.secrets.cipher',
+            'string(schema.spec.name) + "-kratos-secrets"',
+            'cipher'
+          ),
+        ];
     const kratos = kratosHelmRelease({
       id: 'kratosHelmRelease',
       name: `${typedSpec.name}-kratos`,

--- a/src/factories/ory/compositions/ory-platform-stack.ts
+++ b/src/factories/ory/compositions/ory-platform-stack.ts
@@ -18,7 +18,10 @@ import {
   OryPlatformStackStatusSchema,
   type OryValueSource,
 } from '../types.js';
-import { oryIdentityStack } from './ory-identity-stack.js';
+import {
+  oryIdentityStack,
+  oryKroLiteralSecretSchemaFieldValidations,
+} from './ory-identity-stack.js';
 import { oathkeeperRule } from '../resources/oathkeeper-rule.js';
 
 const apisixRouteSpecSchema = type({
@@ -717,5 +720,12 @@ export const oryPlatformStack = kubernetesComposition(
       ory: oryStatus,
       endpoints: oryStatus.endpoints,
     };
+  },
+  {
+    // Nested composition admission metadata is intentionally not inherited by
+    // the imperative root. The platform exposes the same literal-capable
+    // direct schema as the identity stack, so attach the KRO restriction at
+    // this public root as well.
+    schemaFieldValidations: oryKroLiteralSecretSchemaFieldValidations,
   }
 );

--- a/test/factories/ory/bootstrap-composition.test.ts
+++ b/test/factories/ory/bootstrap-composition.test.ts
@@ -454,6 +454,19 @@ describe('Ory identity stack composition', () => {
     });
   });
 
+  it('rejects literal high-level and dependency secret sources from KRO admission', () => {
+    const yaml = oryIdentityStack.toYaml();
+
+    expect(yaml).toContain(
+      'validation="!has(self.systemSecret) || !has(self.systemSecret.value)"'
+    );
+    expect(yaml).toContain('!has(self.secrets.cookie.value)');
+    expect(yaml).toContain('!has(self.secrets.cipher.value)');
+    expect(yaml).toContain('!has(self.hydra.systemSecret.value.value)');
+    expect(yaml).toContain('!has(self.kratos.secrets.cookie.value.value)');
+    expect(yaml).toContain('!has(self.kratos.secrets.cipher.value.value)');
+  });
+
   it('Generate direct-mode YAML for managed local dependency sources with starter OAuth2Client and Rule resources', async () => {
     const factory = oryIdentityStack.factory('direct', { namespace: 'ory-test' });
     const yaml = await factory.toYaml({

--- a/test/factories/ory/bootstrap-composition.test.ts
+++ b/test/factories/ory/bootstrap-composition.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'bun:test';
+import { loadAll } from 'js-yaml';
+import { evaluateSchemaCelExpression } from '../../../src/core/deployment/schema-cel-evaluator.js';
+import { Cel } from '../../../src/core/references/cel.js';
+import type { KroCompatibleType } from '../../../src/core/types/schema.js';
 import { oryIdentityStack } from '../../../src/factories/ory/index.js';
 import {
   OryIdentityStackConfigSchema,
@@ -50,6 +54,44 @@ function managedIdentityConfig(namespaceOwnership: 'owned' | 'external') {
       },
     },
   } as const;
+}
+
+function evaluateSecretKeyRefsFromKroPatches(yaml: string, spec: KroCompatibleType) {
+  const [definition] = loadAll(yaml) as Array<{
+    spec?: {
+      resources?: Array<{
+        template?: {
+          spec?: {
+            postRenderers?: Array<{
+              kustomize?: { patches?: Array<{ patch?: string }> };
+            }>;
+          };
+        };
+      }>;
+    };
+  }>;
+  const references: Array<{ name: unknown; key: unknown }> = [];
+  if (!definition) throw new Error('Expected an Ory ResourceGraphDefinition');
+
+  for (const resource of definition.spec?.resources ?? []) {
+    for (const renderer of resource.template?.spec?.postRenderers ?? []) {
+      for (const patch of renderer.kustomize?.patches ?? []) {
+        const lines = patch.patch?.split('\n') ?? [];
+        for (let index = 0; index < lines.length; index += 1) {
+          if (lines[index]?.trim() !== 'secretKeyRef:') continue;
+          const name = lines[index + 1]?.trim().match(/^name: \$\{(.+)\}$/)?.[1];
+          const key = lines[index + 2]?.trim().match(/^key: \$\{(.+)\}$/)?.[1];
+          if (!name || !key) continue;
+          references.push({
+            name: evaluateSchemaCelExpression(Cel.expr(name), spec),
+            key: evaluateSchemaCelExpression(Cel.expr(key), spec),
+          });
+        }
+      }
+    }
+  }
+
+  return references;
 }
 
 // Test decision: keep this file focused on Ory-only Helm wiring. Graph-managed
@@ -347,6 +389,69 @@ describe('Ory identity stack composition', () => {
     expect(kro).toContain('name: ${string(schema.spec.name)}-hydra');
     expect(kro).toContain('name: ${string(schema.spec.name)}-kratos');
     expect(kro).toContain('name: ${string(schema.spec.name)}-kratos-courier');
+    expect(kro).toContain('schema.spec.hydra.systemSecret.secretRef.name');
+    expect(kro).toContain(
+      'schema.spec.dependencySources.hydra.systemSecret.value.secretRef.name'
+    );
+    expect(kro).toContain('schema.spec.kratos.secrets.cookie.secretRef.name');
+    expect(kro).toContain(
+      'schema.spec.dependencySources.kratos.secrets.cookie.value.secretRef.name'
+    );
+    expect(kro).toContain('schema.spec.kratos.secrets.cipher.secretRef.name');
+    expect(kro).toContain(
+      'schema.spec.dependencySources.kratos.secrets.cipher.value.secretRef.name'
+    );
+  });
+
+  it('projects concrete external Secret bindings into KRO post-renderers', () => {
+    const external = managedIdentityConfig('external');
+    const spec = {
+      ...external,
+      dependencySources: {
+        ...external.dependencySources,
+        hydra: {
+          ...external.dependencySources?.hydra,
+          systemSecret: {
+            mode: 'external',
+            value: {
+              secretRef: { name: 'external-hydra-system', key: 'hydra-system-key' },
+            },
+          },
+        },
+        kratos: {
+          ...external.dependencySources?.kratos,
+          secrets: {
+            cookie: {
+              mode: 'external',
+              value: {
+                secretRef: { name: 'external-kratos-cookie', key: 'cookie-key' },
+              },
+            },
+            cipher: {
+              mode: 'external',
+              value: {
+                secretRef: { name: 'external-kratos-cipher', key: 'cipher-key' },
+              },
+            },
+          },
+        },
+      },
+    } as const;
+    const yaml = oryIdentityStack.toYaml();
+    const references = evaluateSecretKeyRefsFromKroPatches(yaml, spec);
+
+    expect(references).toContainEqual({
+      name: 'external-hydra-system',
+      key: 'hydra-system-key',
+    });
+    expect(references).toContainEqual({
+      name: 'external-kratos-cookie',
+      key: 'cookie-key',
+    });
+    expect(references).toContainEqual({
+      name: 'external-kratos-cipher',
+      key: 'cipher-key',
+    });
   });
 
   it('Generate direct-mode YAML for managed local dependency sources with starter OAuth2Client and Rule resources', async () => {

--- a/test/factories/ory/bootstrap-composition.test.ts
+++ b/test/factories/ory/bootstrap-composition.test.ts
@@ -262,7 +262,9 @@ describe('Ory identity stack composition', () => {
     expect(yaml).toContain('name: SECRETS_SYSTEM');
     expect(yaml).toContain('name: SECRETS_COOKIE');
     expect(yaml).toContain('name: SECRETS_CIPHER');
-    expect(yaml).toContain('$patch: delete');
+    expect(yaml).not.toContain('$patch: delete');
+    expect(yaml).toContain('valueFrom:');
+    expect(yaml).toContain('secretKeyRef:');
     expect(yaml).toContain('customReadinessProbe');
     expect(yaml).toContain('customStartupProbe');
     expect(yaml).toContain('/health/alive');
@@ -433,7 +435,12 @@ describe('Ory identity stack composition', () => {
     expect(yaml).toContain('postRenderers:');
     expect(yaml).toContain('name: identity-test-hydra');
     expect(yaml).toContain('name: identity-test-kratos');
-    expect(yaml).toContain('$patch: delete');
+    expect(yaml).not.toContain('$patch: delete');
+    expect(yaml).toContain('name: identity-test-hydra-secrets');
+    expect(yaml).toContain('key: system');
+    expect(yaml).toContain('name: identity-test-kratos-secrets');
+    expect(yaml).toContain('key: cookie');
+    expect(yaml).toContain('key: cipher');
     expect(yaml).toContain('kind: OAuth2Client');
     expect(yaml).toContain('kind: Rule');
     expect(yaml).toContain('apiVersion: hydra.ory.sh/v1alpha1');

--- a/test/factories/ory/platform-composition.test.ts
+++ b/test/factories/ory/platform-composition.test.ts
@@ -276,6 +276,19 @@ describe('Ory platform stack composition', () => {
     expect(renderedYaml).not.toContain('${${');
   });
 
+  it('rejects literal identity secret sources from platform KRO admission', () => {
+    const renderedYaml = oryPlatformStack.toYaml();
+
+    expect(renderedYaml).toContain(
+      'validation="!has(self.systemSecret) || !has(self.systemSecret.value)"'
+    );
+    expect(renderedYaml).toContain('!has(self.secrets.cookie.value)');
+    expect(renderedYaml).toContain('!has(self.secrets.cipher.value)');
+    expect(renderedYaml).toContain('!has(self.hydra.systemSecret.value.value)');
+    expect(renderedYaml).toContain('!has(self.kratos.secrets.cookie.value.value)');
+    expect(renderedYaml).toContain('!has(self.kratos.secrets.cipher.value.value)');
+  });
+
   it('produces a strict semantic plan for the managed platform contract', () => {
     const spec = {
       name: 'identity-start-identity',


### PR DESCRIPTION
## What changed

- Replace the Ory charts' generated-secret environment entries with the external Secret references declared by TypeKro.
- Stop using a strategic-merge `$patch: delete` entry that matched and removed both the chart-owned environment variable and TypeKro's replacement.
- Cover Hydra `SECRETS_SYSTEM` and Kratos `SECRETS_COOKIE` / `SECRETS_CIPHER` in direct and rendered KRO output.
- Fail KRO admission closed for literal Hydra/Kratos secret sources, at both the high-level and dependency-source APIs, because a KRO post-renderer cannot safely switch between literal `value` and `valueFrom` using the current patch shape. Direct mode continues to support literals.

## Root cause

Kubernetes strategic merge treats `env[].name` as the list merge key. The existing post-renderer deleted entries by name, so it also deleted the external replacement emitted through `deployment.extraEnv` / `statefulSet.extraEnv`. Hydra then started without `SECRETS_SYSTEM` and returned 500 for OAuth2 client creation.

The first KRO correction handled SecretRefs but allowed literal values to fall through to nonexistent managed Secret names. The public KRO schema now rejects those inputs explicitly instead of silently rewiring them.

## Impact

Managed Ory stacks retain exactly one protected environment entry per secret, backed by the declared external Secret. Hydra client provisioning and Kratos secret configuration work without falling back to chart-generated credentials. KRO callers get an admission error for literal sources and a clear path to use Secret-backed values; direct callers retain literal-source support.

## Verification

- Complete TypeKro commit-hook suite: 5,271 passed, 13 skipped, 1 todo, 0 failed.
- Focused Ory regressions cover SecretRefs plus high-level and dependency-source literal rejection in the generated RGD.
- Typecheck, lint, and diff checks passed.
- Live OrbStack reconciliation rolled Hydra and Kratos with the external Secret references.
- A Hydra admin OAuth2-client creation request changed from HTTP 500 (`The system secret is not configured`) to HTTP 201; the diagnostic client was then deleted.