### PR TITLE
fix Rook single-node CSI teardown

### DIFF
--- a/docs/api/rook/index.md
+++ b/docs/api/rook/index.md
@@ -105,7 +105,10 @@ the object store after it. The external-operator variant omits the operator
 release and Namespace, and requires their names explicitly.
 
 The development profile is intentionally replication-one and is not highly
-available:
+available. Its managed-operator composition disables the `rook-ceph` operator
+chart's CSI dependency because this object-storage-only profile owns no block
+pools or filesystems. This avoids installing unused CSI `ClientProfile`
+finalizers whose lifecycle would otherwise need to precede operator teardown:
 
 ```ts
 const local = rookCephSingleNodePlatform.factory('kro', {
@@ -204,6 +207,12 @@ await rookCephExternalOperatorSingleNodePlatform
     storageClassName: 'local-block',
   });
 ```
+
+The external operator remains the authority for its CSI controllers and
+finalizers. Its platform owner must keep that operator running until the
+external-operator cluster and all of its operator-owned descendants have
+finished deletion; TypeKro deliberately does not mutate the external
+operator's Helm values.
 
 All three compositions create a distinct custom `repositoryNamespace` by
 default. Set `repositoryNamespaceOwnership: 'external'` only when another

--- a/src/factories/rook/compositions/rook-ceph-platform.ts
+++ b/src/factories/rook/compositions/rook-ceph-platform.ts
@@ -113,7 +113,9 @@ export const rookCephSingleNodePlatform = kubernetesComposition(
       repositoryName,
       repositoryNamespace,
       repositoryUrl,
-      values: clusterOnlyValues(mapRookCephSingleNodePlatformToHelmValues(spec, storageSize)),
+      values: singleNodeClusterOnlyValues(
+        mapRookCephSingleNodePlatformToHelmValues(spec, storageSize)
+      ),
       id: 'clusterRelease',
     });
     clusterRelease.dependsOn(operatorRelease);
@@ -372,7 +374,9 @@ export const rookCephExternalOperatorSingleNodePlatform = kubernetesComposition(
       repositoryName,
       repositoryNamespace,
       repositoryUrl,
-      values: clusterOnlyValues(mapRookCephSingleNodePlatformToHelmValues(spec, storageSize)),
+      values: singleNodeClusterOnlyValues(
+        mapRookCephSingleNodePlatformToHelmValues(spec, storageSize)
+      ),
       id: 'clusterRelease',
     });
     clusterRelease.dependsOn(externalOperator);
@@ -496,4 +500,38 @@ function clusterOnlyValues(values: unknown) {
     return mergeValuesExpression(values, clusterOnly);
   }
   return { ...(structuredClone(values) as Record<string, unknown>), ...clusterOnly };
+}
+
+/**
+ * The object-storage-only single-node profiles do not use Rook's CSI operator.
+ * Installing it would add chart-internal ClientProfile resources whose cleanup
+ * finalizers depend on the Rook operator. The cluster owns no block pools or
+ * filesystems, so disabling that subchart removes an unused controller and
+ * prevents its finalizers from outliving the operator during platform teardown.
+ *
+ * Keep this as a protected final overlay: raw chart values may customize other
+ * CSI settings, but cannot re-enable a controller whose lifecycle is outside
+ * this composition's dependency graph.
+ */
+function singleNodeClusterOnlyValues(values: unknown) {
+  const singleNodeOnly = {
+    cephBlockPools: [],
+    cephFileSystems: [],
+    cephObjectStores: [],
+    csi: { installCsiOperator: false },
+  };
+  if (isKubernetesRef(values) || isCelExpression(values) || isValuesMergeExpression(values)) {
+    return mergeValuesExpression(values, singleNodeOnly);
+  }
+
+  const cloned = structuredClone(values) as Record<string, unknown>;
+  const authoredCsi =
+    cloned.csi && typeof cloned.csi === 'object' && !Array.isArray(cloned.csi)
+      ? (cloned.csi as Record<string, unknown>)
+      : {};
+  return {
+    ...cloned,
+    ...singleNodeOnly,
+    csi: { ...authoredCsi, installCsiOperator: false },
+  };
 }

--- a/src/factories/rook/compositions/rook-ceph-platform.ts
+++ b/src/factories/rook/compositions/rook-ceph-platform.ts
@@ -102,6 +102,10 @@ export const rookCephSingleNodePlatform = kubernetesComposition(
       values: {
         enableOBCWatchOperatorNamespace: false,
         resources: { requests: { cpu: '100m', memory: '128Mi' } },
+        // The object-only development profile owns no block pools or file
+        // systems. Disable the operator chart's CSI dependency so its
+        // ClientProfile finalizers cannot outlive this owned operator.
+        csi: { installCsiOperator: false },
       },
       id: 'operatorRelease',
     });
@@ -113,9 +117,7 @@ export const rookCephSingleNodePlatform = kubernetesComposition(
       repositoryName,
       repositoryNamespace,
       repositoryUrl,
-      values: singleNodeClusterOnlyValues(
-        mapRookCephSingleNodePlatformToHelmValues(spec, storageSize)
-      ),
+      values: clusterOnlyValues(mapRookCephSingleNodePlatformToHelmValues(spec, storageSize)),
       id: 'clusterRelease',
     });
     clusterRelease.dependsOn(operatorRelease);
@@ -316,7 +318,9 @@ export const rookCephProductionPlatform = kubernetesComposition(
 /**
  * Complete one-node Ceph cluster that references an already managed Rook
  * operator. The operator Deployment is an observed prerequisite and is never
- * emitted, adopted, or deleted by this composition.
+ * emitted, adopted, or deleted by this composition. Its platform owner must
+ * keep it running until this cluster and any operator-owned CSI descendants
+ * have completed deletion.
  */
 export const rookCephExternalOperatorSingleNodePlatform = kubernetesComposition(
   {
@@ -374,9 +378,7 @@ export const rookCephExternalOperatorSingleNodePlatform = kubernetesComposition(
       repositoryName,
       repositoryNamespace,
       repositoryUrl,
-      values: singleNodeClusterOnlyValues(
-        mapRookCephSingleNodePlatformToHelmValues(spec, storageSize)
-      ),
+      values: clusterOnlyValues(mapRookCephSingleNodePlatformToHelmValues(spec, storageSize)),
       id: 'clusterRelease',
     });
     clusterRelease.dependsOn(externalOperator);
@@ -500,38 +502,4 @@ function clusterOnlyValues(values: unknown) {
     return mergeValuesExpression(values, clusterOnly);
   }
   return { ...(structuredClone(values) as Record<string, unknown>), ...clusterOnly };
-}
-
-/**
- * The object-storage-only single-node profiles do not use Rook's CSI operator.
- * Installing it would add chart-internal ClientProfile resources whose cleanup
- * finalizers depend on the Rook operator. The cluster owns no block pools or
- * filesystems, so disabling that subchart removes an unused controller and
- * prevents its finalizers from outliving the operator during platform teardown.
- *
- * Keep this as a protected final overlay: raw chart values may customize other
- * CSI settings, but cannot re-enable a controller whose lifecycle is outside
- * this composition's dependency graph.
- */
-function singleNodeClusterOnlyValues(values: unknown) {
-  const singleNodeOnly = {
-    cephBlockPools: [],
-    cephFileSystems: [],
-    cephObjectStores: [],
-    csi: { installCsiOperator: false },
-  };
-  if (isKubernetesRef(values) || isCelExpression(values) || isValuesMergeExpression(values)) {
-    return mergeValuesExpression(values, singleNodeOnly);
-  }
-
-  const cloned = structuredClone(values) as Record<string, unknown>;
-  const authoredCsi =
-    cloned.csi && typeof cloned.csi === 'object' && !Array.isArray(cloned.csi)
-      ? (cloned.csi as Record<string, unknown>)
-      : {};
-  return {
-    ...cloned,
-    ...singleNodeOnly,
-    csi: { ...authoredCsi, installCsiOperator: false },
-  };
 }

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
+import { loadAll } from 'js-yaml';
 
 import {
   DEFAULT_ROOK_CEPH_VERSION,
@@ -174,26 +175,17 @@ describe('official Rook Ceph cluster chart platform', () => {
     expectCleanYaml(yaml);
   });
 
-  it('keeps the unused CSI operator disabled in object-only single-node profiles', () => {
+  it('disables CSI on the owned operator chart rather than the cluster chart', () => {
     const config = {
       name: 'rook-local',
       profile: 'single-node-development' as const,
       namespace: 'ceph-data',
       operatorNamespace: 'ceph-operator',
       storageClassName: 'local-path',
-      values: {
-        csi: {
-          installCsiOperator: true,
-          enableRbdDriver: false,
-        },
-      },
     };
 
     const directYaml = rookCephSingleNodePlatform
       .factory('direct', { namespace: 'control' })
-      .toYaml(config);
-    const kroYaml = rookCephSingleNodePlatform
-      .factory('kro', { namespace: 'control' })
       .toYaml(config);
     const kroDefinitionYaml = rookCephSingleNodePlatform
       .factory('kro', { namespace: 'control' })
@@ -205,18 +197,31 @@ describe('official Rook Ceph cluster chart platform', () => {
         operatorDeploymentName: 'rook-ceph-operator',
       });
 
-    for (const yaml of [directYaml, externalOperatorYaml]) {
-      expect(yaml).toContain('installCsiOperator: false');
-      expect(yaml).not.toContain('installCsiOperator: true');
-      expect(yaml).toContain('enableRbdDriver: false');
-      expectCleanYaml(yaml);
-    }
-    // The instance preserves the authored input, while the generated RGD applies
-    // the protected final overlay during reconciliation.
-    expect(kroYaml).toContain('installCsiOperator: true');
-    expect(kroDefinitionYaml).toContain('{"installCsiOperator": false}');
-    expectCleanYaml(kroYaml);
+    const directResources = loadAll(directYaml) as Array<{
+      kind?: string;
+      spec?: {
+        chart?: { spec?: { chart?: string } };
+        values?: { csi?: { installCsiOperator?: boolean } };
+      };
+    }>;
+    const operator = directResources.find(
+      (resource) =>
+        resource.kind === 'HelmRelease' && resource.spec?.chart?.spec?.chart === 'rook-ceph'
+    );
+    const cluster = directResources.find(
+      (resource) =>
+        resource.kind === 'HelmRelease' &&
+        resource.spec?.chart?.spec?.chart === 'rook-ceph-cluster'
+    );
+    expect(operator?.spec?.values?.csi?.installCsiOperator).toBe(false);
+    expect(cluster?.spec?.values?.csi).toBeUndefined();
+
+    expect(kroDefinitionYaml).toContain('chart: rook-ceph');
+    expect(kroDefinitionYaml).toContain('installCsiOperator: false');
+    expect(externalOperatorYaml).not.toContain('installCsiOperator');
+    expectCleanYaml(directYaml);
     expectCleanYaml(kroDefinitionYaml);
+    expectCleanYaml(externalOperatorYaml);
   });
 
   it('keeps the object store behind the executable cluster release lifecycle edge', async () => {
@@ -269,7 +274,7 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(yaml).toContain('kind: CephCluster');
     expect(yaml).toContain('kind: CephObjectStore');
     expect(yaml).toContain('kind: StorageClass');
-    expect(yaml).toContain('{"installCsiOperator": false}');
+    expect(yaml).toContain('installCsiOperator: false');
     expectCleanYaml(yaml);
   });
 

--- a/test/factories/rook/platform.test.ts
+++ b/test/factories/rook/platform.test.ts
@@ -170,7 +170,53 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(yaml).toContain('storageClassName: local-path');
     expect(yaml).toContain('name: harbor-retain');
     expect(yaml).toContain('reclaimPolicy: Retain');
+    expect(yaml).toContain('installCsiOperator: false');
     expectCleanYaml(yaml);
+  });
+
+  it('keeps the unused CSI operator disabled in object-only single-node profiles', () => {
+    const config = {
+      name: 'rook-local',
+      profile: 'single-node-development' as const,
+      namespace: 'ceph-data',
+      operatorNamespace: 'ceph-operator',
+      storageClassName: 'local-path',
+      values: {
+        csi: {
+          installCsiOperator: true,
+          enableRbdDriver: false,
+        },
+      },
+    };
+
+    const directYaml = rookCephSingleNodePlatform
+      .factory('direct', { namespace: 'control' })
+      .toYaml(config);
+    const kroYaml = rookCephSingleNodePlatform
+      .factory('kro', { namespace: 'control' })
+      .toYaml(config);
+    const kroDefinitionYaml = rookCephSingleNodePlatform
+      .factory('kro', { namespace: 'control' })
+      .toYaml();
+    const externalOperatorYaml = rookCephExternalOperatorSingleNodePlatform
+      .factory('direct', { namespace: 'control' })
+      .toYaml({
+        ...config,
+        operatorDeploymentName: 'rook-ceph-operator',
+      });
+
+    for (const yaml of [directYaml, externalOperatorYaml]) {
+      expect(yaml).toContain('installCsiOperator: false');
+      expect(yaml).not.toContain('installCsiOperator: true');
+      expect(yaml).toContain('enableRbdDriver: false');
+      expectCleanYaml(yaml);
+    }
+    // The instance preserves the authored input, while the generated RGD applies
+    // the protected final overlay during reconciliation.
+    expect(kroYaml).toContain('installCsiOperator: true');
+    expect(kroDefinitionYaml).toContain('{"installCsiOperator": false}');
+    expectCleanYaml(kroYaml);
+    expectCleanYaml(kroDefinitionYaml);
   });
 
   it('keeps the object store behind the executable cluster release lifecycle edge', async () => {
@@ -223,6 +269,7 @@ describe('official Rook Ceph cluster chart platform', () => {
     expect(yaml).toContain('kind: CephCluster');
     expect(yaml).toContain('kind: CephObjectStore');
     expect(yaml).toContain('kind: StorageClass');
+    expect(yaml).toContain('{"installCsiOperator": false}');
     expectCleanYaml(yaml);
   });
 


### PR DESCRIPTION
## What changed

- disables the Rook CSI operator subchart on the actual `rook-ceph` operator HelmRelease for the owned, object-storage-only single-node platform
- leaves the separate `rook-ceph-cluster` chart untouched because `csi.installCsiOperator` is not consumed there
- keeps the external-operator composition honest: it cannot mutate an externally owned operator, so its contract and documentation now require that operator to remain available through cluster/CSI descendant teardown
- adds direct and KRO regressions that parse the rendered HelmRelease resources and prove the setting is attached to the operator chart, plus a regression proving external mode does not emit an inert cluster-chart setting

## Why

The single-node profile owns no block pools or filesystems, but the owned Rook operator chart installed the CSI operator by default. That subchart creates `ClientProfile` resources with cleanup finalizers managed by the Rook operator. During platform teardown, those chart-internal resources could outlive their controller and strand the operator HelmRelease. TypeKro's outer composition graph cannot topologically order chart-internal CRs, so the owned provider should avoid installing this unused controller.

Production Rook profiles are unchanged. External-operator mode documents the lifecycle prerequisite rather than pretending it can configure infrastructure it does not own.

## Validation

- `bun test test/factories/rook/platform.test.ts` — 15 passed
- `bun run typecheck`
- `bun run lint`
- `git diff --check`

The corrected provider behavior will also be consumed by Applik8s's External-profile OrbStack acceptance gate to exercise the full install/delete lifecycle before this draft is promoted.