### PR TITLE
fix Harbor immutable project teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Confirmed Harbor project teardown with `purgeRepositories: true` now removes
+  project immutable-tag rules before deleting repositories. TypeKro-managed
+  immutability no longer blocks its own exact-name-confirmed lifecycle with
+  Harbor HTTP 412, and robot Secrets remain until project deletion completes.
 - Direct Alchemy singleton owners now gate consumer scheduling through a dedicated barrier instead
   of being injected into each consumer's canonical live-resource dependencies. This preserves
   singleton readiness ordering without making direct artifact execution records fail dependency

--- a/src/factories/harbor/provider/harbor-api.ts
+++ b/src/factories/harbor/provider/harbor-api.ts
@@ -294,6 +294,13 @@ export async function deleteHarborProject(
     throw new Error('Harbor project deletion timeoutMs must be a positive finite number.');
   }
   if (options.purgeRepositories) {
+    // Harbor enforces immutable-tag rules on repository deletion as well as
+    // pushes. Exact-name confirmation plus purgeRepositories already grants
+    // destructive authority over the complete project, so remove every
+    // project rule before purging its repositories. Leaving the rules in place
+    // makes TypeKro's own managed immutable policy render confirmed teardown
+    // impossible with HTTP 412.
+    await removeHarborProjectImmutableRules(client, project, options.signal);
     await purgeHarborProjectRepositories(client, project, timeoutMs, options.signal);
   }
   const deletion = await client.request(
@@ -311,6 +318,36 @@ export async function deleteHarborProject(
     const store = options.store ?? createHarborKubernetesStore(options.kubeConfig);
     await Promise.all(
       secretNames.map((name) => store.deleteSecret(options.secretNamespace as string, name))
+    );
+  }
+}
+
+async function removeHarborProjectImmutableRules(
+  client: HarborApiClient,
+  project: string,
+  signal: AbortSignal | undefined
+): Promise<void> {
+  const path = `/projects/${encodeURIComponent(project)}/immutabletagrules`;
+  const listed = await client.request<HarborImmutableRule[]>(
+    { method: 'GET', path, signal },
+    [200, 404]
+  );
+  if (listed.status === 404) return;
+  for (const rule of listed.body ?? []) {
+    if (!Number.isInteger(rule.id)) {
+      throw new HarborApiError(
+        `Harbor immutable-tag rule for project ${project} was missing its ID.`,
+        200,
+        path
+      );
+    }
+    await client.request(
+      {
+        method: 'DELETE',
+        path: `${path}/${rule.id as number}`,
+        signal,
+      },
+      [200, 204, 404]
     );
   }
 }

--- a/test/factories/harbor/provider.test.ts
+++ b/test/factories/harbor/provider.test.ts
@@ -77,6 +77,7 @@ class FakeHarbor implements HarborApiTransport {
       );
     }
     if (request.path.startsWith('/projects/chirp/repositories/') && request.method === 'DELETE') {
+      if (this.immutableRule) return response(412);
       const repository = decodeURIComponent(request.path.split('/').at(-1) ?? '');
       const fullName = `chirp/${repository}`;
       const index = this.repositories.indexOf(fullName);
@@ -104,6 +105,10 @@ class FakeHarbor implements HarborApiTransport {
     }
     if (request.path === '/projects/chirp/immutabletagrules/11' && request.method === 'PUT') {
       if ((request.body as { id?: number }).id !== 11) return response(400);
+      return response(200);
+    }
+    if (request.path === '/projects/chirp/immutabletagrules/11' && request.method === 'DELETE') {
+      this.immutableRule = false;
       return response(200);
     }
     if (request.path === '/retentions' && request.method === 'POST') {
@@ -514,6 +519,7 @@ describe('Harbor direct preparation providers', () => {
   it('purges a non-empty project only with explicit confirmation and waits before deleting Secrets', async () => {
     const transport = new FakeHarbor();
     transport.projectExists = true;
+    transport.immutableRule = true;
     transport.repositories.push('chirp/typekro-oci-smoke');
     const client = new HarborApiClient(transport);
     const store = new MemoryStore();
@@ -549,6 +555,18 @@ describe('Harbor direct preparation providers', () => {
           request.path === '/projects/chirp/repositories/typekro-oci-smoke'
       )
     ).toBe(true);
+    const ruleDeletion = transport.requests.findIndex(
+      (request) =>
+        request.method === 'DELETE' &&
+        request.path === '/projects/chirp/immutabletagrules/11'
+    );
+    const repositoryDeletion = transport.requests.findIndex(
+      (request) =>
+        request.method === 'DELETE' &&
+        request.path === '/projects/chirp/repositories/typekro-oci-smoke'
+    );
+    expect(ruleDeletion).toBeGreaterThanOrEqual(0);
+    expect(repositoryDeletion).toBeGreaterThan(ruleDeletion);
   });
 
   it('redacts response bodies from Harbor API failures', async () => {


### PR DESCRIPTION
## Summary

- remove project immutable-tag rules before an exact-name-confirmed repository purge
- preserve the existing fail-closed confirmation, bounded absence wait, and post-delete robot Secret cleanup
- cover the real Harbor 412 ordering failure and document the fix

## Verification

- focused Harbor provider tests: 9 passed
- full unit suite: 5,269 passed, 13 skipped, 1 todo, 0 failed
- full TypeScript typecheck
- Biome lint
- live OrbStack recovery of an immutable Chirp project with stale registry metadata
