### PR TITLE
chore: release v0.33.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.33.3",
+  "version": "0.33.4",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

- release the lifecycle, artifact migration, Ory, and Rook fixes merged in #141-#148
- bump the package version from 0.33.3 to 0.33.4

## Verification

- bun run test (5,290 passed, 0 failed)
- bun run build
- npm pack --dry-run