### PR TITLE
chore: release v0.33.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.33.4",
+  "version": "0.33.5",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

- release the Harbor immutable-project teardown fix from #149
- bump the package version from 0.33.4 to 0.33.5

## Verification

- focused Harbor provider tests: 9 passed
- full unit suite: 5,290 passed, 0 failed
- KubernetesRef performance benchmark: 20 consecutive isolated passes
- fresh #149 CI