### PR TITLE
Fix direct dependency resolution for composition aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Direct dependency planning now resolves composition callback and
+  local-variable aliases to their canonical graph resources, fails closed when
+  an alias is ambiguous, and reports repeated unknown references only once per
+  source resource.
 - Confirmed Harbor project teardown with `purgeRepositories: true` now removes
   project immutable-tag rules before deleting repositories. TypeKro-managed
   immutability no longer blocks its own exact-name-confirmed lifecycle with

--- a/src/core/composition/imperative.ts
+++ b/src/core/composition/imperative.ts
@@ -575,16 +575,39 @@ function executeNestedCompositionWithSpec<
   // Determine if this composition has a single resource
   const resourceCount = Object.keys(executionContext.resources).length;
   const nestedResourceIds = executionContext.nestedCompositionIds ?? new Set<string>();
+  const mergedResourceIds = new Map(
+    Object.keys(executionContext.resources).map((resourceId) => [
+      resourceId,
+      computeMergedId(baseId, resourceId, resourceCount, nestedResourceIds.has(resourceId)),
+    ])
+  );
+  const localIdentityOwners = new Map<string, Set<string>>();
+  const registerLocalIdentity = (identity: string | undefined, targetId: string): void => {
+    if (!identity) return;
+    const owners = localIdentityOwners.get(identity) ?? new Set<string>();
+    owners.add(targetId);
+    localIdentityOwners.set(identity, owners);
+  };
+  for (const [resourceId, resource] of Object.entries(executionContext.resources)) {
+    const targetId = mergedResourceIds.get(resourceId);
+    if (!targetId) continue;
+    registerLocalIdentity(resourceId, targetId);
+    registerLocalIdentity(getResourceId(resource), targetId);
+    for (const alias of getMetadataField(resource, 'resourceAliases') ?? []) {
+      registerLocalIdentity(alias, targetId);
+    }
+  }
+  const localAliasTargets = Object.fromEntries(
+    [...localIdentityOwners].flatMap(([identity, owners]) =>
+      owners.size === 1 ? [[identity, owners.values().next().value as string]] : []
+    )
+  );
 
   // Merge the executed composition's resources into the parent context
   const mergedInnerResourceIds: string[] = [];
   for (const [resourceId, resource] of Object.entries(executionContext.resources)) {
-    const uniqueId = computeMergedId(
-      baseId,
-      resourceId,
-      resourceCount,
-      nestedResourceIds.has(resourceId)
-    );
+    const uniqueId = mergedResourceIds.get(resourceId);
+    if (!uniqueId) continue;
     const mergedResource = { ...(resource as Record<string, unknown>) } as Enhanced<
       unknown,
       unknown
@@ -608,6 +631,18 @@ function executeNestedCompositionWithSpec<
     const aliases = new Set(existingAliases ?? []);
     aliases.add(resourceId);
     setMetadataField(mergedResource, 'resourceAliases', Array.from(aliases));
+
+    const inheritedAliasTargets =
+      getMetadataField(mergedResource, 'resourceAliasTargets') ?? {};
+    setMetadataField(mergedResource, 'resourceAliasTargets', {
+      ...localAliasTargets,
+      ...Object.fromEntries(
+        Object.entries(inheritedAliasTargets).map(([identity, targetId]) => [
+          identity,
+          mergedResourceIds.get(targetId) ?? targetId,
+        ])
+      ),
+    });
 
     const existingDependsOn = getMetadataField(mergedResource, 'dependsOn') as
       | Array<{ resourceId: string; condition?: string }>

--- a/src/core/dependencies/resolver.ts
+++ b/src/core/dependencies/resolver.ts
@@ -36,31 +36,42 @@ export class DependencyResolver {
   ): DependencyGraph {
     const graph = new DependencyGraph();
 
-    // Add all resources as nodes and build a reverse map from original
-    // composition IDs (e.g., 'database') to graph IDs (e.g., 'testappResource0Database').
-    // Marker strings in template literals use the original composition ID, but
-    // the graph nodes use the prefixed deployment ID.
-    const originalIdToGraphId = new Map<string, string>();
+    // Add all resources as nodes and build a reverse map from every authored
+    // identity to graph IDs. References may use the graph ID, the resource's
+    // original composition ID, or a local-variable/callback alias preserved in
+    // resource metadata. Nested compositions prefix graph IDs, so resolving only
+    // the original resource ID loses otherwise valid dependencies.
+    const identityToGraphIds = new Map<string, Set<string>>();
+    const registerIdentity = (identity: string | undefined, graphId: string): void => {
+      if (!identity) return;
+      const owners = identityToGraphIds.get(identity) ?? new Set<string>();
+      owners.add(graphId);
+      identityToGraphIds.set(identity, owners);
+    };
     for (const resource of resources) {
       graph.addNode(resource.id, resource);
 
       const originalId = getResourceId(resource);
-      if (originalId && originalId !== resource.id) {
-        originalIdToGraphId.set(originalId, resource.id);
+      registerIdentity(resource.id, resource.id);
+      registerIdentity(originalId, resource.id);
+      for (const alias of getMetadataField(resource, 'resourceAliases') ?? []) {
+        registerIdentity(alias, resource.id);
       }
     }
 
     // Analyze each resource for references and add edges
     for (const resource of resources) {
       const references = this.extractReferences(resource);
+      const warnedUnknownReferences = new Set<string>();
 
       for (const ref of references) {
         // Skip schema references (these are internal TypeKro references)
         if (ref.resourceId !== '__schema__' && ref.resourceId !== 'schema') {
-          // Resolve the reference ID: try graph ID first, then original ID mapping
-          const targetId = graph.hasNode(ref.resourceId)
-            ? ref.resourceId
-            : originalIdToGraphId.get(ref.resourceId);
+          const targetId = this.resolveResourceIdentity(
+            ref.resourceId,
+            identityToGraphIds,
+            resource.id
+          );
 
           if (targetId) {
             try {
@@ -71,10 +82,13 @@ export class DependencyResolver {
           } else {
             // Log warning if referenced resource doesn't exist in the graph
             // This might be an external reference that will be resolved at runtime
-            this.logger.warn('Reference to unknown resource', {
-              referencedResourceId: ref.resourceId,
-              sourceResourceId: resource.id,
-            });
+            if (!warnedUnknownReferences.has(ref.resourceId)) {
+              warnedUnknownReferences.add(ref.resourceId);
+              this.logger.warn('Reference to unknown resource', {
+                referencedResourceId: ref.resourceId,
+                sourceResourceId: resource.id,
+              });
+            }
           }
         }
       }
@@ -83,9 +97,11 @@ export class DependencyResolver {
         | Array<{ resourceId: string }>
         | undefined;
       for (const dep of explicitDependencies ?? []) {
-        const targetId = graph.hasNode(dep.resourceId)
-          ? dep.resourceId
-          : originalIdToGraphId.get(dep.resourceId);
+        const targetId = this.resolveResourceIdentity(
+          dep.resourceId,
+          identityToGraphIds,
+          resource.id
+        );
         if (!targetId) {
           if (options.knownExternalResourceIds?.has(dep.resourceId)) {
             this.logger.debug('Skipping apply-order edge to known external resource', {
@@ -232,6 +248,31 @@ export class DependencyResolver {
     }
 
     return graph;
+  }
+
+  private resolveResourceIdentity(
+    identity: string,
+    identityToGraphIds: ReadonlyMap<string, ReadonlySet<string>>,
+    sourceResourceId: string
+  ): string | undefined {
+    const owners = identityToGraphIds.get(identity);
+    if (!owners || owners.size === 0) return undefined;
+    if (owners.size > 1) {
+      throw new TypeKroError(
+        `Resource identity '${identity}' referenced by '${sourceResourceId}' is ambiguous between resources ${[
+          ...owners,
+        ]
+          .map((owner) => `'${owner}'`)
+          .join(' and ')}`,
+        'AMBIGUOUS_DEPENDENCY_REFERENCE',
+        {
+          sourceResourceId,
+          referencedResourceId: identity,
+          owners: [...owners],
+        }
+      );
+    }
+    return owners.values().next().value;
   }
 
   /**

--- a/src/core/dependencies/resolver.ts
+++ b/src/core/dependencies/resolver.ts
@@ -70,7 +70,7 @@ export class DependencyResolver {
           const targetId = this.resolveResourceIdentity(
             ref.resourceId,
             identityToGraphIds,
-            resource.id
+            resource
           );
 
           if (targetId) {
@@ -100,7 +100,7 @@ export class DependencyResolver {
         const targetId = this.resolveResourceIdentity(
           dep.resourceId,
           identityToGraphIds,
-          resource.id
+          resource
         );
         if (!targetId) {
           if (options.knownExternalResourceIds?.has(dep.resourceId)) {
@@ -253,8 +253,15 @@ export class DependencyResolver {
   private resolveResourceIdentity(
     identity: string,
     identityToGraphIds: ReadonlyMap<string, ReadonlySet<string>>,
-    sourceResourceId: string
+    sourceResource: DeployableK8sResource<Enhanced<unknown, unknown>>
   ): string | undefined {
+    const sourceResourceId = sourceResource.id;
+    const scopedTarget = getMetadataField(sourceResource, 'resourceAliasTargets')?.[identity];
+    if (scopedTarget) {
+      const scopedOwners = identityToGraphIds.get(scopedTarget);
+      if (scopedOwners?.size === 1) return scopedOwners.values().next().value;
+    }
+
     const owners = identityToGraphIds.get(identity);
     if (!owners || owners.size === 0) return undefined;
     if (owners.size > 1) {

--- a/src/core/metadata/resource-metadata.ts
+++ b/src/core/metadata/resource-metadata.ts
@@ -66,6 +66,15 @@ export interface ResourceMetadata {
   resourceId?: string;
   /** Local resource IDs that should resolve to this emitted resource ID. */
   resourceAliases?: string[];
+  /**
+   * Composition-local resource identity bindings visible from this resource.
+   *
+   * Nested composition flattening prefixes emitted graph IDs while authored
+   * references continue to use local child names. Keeping the bindings on the
+   * source resource lets dependency resolution distinguish repeated instances
+   * of the same composition without making those local names graph-global.
+   */
+  resourceAliasTargets?: Record<string, string>;
   /** Factory-provided function that evaluates whether a deployed resource is ready */
   readinessEvaluator?: (resource: unknown) => ResourceStatus;
   /** Serializable identity for resolving the evaluator after artifact rehydration. */

--- a/test/core/dependency-resolver.test.ts
+++ b/test/core/dependency-resolver.test.ts
@@ -236,6 +236,62 @@ describe('DependencyResolver', () => {
       );
     });
 
+    it('resolves repeated composition aliases relative to the source resource scope', () => {
+      const firstConfig = createMockResource({
+        id: 'demoResource0Configmap',
+        metadata: { name: 'first-config' },
+      });
+      setResourceId(firstConfig, 'config');
+      setMetadataField(firstConfig, 'resourceAliases', ['config']);
+      const firstConsumer = createMockResource({
+        id: 'demoResource1Deployment',
+        metadata: { name: 'first-consumer' },
+        spec: {
+          value: {
+            [CEL_EXPRESSION_BRAND]: true,
+            expression: 'config.status.ready',
+          },
+        },
+      });
+      setMetadataField(firstConsumer, 'resourceAliasTargets', {
+        config: 'demoResource0Configmap',
+      });
+
+      const secondConfig = createMockResource({
+        id: 'demoResource2Configmap',
+        metadata: { name: 'second-config' },
+      });
+      setResourceId(secondConfig, 'config');
+      setMetadataField(secondConfig, 'resourceAliases', ['config']);
+      const secondConsumer = createMockResource({
+        id: 'demoResource3Deployment',
+        metadata: { name: 'second-consumer' },
+        spec: {
+          value: {
+            [CEL_EXPRESSION_BRAND]: true,
+            expression: 'config.status.ready',
+          },
+        },
+      });
+      setMetadataField(secondConsumer, 'resourceAliasTargets', {
+        config: 'demoResource2Configmap',
+      });
+
+      const graph = resolver.buildDependencyGraph([
+        firstConfig,
+        firstConsumer,
+        secondConfig,
+        secondConsumer,
+      ]);
+
+      expect(graph.getDependencies('demoResource1Deployment')).toEqual([
+        'demoResource0Configmap',
+      ]);
+      expect(graph.getDependencies('demoResource3Deployment')).toEqual([
+        'demoResource2Configmap',
+      ]);
+    });
+
     it('reports each unknown reference only once per source resource', () => {
       const warnings: Array<{ message: string; context?: unknown }> = [];
       (

--- a/test/core/dependency-resolver.test.ts
+++ b/test/core/dependency-resolver.test.ts
@@ -177,6 +177,100 @@ describe('DependencyResolver', () => {
       expect(graph.getDependencies('app')).toContain('db');
     });
 
+    it('resolves preserved composition aliases to their prefixed graph resource', () => {
+      const warnings: Array<{ message: string; context?: unknown }> = [];
+      (
+        resolver as unknown as { logger: { warn: (message: string, context?: unknown) => void } }
+      ).logger = {
+        warn: (message, context) => warnings.push({ message, context }),
+      };
+      const producer = createMockResource({
+        id: 'stack1DatabaseRelease',
+        metadata: { name: 'database' },
+      });
+      setResourceId(producer, 'databaseRelease');
+      setMetadataField(producer, 'resourceAliases', ['database']);
+      const consumer = createMockResource({
+        id: 'consumer',
+        metadata: { name: 'consumer' },
+        spec: {
+          value: {
+            [CEL_EXPRESSION_BRAND]: true,
+            expression: 'database.status.conditions.exists(c, c.status == "True")',
+          },
+        },
+      });
+
+      const graph = resolver.buildDependencyGraph([producer, consumer]);
+
+      expect(graph.getDependencies('consumer')).toEqual(['stack1DatabaseRelease']);
+      expect(warnings).toEqual([]);
+    });
+
+    it('fails closed when a dependency reference matches multiple resource aliases', () => {
+      const first = createMockResource({
+        id: 'stack1First',
+        metadata: { name: 'first' },
+      });
+      setResourceId(first, 'first');
+      setMetadataField(first, 'resourceAliases', ['contract']);
+      const second = createMockResource({
+        id: 'stack1Second',
+        metadata: { name: 'second' },
+      });
+      setResourceId(second, 'second');
+      setMetadataField(second, 'resourceAliases', ['contract']);
+      const consumer = createMockResource({
+        id: 'consumer',
+        metadata: { name: 'consumer' },
+        spec: {
+          value: {
+            [CEL_EXPRESSION_BRAND]: true,
+            expression: 'contract.status.ready',
+          },
+        },
+      });
+
+      expect(() => resolver.buildDependencyGraph([first, second, consumer])).toThrow(
+        "Resource identity 'contract' referenced by 'consumer' is ambiguous"
+      );
+    });
+
+    it('reports each unknown reference only once per source resource', () => {
+      const warnings: Array<{ message: string; context?: unknown }> = [];
+      (
+        resolver as unknown as { logger: { warn: (message: string, context?: unknown) => void } }
+      ).logger = {
+        warn: (message, context) => warnings.push({ message, context }),
+      };
+      const consumer = createMockResource({
+        id: 'consumer',
+        metadata: { name: 'consumer' },
+        spec: {
+          first: {
+            [CEL_EXPRESSION_BRAND]: true,
+            expression: 'missing.status.ready',
+          },
+          second: {
+            [CEL_EXPRESSION_BRAND]: true,
+            expression: 'missing.status.phase',
+          },
+        },
+      });
+
+      resolver.buildDependencyGraph([consumer]);
+
+      expect(warnings).toEqual([
+        {
+          message: 'Reference to unknown resource',
+          context: {
+            referencedResourceId: 'missing',
+            sourceResourceId: 'consumer',
+          },
+        },
+      ]);
+    });
+
     it('normalizes CEL schema roots without reporting an unknown resource', () => {
       const warnings: Array<{ message: string; context?: unknown }> = [];
       (

--- a/test/core/direct-factory-characterization.test.ts
+++ b/test/core/direct-factory-characterization.test.ts
@@ -396,6 +396,65 @@ function getPrivateMethod<TInstance extends object>(
 // ===========================================================================
 
 describe('DirectFactory: __resourceId preservation', () => {
+  it('keeps dependency aliases local when the same nested composition is reused', () => {
+    const reusable = kubernetesComposition(
+      {
+        name: 'repeated-nested-dependency',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'RepeatedNestedDependency',
+        spec: type({ name: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        const config = simple.Deployment({
+          id: 'config',
+          name: `${spec.name}-config`,
+          image: 'nginx:1.27',
+        });
+        simple.Deployment({
+          id: 'deployment',
+          name: `${spec.name}-consumer`,
+          image: 'nginx:1.27',
+          env: {
+            CONFIG_REVISION: config.status.readyReplicas as unknown as string,
+          },
+        });
+        return { ready: true };
+      }
+    );
+    const parent = kubernetesComposition(
+      {
+        name: 'repeated-nested-dependency-parent',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'RepeatedNestedDependencyParent',
+        spec: type({ name: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        reusable({ name: `${spec.name}-first` });
+        reusable({ name: `${spec.name}-second` });
+        return { ready: true };
+      }
+    );
+
+    const graph = parent
+      .factory('direct', { namespace: 'default' })
+      .createResourceGraphForInstance({ name: 'demo' });
+    const resourceIdByName = new Map(
+      graph.resources.map((resource) => [resource.manifest.metadata.name, resource.id])
+    );
+
+    expect(
+      graph.dependencyGraph.getDependencies(resourceIdByName.get('demo-first-consumer')!)
+    ).toContain(resourceIdByName.get('demo-first-config'));
+    expect(
+      graph.dependencyGraph.getDependencies(resourceIdByName.get('demo-second-consumer')!)
+    ).toContain(resourceIdByName.get('demo-second-config'));
+    expect(
+      graph.dependencyGraph.getDependencies(resourceIdByName.get('demo-first-consumer')!)
+    ).not.toContain(resourceIdByName.get('demo-second-config'));
+  });
+
   it('resources in graph have resourceId stored in WeakMap metadata', async () => {
     const factory = await createTestFactory('rid-test');
     const graph = factory.createResourceGraphForInstance(DEFAULT_SPEC);


### PR DESCRIPTION
## What changed

- resolve preserved composition callback/local-variable aliases when building direct dependency graphs
- fail closed when one dependency identity is owned by multiple resources
- deduplicate repeated unknown-reference warnings per source resource
- document the fix in the changelog

## Why

Nested and imperative compositions already preserve authored aliases in `resourceAliases`, but `DependencyResolver` only considered graph IDs and original resource IDs. Valid CEL references such as `hydra.status...` therefore appeared unknown after the corresponding HelmRelease was prefixed and canonicalized (for example, `oryIdentityStack1HydraHelmRelease`). This produced a large warning flood and could omit real apply-order edges.

The resolver now treats graph IDs, original IDs, and preserved aliases as one identity space. Ambiguous identities are rejected instead of silently choosing an owner.

## Validation

- `bun test test/core/dependency-resolver.test.ts --timeout 10000` — 50 passed
- `TYPEKRO_LOG_LEVEL=warn bun test test/factories/ory/bootstrap-composition.test.ts --timeout 10000` — 10 passed, no unknown Ory dependency warnings
- `bun run typecheck:lib`
- `bun run lint`
- `git diff --check`
- broader core + Ory run: 2,969 passed, 10 skipped; the one failure is the pre-existing `status-field-integration` fixture using KRO-reserved root status field `conditions`, reproduced unchanged on v0.33.5
