### PR TITLE
fix: preserve planning values through aspects

### DIFF
--- a/src/core/aspects/apply.ts
+++ b/src/core/aspects/apply.ts
@@ -94,9 +94,12 @@ function cloneValue<T>(value: T): T {
   }
   if (Array.isArray(value)) return value.map((item) => cloneValue(item)) as T;
   if (value && typeof value === 'object') {
-    const clone: Record<string, unknown> = {};
+    const clone: Record<PropertyKey, unknown> = {};
     for (const [key, child] of Object.entries(value)) {
       clone[key] = cloneValue(child);
+    }
+    for (const key of Object.getOwnPropertySymbols(value)) {
+      clone[key] = cloneValue(Reflect.get(value, key));
     }
     return clone as T;
   }

--- a/test/core/planning/composition.test.ts
+++ b/test/core/planning/composition.test.ts
@@ -12,6 +12,7 @@ import { registerFactory } from '../../../src/core/resources/factory-registry.js
 import {
   adapterCapabilityDiagnostics,
   artifactOutput,
+  collectArtifactOutputUses,
   compileDirectArtifactPlan,
   compileKroArtifactPlan,
   decodeDesiredStatePlan,
@@ -395,6 +396,69 @@ describe('captured composition planning prototype', () => {
     expect(factoryGraph.resources[0]?.manifest.metadata?.labels).toEqual(
       expect.objectContaining({ environment: 'test', team: 'platform' })
     );
+  });
+
+  it('preserves branded artifact outputs while aspects clone resource values', () => {
+    const composition = toResourceGraph(
+      definition,
+      (schema) => ({
+        deployment: createResource({
+          id: 'deployment',
+          apiVersion: 'apps/v1',
+          kind: 'Deployment',
+          metadata: { name: schema.spec.name },
+          spec: {
+            replicas: schema.spec.replicas,
+            selector: { matchLabels: { app: schema.spec.name } },
+            template: {
+              metadata: { labels: { app: schema.spec.name } },
+              spec: {
+                containers: [
+                  {
+                    name: 'application',
+                    image: artifactOutput(
+                      'application-image',
+                      'immutableReference'
+                    ),
+                  },
+                ],
+              },
+            },
+          },
+        }),
+      }),
+      (schema, resources) => ({
+        readyReplicas: resources.deployment.status.readyReplicas,
+        summary: schema.spec.name,
+      })
+    );
+
+    const plan = composition.plan!(
+      { name: 'demo', image: 'unused', replicas: 2 },
+      {
+        strict: true,
+        aspects: [withLabels({ environment: 'development' })],
+        inputs: {
+          image: {
+            kind: 'artifact',
+            requirement: {
+              id: 'application-image',
+              kind: 'container-image',
+              descriptor: { kind: 'literal', value: 'demo' },
+              outputs: ['immutableReference'],
+            },
+          },
+        },
+      }
+    );
+
+    expect(collectArtifactOutputUses(plan.nodes)).toEqual([
+      {
+        requirementId: 'application-image',
+        output: 'immutableReference',
+        sensitive: false,
+      },
+    ]);
   });
 
   it('projects activation, readiness, dependency edges, and external lifecycle policies', () => {


### PR DESCRIPTION
## Summary

- preserve symbol-keyed TypeKro planning values when aspects clone resource graphs
- recursively clone symbol-backed values using the same cycle-safe object graph
- add regression coverage proving an artifact-backed container reference remains discoverable after an aspect transforms its Deployment

## Why

TypeKro aspects cloned only string-keyed enumerable properties. Internal planning values are symbol-backed, so applying an otherwise unrelated hot-reload aspect could make artifact outputs disappear from the semantic plan. Applik8s' generated development deployment exposed this when the application image artifact was no longer materialized even though the authored resource still referenced it.

## Verification

- 29 focused planning tests passed
- 49 focused aspect tests passed
- `bun run typecheck:lib` passed
- `bun run lint` passed
- full suite: 5,291 passed, 13 skipped, 1 todo
