### PR TITLE
fix NACK controller singleton ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ClusterRoleBinding names; deleting one former installation could therefore
   remove RBAC from another live controller. Stream and Consumer resources keep
   per-resource NATS routing, shared controller configuration is concrete
-  build-time input through `makeNatsBootstrap()`, and consumer deletion no
-  longer owns controller teardown.
+  build-time input through `makeNatsBootstrap()`, protected values preserve the
+  multi-system routing model, and consumer deletion no longer owns controller
+  teardown. The singleton uses collision-free service-account/RBAC names so it
+  can become ready alongside a v0.33.5 controller; direct deploy then performs
+  UID-leased retirement of the exact legacy HelmRelease while KRO/Alchemy use
+  normal graph pruning.
 - Confirmed Harbor project teardown with `purgeRepositories: true` now removes
   project immutable-tag rules before deleting repositories. TypeKro-managed
   immutability no longer blocks its own exact-name-confirmed lifecycle with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- NATS bootstraps now consume one explicit cluster-wide NACK singleton in
+  CRD-connect mode instead of installing a competing non-namespaced controller
+  per NATS instance. The official NACK chart uses fixed ClusterRole and
+  ClusterRoleBinding names; deleting one former installation could therefore
+  remove RBAC from another live controller. Stream and Consumer resources keep
+  per-resource NATS routing, shared controller configuration is concrete
+  build-time input through `makeNatsBootstrap()`, and consumer deletion no
+  longer owns controller teardown.
 - Confirmed Harbor project teardown with `purgeRepositories: true` now removes
   project immutable-tag rules before deleting repositories. TypeKro-managed
   immutability no longer blocks its own exact-name-confirmed lifecycle with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-resource NATS routing, shared controller configuration is concrete
   build-time input through `makeNatsBootstrap()`, protected values preserve the
   multi-system routing model, and consumer deletion no longer owns controller
-  teardown. The singleton uses collision-free service-account/RBAC names so it
-  can become ready alongside a v0.33.5 controller; direct deploy then performs
-  UID-leased retirement of the exact legacy HelmRelease while KRO/Alchemy use
-  normal graph pruning.
+  teardown. The singleton uses TypeKro-prefixed service-account/RBAC names so
+  even a controller named `jetstream` can become ready alongside a v0.33.5
+  controller; direct deploy then performs UID-leased retirement of the exact
+  legacy HelmRelease while recognizing a current NATS server itself named
+  `nack`, and KRO/Alchemy use normal graph pruning.
 - Confirmed Harbor project teardown with `purgeRepositories: true` now removes
   project immutable-tag rules before deleting repositories. TypeKro-managed
   immutability no longer blocks its own exact-name-confirmed lifecycle with

--- a/docs/api/nats/index.md
+++ b/docs/api/nats/index.md
@@ -50,7 +50,12 @@ typed connection fields. This is what allows one controller to reconcile resourc
 NATS systems without per-installation controller races.
 
 NATS server `values` remain a graph-aware passthrough map merged after safe defaults. Shared NACK
-configuration is build-time because every consumer must agree on one concrete singleton spec:
+configuration is build-time because every consumer must agree on one concrete singleton spec.
+TypeKro applies the singleton's routing and ownership invariants after custom values:
+cluster-wide watching, the controller-runtime control loop, write reconciliation, its owned
+namespace, and a release-specific service-account/RBAC identity cannot be overridden. Global
+`jetstream.nats` values are rejected because they would disable CRD-connect routing; put the
+connection on each typed JetStream resource instead. Other chart customization remains available:
 
 ```ts
 const productionNats = makeNatsBootstrap({
@@ -67,6 +72,19 @@ const productionNats = makeNatsBootstrap({
 
 Use `nackControllerBootstrap` directly only when explicitly installing, inspecting, or deleting
 the singleton owner. Normal applications should consume it through `natsBootstrap`.
+
+### Upgrading installations created by TypeKro v0.33.5
+
+v0.33.5 installed `HelmRelease/nack` inside each NATS workload Namespace. The singleton uses a
+different, deterministic service-account and ClusterRole identity, so Helm never has to adopt
+resources owned by the old release. Imperative `factory.deploy()` makes the singleton Ready first,
+then retires only an exact UID-leased v0.33.5 child whose TypeKro factory, instance, resource ID,
+and chart all match. A same-named user HelmRelease fails closed and is never deleted.
+
+KRO and Alchemy preserve the same dependency order: create the singleton before updating the
+consumer, then let their normal graph/state pruning remove the retired child. Static direct YAML
+cannot perform an ownership-checked live migration; upgrade through `factory.deploy()` or the
+original Alchemy state before returning to a render-only workflow.
 
 The former runtime `nackVersion` and `nackValues` fields remain in the generated schema so existing
 KRO CRDs can upgrade without a destructive schema transition. They are deprecated compatibility

--- a/docs/api/nats/index.md
+++ b/docs/api/nats/index.md
@@ -9,7 +9,12 @@ TypeKro installs the official NATS Helm chart with persistent JetStream storage,
 official NACK controller, and manages Stream and Consumer resources through NACK CRDs.
 
 ```ts
-import { jetStreamConsumer, jetStreamStream, natsBootstrap } from 'typekro/nats';
+import {
+  jetStreamConsumer,
+  jetStreamStream,
+  makeNatsBootstrap,
+  natsBootstrap,
+} from 'typekro/nats';
 ```
 
 ## Platform installation
@@ -34,8 +39,40 @@ that Namespace out of the RGD graph** — emitting it as a retained resource cre
 so the instance can safely live in it without a namespace/finalizer deadlock on delete. With
 `namespaceOwnership: 'external'` the Namespace is not owned (you pre-create it) and nothing is
 hoisted. Shared platform
-installations should be singleton-owned. The bootstrap pins the official `nats` and `nack` charts;
-`values` and `nackValues` are graph-aware passthrough maps merged after safe defaults.
+installations should be singleton-owned. The bootstrap pins the official `nats` chart and consumes
+one cluster-wide NACK controller through TypeKro's singleton owner boundary. Deleting one NATS
+installation therefore cannot remove the fixed-name ClusterRole or ClusterRoleBinding used by
+another installation.
+
+The shared NACK controller runs in the chart's CRD-connect mode: it has no installation-specific
+default NATS URL. Each `Stream`, `Consumer`, or `Account` identifies its NATS system through its
+typed connection fields. This is what allows one controller to reconcile resources for multiple
+NATS systems without per-installation controller races.
+
+NATS server `values` remain a graph-aware passthrough map merged after safe defaults. Shared NACK
+configuration is build-time because every consumer must agree on one concrete singleton spec:
+
+```ts
+const productionNats = makeNatsBootstrap({
+  controller: {
+    version: '0.34.0',
+    values: {
+      resources: {
+        requests: { cpu: '100m', memory: '128Mi' },
+      },
+    },
+  },
+});
+```
+
+Use `nackControllerBootstrap` directly only when explicitly installing, inspecting, or deleting
+the singleton owner. Normal applications should consume it through `natsBootstrap`.
+
+The former runtime `nackVersion` and `nackValues` fields remain in the generated schema so existing
+KRO CRDs can upgrade without a destructive schema transition. They are deprecated compatibility
+assertions: when present they must equal the build-time singleton configuration. Move those values
+to `makeNatsBootstrap({ controller: ... })`; mismatches fail closed instead of silently changing a
+cluster-shared controller from one consumer instance.
 
 JetStream is enabled with file-backed PVC storage. One replica is suitable for development. A
 production cluster normally uses three NATS replicas, three stream replicas, fast local storage,
@@ -107,6 +144,7 @@ idempotency, command results, retry classification, dead-letter semantics, and s
 behavior. JetStream publication is at-least-once; message-ID deduplication is bounded by the
 configured duplicate window and does not replace an application inbox.
 
-For authenticated installations, configure the official charts through passthrough values and
-mount credentials into NACK. Stream and Consumer factories expose `creds`, `nkey`, `servers`, and
-`jsDomain`; these are paths or routing settings, never inline credential contents.
+For authenticated installations, configure the official charts through passthrough values.
+Stream and Consumer factories expose `creds`, `nkey`, `servers`, and `jsDomain`; these are paths or
+routing settings, never inline credential contents. Because the controller is shared, prefer
+per-resource connection fields or NACK `Account` resources over controller-global credentials.

--- a/docs/api/nats/index.md
+++ b/docs/api/nats/index.md
@@ -53,7 +53,9 @@ NATS server `values` remain a graph-aware passthrough map merged after safe defa
 configuration is build-time because every consumer must agree on one concrete singleton spec.
 TypeKro applies the singleton's routing and ownership invariants after custom values:
 cluster-wide watching, the controller-runtime control loop, write reconciliation, its owned
-namespace, and a release-specific service-account/RBAC identity cannot be overridden. Global
+namespace, and a TypeKro-prefixed release-specific service-account/RBAC identity cannot be
+overridden. The prefix keeps every legal controller name disjoint from the v0.33.5
+`jetstream-controller` identity. Global
 `jetstream.nats` values are rejected because they would disable CRD-connect routing; put the
 connection on each typed JetStream resource instead. Other chart customization remains available:
 
@@ -79,7 +81,9 @@ v0.33.5 installed `HelmRelease/nack` inside each NATS workload Namespace. The si
 different, deterministic service-account and ClusterRole identity, so Helm never has to adopt
 resources owned by the old release. Imperative `factory.deploy()` makes the singleton Ready first,
 then retires only an exact UID-leased v0.33.5 child whose TypeKro factory, instance, resource ID,
-and chart all match. A same-named user HelmRelease fails closed and is never deleted.
+and chart all match. A current NATS server itself named `nack` is recognized by its distinct
+`natsHelmRelease` resource identity and is left untouched; every unrelated same-named HelmRelease
+fails closed and is never deleted.
 
 KRO and Alchemy preserve the same dependency order: create the singleton before updating the
 consumer, then let their normal graph/state pruning remove the retired child. Static direct YAML

--- a/src/factories/nats/compositions/index.ts
+++ b/src/factories/nats/compositions/index.ts
@@ -1,1 +1,2 @@
+export * from './nack-controller-bootstrap.js';
 export * from './nats-bootstrap.js';

--- a/src/factories/nats/compositions/nack-controller-bootstrap.ts
+++ b/src/factories/nats/compositions/nack-controller-bootstrap.ts
@@ -5,8 +5,8 @@ import { isKubernetesRef } from '../../../utils/type-guards.js';
 import { helmReleaseConditionSummary } from '../../helm/status.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
 import {
-  DEFAULT_NACK_VERSION,
   DEFAULT_NACK_REPOSITORY_NAME,
+  DEFAULT_NACK_VERSION,
   DEFAULT_NATS_REPOSITORY_URL,
   natsHelmRelease,
   natsHelmRepository,
@@ -17,6 +17,16 @@ import {
   NackControllerBootstrapStatusSchema,
   type NatsHelmValues,
 } from '../types.js';
+
+const NACK_VALUES_VALIDATION =
+  '(!has(self.jetstream) || (' +
+  '(!has(self.jetstream.nats) || size(self.jetstream.nats) == 0) && ' +
+  '(!has(self.jetstream.tls) || size(self.jetstream.tls) == 0) && ' +
+  '(!has(self.jetstream.additionalArgs) || self.jetstream.additionalArgs.all(arg, ' +
+  '!(arg == "-s" || arg.startsWith("-s=") || arg == "--server" || ' +
+  'arg.startsWith("--server=") || arg == "--namespace" || ' +
+  'arg.startsWith("--namespace=") || arg == "--read-only" || ' +
+  'arg.startsWith("--read-only="))))) && !has(self.rbacRules)';
 
 /**
  * Own the single cluster-wide NACK controller used by NATS installations.
@@ -49,14 +59,36 @@ export const nackControllerBootstrap = kubernetesComposition(
     const version = spec.version ?? DEFAULT_NACK_VERSION;
     const repositoryName = spec.repositoryName ?? DEFAULT_NACK_REPOSITORY_NAME;
     const repositoryUrl = spec.repositoryUrl ?? DEFAULT_NATS_REPOSITORY_URL;
-    const defaults: NatsHelmValues = {
+    if (!graphMode) {
+      validateNackControllerValues(spec.values);
+    }
+    const controllerName = graphMode
+      ? Cel.expr<string>('string(schema.spec.name) + "-controller"')
+      : `${spec.name}-controller`;
+    const protectedValues: NatsHelmValues = {
       jetstream: {
         enabled: true,
         controlLoop: true,
       },
       namespaced: false,
+      // The v0.33.5 per-installation chart used the chart default
+      // `jetstream-controller`. A distinct, deterministic identity lets this
+      // singleton become Ready before the legacy release is retired, without
+      // asking Helm to steal another release's ClusterRole/Binding.
+      nameOverride: spec.name,
+      namespaceOverride: spec.namespace,
+      serviceAccountName: controllerName,
+      useLegacyNames: false,
+      readOnly: false,
+      automountServiceAccountToken: true,
     };
-    const values = spec.values ? mergeValuesExpression(defaults, spec.values) : defaults;
+    // User values are deliberately the base. The singleton invariants are the
+    // final overlay so ordinary chart customization remains available without
+    // being able to select a single NATS server, a namespace-only watch, or a
+    // controller that never reconciles.
+    const values = spec.values
+      ? mergeValuesExpression(spec.values, protectedValues)
+      : protectedValues;
 
     namespace({
       id: 'nackNamespace',
@@ -93,8 +125,71 @@ export const nackControllerBootstrap = kubernetesComposition(
       ...helmReleaseConditionSummary(release),
       version,
     };
+  },
+  {
+    schemaFieldValidations: {
+      values: NACK_VALUES_VALIDATION,
+    },
   }
 );
 
 /** Explicit lifecycle alias for the cluster-wide NACK owner. */
 export const nackControllerInstallation = nackControllerBootstrap;
+
+function validateNackControllerValues(values: NackControllerBootstrapConfig['values']): void {
+  if (!values || typeof values !== 'object' || isKubernetesRef(values)) return;
+  const valuesRecord = values as Record<string, unknown>;
+  if (Object.hasOwn(valuesRecord, 'rbacRules')) {
+    throw new Error(
+      'NACK singleton values.rbacRules cannot replace the controller permissions. Add separate ' +
+        'RBAC resources for extra access.'
+    );
+  }
+  const jetstream = valuesRecord.jetstream;
+  if (!jetstream || typeof jetstream !== 'object' || Array.isArray(jetstream)) return;
+  const nats = (jetstream as Record<string, unknown>).nats;
+  if (
+    nats &&
+    typeof nats === 'object' &&
+    !Array.isArray(nats) &&
+    Object.keys(nats as Record<string, unknown>).length > 0
+  ) {
+    throw new Error(
+      'NACK singleton values.jetstream.nats must be omitted. The shared controller uses ' +
+        'CRD-connect mode; each JetStream resource declares its own NATS connection.'
+    );
+  }
+  const tls = (jetstream as Record<string, unknown>).tls;
+  if (
+    tls &&
+    typeof tls === 'object' &&
+    !Array.isArray(tls) &&
+    Object.keys(tls as Record<string, unknown>).length > 0
+  ) {
+    throw new Error(
+      'NACK singleton values.jetstream.tls must be omitted. Shared-controller connection ' +
+        'security belongs on each JetStream resource.'
+    );
+  }
+  const additionalArgs = (jetstream as Record<string, unknown>).additionalArgs;
+  if (
+    Array.isArray(additionalArgs) &&
+    additionalArgs.some(
+      (argument) =>
+        typeof argument === 'string' &&
+        (argument === '-s' ||
+          argument.startsWith('-s=') ||
+          argument === '--server' ||
+          argument.startsWith('--server=') ||
+          argument === '--namespace' ||
+          argument.startsWith('--namespace=') ||
+          argument === '--read-only' ||
+          argument.startsWith('--read-only='))
+    )
+  ) {
+    throw new Error(
+      'NACK singleton values.jetstream.additionalArgs cannot override server, namespace, or ' +
+        'read-only routing invariants.'
+    );
+  }
+}

--- a/src/factories/nats/compositions/nack-controller-bootstrap.ts
+++ b/src/factories/nats/compositions/nack-controller-bootstrap.ts
@@ -63,8 +63,8 @@ export const nackControllerBootstrap = kubernetesComposition(
       validateNackControllerValues(spec.values);
     }
     const controllerName = graphMode
-      ? Cel.expr<string>('string(schema.spec.name) + "-controller"')
-      : `${spec.name}-controller`;
+      ? Cel.expr<string>('"typekro-" + string(schema.spec.name) + "-controller"')
+      : `typekro-${spec.name}-controller`;
     const protectedValues: NatsHelmValues = {
       jetstream: {
         enabled: true,
@@ -72,9 +72,10 @@ export const nackControllerBootstrap = kubernetesComposition(
       },
       namespaced: false,
       // The v0.33.5 per-installation chart used the chart default
-      // `jetstream-controller`. A distinct, deterministic identity lets this
-      // singleton become Ready before the legacy release is retired, without
-      // asking Helm to steal another release's ClusterRole/Binding.
+      // `jetstream-controller`. The TypeKro prefix makes this identity
+      // disjoint for every legal controller name, including `jetstream`, so
+      // the singleton can become Ready before the legacy release is retired
+      // without asking Helm to steal another release's ClusterRole/Binding.
       nameOverride: spec.name,
       namespaceOverride: spec.namespace,
       serviceAccountName: controllerName,

--- a/src/factories/nats/compositions/nack-controller-bootstrap.ts
+++ b/src/factories/nats/compositions/nack-controller-bootstrap.ts
@@ -1,0 +1,100 @@
+import { mergeValuesExpression } from '../../../core/aspects/values-merge.js';
+import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import { Cel } from '../../../core/references/cel.js';
+import { isKubernetesRef } from '../../../utils/type-guards.js';
+import { helmReleaseConditionSummary } from '../../helm/status.js';
+import { namespace } from '../../kubernetes/core/namespace.js';
+import {
+  DEFAULT_NACK_VERSION,
+  DEFAULT_NACK_REPOSITORY_NAME,
+  DEFAULT_NATS_REPOSITORY_URL,
+  natsHelmRelease,
+  natsHelmRepository,
+} from '../resources/helm.js';
+import {
+  type NackControllerBootstrapConfig,
+  NackControllerBootstrapConfigSchema,
+  NackControllerBootstrapStatusSchema,
+  type NatsHelmValues,
+} from '../types.js';
+
+/**
+ * Own the single cluster-wide NACK controller used by NATS installations.
+ *
+ * The official chart's non-namespaced mode creates fixed-name ClusterRoles and
+ * ClusterRoleBindings. Installing the chart once per NATS cluster makes those
+ * resources cross-instance shared state: deleting one release can remove RBAC
+ * from another controller. This composition gives that state one explicit
+ * lifecycle owner. `natsBootstrap` consumes it through `singleton(...)`.
+ *
+ * The controller intentionally omits a default NATS URL, selecting NACK's
+ * `-crd-connect` mode. Each Stream, Consumer, or Account then identifies its
+ * own NATS system through its typed connection fields, allowing one controller
+ * to reconcile multiple NATS systems safely.
+ */
+export const nackControllerBootstrap = kubernetesComposition(
+  {
+    name: 'nack-controller-bootstrap',
+    kind: 'NackControllerBootstrap',
+    spec: NackControllerBootstrapConfigSchema,
+    status: NackControllerBootstrapStatusSchema,
+  },
+  (spec: NackControllerBootstrapConfig) => {
+    const graphMode = isKubernetesRef(spec.name);
+    const ownsNamespace = graphMode
+      ? Cel.expr<boolean>(
+          '!has(schema.spec.namespaceOwnership) || schema.spec.namespaceOwnership == "owned"'
+        )
+      : spec.namespaceOwnership !== 'external';
+    const version = spec.version ?? DEFAULT_NACK_VERSION;
+    const repositoryName = spec.repositoryName ?? DEFAULT_NACK_REPOSITORY_NAME;
+    const repositoryUrl = spec.repositoryUrl ?? DEFAULT_NATS_REPOSITORY_URL;
+    const defaults: NatsHelmValues = {
+      jetstream: {
+        enabled: true,
+        controlLoop: true,
+      },
+      namespaced: false,
+    };
+    const values = spec.values ? mergeValuesExpression(defaults, spec.values) : defaults;
+
+    namespace({
+      id: 'nackNamespace',
+      metadata: {
+        name: spec.namespace,
+        labels: {
+          'app.kubernetes.io/name': 'nack',
+          'app.kubernetes.io/instance': spec.name,
+          'app.kubernetes.io/managed-by': 'typekro',
+        },
+      },
+    }).withIncludeWhen(ownsNamespace);
+
+    const repository = natsHelmRepository({
+      id: 'nackHelmRepository',
+      name: repositoryName,
+      namespace: spec.namespace,
+      url: repositoryUrl,
+    });
+    const release = natsHelmRelease({
+      id: 'nackHelmRelease',
+      name: spec.name,
+      namespace: spec.namespace,
+      chart: 'nack',
+      version,
+      values,
+      repositoryName,
+      repositoryNamespace: spec.namespace,
+      repositoryUrl,
+    });
+    release.dependsOn(repository);
+
+    return {
+      ...helmReleaseConditionSummary(release),
+      version,
+    };
+  }
+);
+
+/** Explicit lifecycle alias for the cluster-wide NACK owner. */
+export const nackControllerInstallation = nackControllerBootstrap;

--- a/src/factories/nats/compositions/nack-controller-migration.ts
+++ b/src/factories/nats/compositions/nack-controller-migration.ts
@@ -4,6 +4,7 @@ import { isNotFoundError } from '../../../core/kubernetes/errors.js';
 
 const LEGACY_NACK_RELEASE = 'nack';
 const LEGACY_NACK_RESOURCE_ID = 'nackHelmRelease';
+const CURRENT_NATS_RESOURCE_ID = 'natsHelmRelease';
 const NATS_FACTORY_NAME = 'nats-bootstrap';
 
 export interface LegacyNackRetirementOptions {
@@ -46,6 +47,8 @@ export async function retireLegacyNackController(
     throw error;
   }
 
+  const classification = classifyNackRelease(live, options.instanceName);
+  if (classification === 'current-nats-server') return;
   assertLegacyNackOwnership(live, options.instanceName);
   const uid = live.metadata?.uid;
   if (!uid) {
@@ -92,11 +95,7 @@ export async function retireLegacyNackController(
 
 function assertLegacyNackOwnership(resource: KubernetesObject, instanceName: string): void {
   const tags = extractTypekroTags(resource);
-  const chartName = (
-    resource as KubernetesObject & {
-      spec?: { chart?: { spec?: { chart?: unknown } } };
-    }
-  ).spec?.chart?.spec?.chart;
+  const chartName = chart(resource);
   const problems = [
     ...(tags.factoryName === NATS_FACTORY_NAME
       ? []
@@ -114,6 +113,45 @@ function assertLegacyNackOwnership(resource: KubernetesObject, instanceName: str
         `(${problems.join(', ')}).`
     );
   }
+}
+
+function classifyNackRelease(
+  resource: KubernetesObject,
+  instanceName: string
+): 'legacy-controller' | 'current-nats-server' | 'unrelated' {
+  const tags = extractTypekroTags(resource);
+  const chartName = chart(resource);
+  if (
+    tags.factoryName === NATS_FACTORY_NAME &&
+    tags.instanceName === instanceName &&
+    tags.resourceId === LEGACY_NACK_RESOURCE_ID &&
+    chartName === 'nack'
+  ) {
+    return 'legacy-controller';
+  }
+  // A current NATS instance may itself be named `nack`, which means the fixed
+  // legacy lookup finds the successfully deployed server HelmRelease. This is
+  // not an ownership mismatch and there is no legacy controller left to
+  // retire. Match every current identity component before treating it as
+  // absent so a same-named foreign release still fails closed.
+  if (
+    resource.metadata?.name === LEGACY_NACK_RELEASE &&
+    tags.factoryName === NATS_FACTORY_NAME &&
+    tags.instanceName === instanceName &&
+    tags.resourceId === CURRENT_NATS_RESOURCE_ID &&
+    chartName === 'nats'
+  ) {
+    return 'current-nats-server';
+  }
+  return 'unrelated';
+}
+
+function chart(resource: KubernetesObject): unknown {
+  return (
+    resource as KubernetesObject & {
+      spec?: { chart?: { spec?: { chart?: unknown } } };
+    }
+  ).spec?.chart?.spec?.chart;
 }
 
 function abortableDelay(milliseconds: number, signal?: AbortSignal): Promise<void> {

--- a/src/factories/nats/compositions/nack-controller-migration.ts
+++ b/src/factories/nats/compositions/nack-controller-migration.ts
@@ -1,0 +1,135 @@
+import type { KubernetesObject, KubernetesObjectApi } from '@kubernetes/client-node';
+import { extractTypekroTags } from '../../../core/deployment/resource-tagging.js';
+import { isNotFoundError } from '../../../core/kubernetes/errors.js';
+
+const LEGACY_NACK_RELEASE = 'nack';
+const LEGACY_NACK_RESOURCE_ID = 'nackHelmRelease';
+const NATS_FACTORY_NAME = 'nats-bootstrap';
+
+export interface LegacyNackRetirementOptions {
+  readonly namespace: string;
+  readonly instanceName: string;
+  readonly kubernetesApi: KubernetesObjectApi;
+  readonly timeout?: number;
+  readonly abortSignal?: AbortSignal;
+}
+
+/**
+ * Retire the v0.33.5 instance-owned NACK HelmRelease after the replacement
+ * singleton is Ready.
+ *
+ * This is intentionally ownership- and UID-leased. A same-named user release,
+ * a release belonging to another TypeKro instance, or a replacement object
+ * appearing during deletion is never adopted or deleted.
+ */
+export async function retireLegacyNackController(
+  options: LegacyNackRetirementOptions
+): Promise<void> {
+  const identity: {
+    apiVersion: string;
+    kind: string;
+    metadata: { name: string; namespace: string };
+  } = {
+    apiVersion: 'helm.toolkit.fluxcd.io/v2',
+    kind: 'HelmRelease',
+    metadata: {
+      name: LEGACY_NACK_RELEASE,
+      namespace: options.namespace,
+    },
+  };
+
+  let live: KubernetesObject;
+  try {
+    live = await options.kubernetesApi.read(identity);
+  } catch (error: unknown) {
+    if (isNotFoundError(error)) return;
+    throw error;
+  }
+
+  assertLegacyNackOwnership(live, options.instanceName);
+  const uid = live.metadata?.uid;
+  if (!uid) {
+    throw new Error(
+      `Refusing to retire legacy NACK HelmRelease ${options.namespace}/${LEGACY_NACK_RELEASE}: ` +
+        'metadata.uid is missing.'
+    );
+  }
+
+  await options.kubernetesApi.delete(
+    live,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'Foreground',
+    { preconditions: { uid } }
+  );
+
+  const timeout = options.timeout ?? 300_000;
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeout) {
+    options.abortSignal?.throwIfAborted();
+    try {
+      const current = await options.kubernetesApi.read(identity);
+      if (current.metadata?.uid && current.metadata.uid !== uid) {
+        throw new Error(
+          `Refusing to continue legacy NACK retirement for ${options.namespace}/${LEGACY_NACK_RELEASE}: ` +
+            `UID changed from ${uid} to ${current.metadata.uid}.`
+        );
+      }
+    } catch (error: unknown) {
+      if (isNotFoundError(error)) return;
+      throw error;
+    }
+    await abortableDelay(1_000, options.abortSignal);
+  }
+
+  throw new Error(
+    `Timed out after ${timeout}ms retiring legacy NACK HelmRelease ` +
+      `${options.namespace}/${LEGACY_NACK_RELEASE} (uid ${uid}).`
+  );
+}
+
+function assertLegacyNackOwnership(resource: KubernetesObject, instanceName: string): void {
+  const tags = extractTypekroTags(resource);
+  const chartName = (
+    resource as KubernetesObject & {
+      spec?: { chart?: { spec?: { chart?: unknown } } };
+    }
+  ).spec?.chart?.spec?.chart;
+  const problems = [
+    ...(tags.factoryName === NATS_FACTORY_NAME
+      ? []
+      : [`factory=${tags.factoryName ?? '<missing>'}`]),
+    ...(tags.instanceName === instanceName ? [] : [`instance=${tags.instanceName ?? '<missing>'}`]),
+    ...(tags.resourceId === LEGACY_NACK_RESOURCE_ID
+      ? []
+      : [`resource-id=${tags.resourceId ?? '<missing>'}`]),
+    ...(chartName === 'nack' ? [] : [`chart=${String(chartName ?? '<missing>')}`]),
+  ];
+  if (problems.length > 0) {
+    throw new Error(
+      `Refusing to retire HelmRelease ${resource.metadata?.namespace}/${resource.metadata?.name}: ` +
+        `it is not the v0.33.5 NACK child owned by ${NATS_FACTORY_NAME}/${instanceName} ` +
+        `(${problems.join(', ')}).`
+    );
+  }
+}
+
+function abortableDelay(milliseconds: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+  }
+  signal.throwIfAborted();
+  return new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason ?? new DOMException('The operation was aborted', 'AbortError'));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, milliseconds);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/src/factories/nats/compositions/nats-bootstrap.ts
+++ b/src/factories/nats/compositions/nats-bootstrap.ts
@@ -1,10 +1,12 @@
 import { mergeValuesExpression } from '../../../core/aspects/values-merge.js';
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { Cel } from '../../../core/references/cel.js';
+import { singleton, stableSerialize } from '../../../core/singleton/singleton.js';
 import { isKubernetesRef } from '../../../utils/type-guards.js';
 import { helmReleaseConditionSummary } from '../../helm/status.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
 import {
+  DEFAULT_NACK_REPOSITORY_NAME,
   DEFAULT_NACK_VERSION,
   DEFAULT_NATS_REPOSITORY_NAME,
   DEFAULT_NATS_REPOSITORY_URL,
@@ -14,152 +16,179 @@ import {
 } from '../resources/helm.js';
 import {
   type NatsBootstrapConfig,
+  type NatsBootstrapBuildOptions,
+  type NackControllerBootstrapConfigSchema,
   NatsBootstrapConfigSchema,
   NatsBootstrapStatusSchema,
   type NatsHelmValues,
 } from '../types.js';
+import { nackControllerBootstrap } from './nack-controller-bootstrap.js';
 
 const DEFAULT_NATS_NAMESPACE = 'nats-system';
+const DEFAULT_NACK_NAMESPACE = 'typekro-nack-system';
 
-/** Install an official NATS cluster with JetStream and the NACK controller. */
-export const natsBootstrap = kubernetesComposition(
-  {
-    name: 'nats-bootstrap',
-    kind: 'NatsBootstrap',
-    spec: NatsBootstrapConfigSchema,
-    status: NatsBootstrapStatusSchema,
-  },
-  (spec: NatsBootstrapConfig) => {
-    const graphMode = isKubernetesRef(spec.name);
-    const targetNamespace = graphMode
-      ? Cel.expr<string>('has(schema.spec.namespace) ? schema.spec.namespace : "nats-system"')
-      : (spec.namespace ?? DEFAULT_NATS_NAMESPACE);
-    const ownsTargetNamespace = graphMode
-      ? Cel.expr<boolean>(
-          '!has(schema.spec.namespaceOwnership) || schema.spec.namespaceOwnership == "owned"'
-        )
-      : spec.namespaceOwnership !== 'external';
-    const repositoryName = spec.repositoryName ?? DEFAULT_NATS_REPOSITORY_NAME;
-    const repositoryNamespace = spec.repositoryNamespace ?? targetNamespace;
-    const repositoryUrl = spec.repositoryUrl ?? DEFAULT_NATS_REPOSITORY_URL;
-    if (!graphMode) {
-      validateReplicaCount(spec.replicas);
-    }
-    const replicas = graphMode
-      ? Cel.expr<number>('has(schema.spec.replicas) ? schema.spec.replicas : 1')
-      : (spec.replicas ?? 1);
-    const clusteringEnabled = graphMode ? Cel.expr<boolean>(replicas, ' > 1') : replicas > 1;
-    const pvcWhenDeleted = graphMode
-      ? Cel.expr<'Delete' | 'Retain'>(
-          'has(schema.spec.pvcRetentionPolicy) && schema.spec.pvcRetentionPolicy == "delete" ? "Delete" : "Retain"'
-        )
-      : spec.pvcRetentionPolicy === 'delete'
-        ? 'Delete'
-        : 'Retain';
-    const endpoint = graphMode
-      ? Cel.expr<string>(
-          '"nats://" + string(schema.spec.name) + "." + string(has(schema.spec.namespace) ? schema.spec.namespace : "nats-system") + ".svc:4222"'
-        )
-      : `nats://${spec.name}.${targetNamespace}.svc:4222`;
-    const serverDefaults: NatsHelmValues = {
-      // Keep the chart Service identity identical to the public endpoint for
-      // every release name. Without this, Helm appends "-nats" whenever the
-      // release name itself does not contain the chart name.
-      fullnameOverride: spec.name,
-      config: {
-        cluster: { enabled: clusteringEnabled, replicas },
-        jetstream: {
-          enabled: true,
-          fileStore: {
+/**
+ * Build a NATS installation composition backed by one cluster-wide NACK owner.
+ *
+ * NACK ownership is deliberately build-time. Every consumer of the singleton
+ * must agree on an identical concrete controller spec.
+ */
+export function makeNatsBootstrap(options: NatsBootstrapBuildOptions = {}) {
+  const controllerSingletonId = options.controller?.singletonId ?? 'nack-controller';
+  const controllerSpec: typeof NackControllerBootstrapConfigSchema.infer = {
+    name: options.controller?.name ?? 'nack',
+    namespace: options.controller?.namespace ?? DEFAULT_NACK_NAMESPACE,
+    namespaceOwnership: options.controller?.namespaceOwnership ?? 'owned',
+    version: options.controller?.version ?? DEFAULT_NACK_VERSION,
+    repositoryName: options.controller?.repositoryName ?? DEFAULT_NACK_REPOSITORY_NAME,
+    repositoryUrl: options.controller?.repositoryUrl ?? DEFAULT_NATS_REPOSITORY_URL,
+    ...(options.controller?.values ? { values: options.controller.values } : {}),
+  };
+
+  return kubernetesComposition(
+    {
+      name: 'nats-bootstrap',
+      kind: 'NatsBootstrap',
+      spec: NatsBootstrapConfigSchema,
+      status: NatsBootstrapStatusSchema,
+    },
+    (spec: NatsBootstrapConfig) => {
+      const graphMode = isKubernetesRef(spec.name);
+      const targetNamespace = graphMode
+        ? Cel.expr<string>('has(schema.spec.namespace) ? schema.spec.namespace : "nats-system"')
+        : (spec.namespace ?? DEFAULT_NATS_NAMESPACE);
+      const ownsTargetNamespace = graphMode
+        ? Cel.expr<boolean>(
+            '!has(schema.spec.namespaceOwnership) || schema.spec.namespaceOwnership == "owned"'
+          )
+        : spec.namespaceOwnership !== 'external';
+      const repositoryName = spec.repositoryName ?? DEFAULT_NATS_REPOSITORY_NAME;
+      const repositoryNamespace = spec.repositoryNamespace ?? targetNamespace;
+      const repositoryUrl = spec.repositoryUrl ?? DEFAULT_NATS_REPOSITORY_URL;
+      if (!graphMode) {
+        validateReplicaCount(spec.replicas);
+        validateLegacyControllerConfig(spec, controllerSpec);
+      }
+      const replicas = graphMode
+        ? Cel.expr<number>('has(schema.spec.replicas) ? schema.spec.replicas : 1')
+        : (spec.replicas ?? 1);
+      const clusteringEnabled = graphMode ? Cel.expr<boolean>(replicas, ' > 1') : replicas > 1;
+      const pvcWhenDeleted = graphMode
+        ? Cel.expr<'Delete' | 'Retain'>(
+            'has(schema.spec.pvcRetentionPolicy) && schema.spec.pvcRetentionPolicy == "delete" ? "Delete" : "Retain"'
+          )
+        : spec.pvcRetentionPolicy === 'delete'
+          ? 'Delete'
+          : 'Retain';
+      const endpoint = graphMode
+        ? Cel.expr<string>(
+            '"nats://" + string(schema.spec.name) + "." + string(has(schema.spec.namespace) ? schema.spec.namespace : "nats-system") + ".svc:4222"'
+          )
+        : `nats://${spec.name}.${targetNamespace}.svc:4222`;
+      const serverDefaults: NatsHelmValues = {
+        // Keep the chart Service identity identical to the public endpoint for
+        // every release name. Without this, Helm appends "-nats" whenever the
+        // release name itself does not contain the chart name.
+        fullnameOverride: spec.name,
+        config: {
+          cluster: { enabled: clusteringEnabled, replicas },
+          jetstream: {
             enabled: true,
-            pvc: {
+            fileStore: {
               enabled: true,
-              size: spec.storageSize ?? '10Gi',
-              ...(spec.storageClassName && { storageClassName: spec.storageClassName }),
+              pvc: {
+                enabled: true,
+                size: spec.storageSize ?? '10Gi',
+                ...(spec.storageClassName && { storageClassName: spec.storageClassName }),
+              },
             },
           },
         },
-      },
-      natsBox: { enabled: true },
-      statefulSet: {
-        merge: {
-          // The official chart merges this object into the StatefulSet root,
-          // so Kubernetes spec fields must remain nested below `spec`.
-          // Emitting the retention policy directly below `merge` produces an
-          // invalid top-level StatefulSet field that Flux cannot server-side
-          // apply.
-          spec: {
-            persistentVolumeClaimRetentionPolicy: {
-              whenDeleted: pvcWhenDeleted,
-              whenScaled: 'Retain',
+        natsBox: { enabled: true },
+        statefulSet: {
+          merge: {
+            // The official chart merges this object into the StatefulSet root,
+            // so Kubernetes spec fields must remain nested below `spec`.
+            // Emitting the retention policy directly below `merge` produces an
+            // invalid top-level StatefulSet field that Flux cannot server-side
+            // apply.
+            spec: {
+              persistentVolumeClaimRetentionPolicy: {
+                whenDeleted: pvcWhenDeleted,
+                whenScaled: 'Retain',
+              },
             },
           },
         },
-      },
-    };
-    const nackDefaults: NatsHelmValues = {
-      jetstream: { enabled: true, nats: { url: endpoint }, controlLoop: true },
-      namespaced: false,
-    };
-    const serverValues = spec.values
-      ? mergeValuesExpression(serverDefaults, spec.values)
-      : serverDefaults;
-    const nackValues = spec.nackValues
-      ? mergeValuesExpression(nackDefaults, spec.nackValues)
-      : nackDefaults;
+      };
+      const serverValues = spec.values
+        ? mergeValuesExpression(serverDefaults, spec.values)
+        : serverDefaults;
 
-    const _namespace = namespace({
-      id: 'natsNamespace',
-      metadata: {
-        name: targetNamespace,
-        labels: {
-          'app.kubernetes.io/name': 'nats',
-          'app.kubernetes.io/instance': spec.name,
-          'app.kubernetes.io/managed-by': 'typekro',
+      const _namespace = namespace({
+        id: 'natsNamespace',
+        metadata: {
+          name: targetNamespace,
+          labels: {
+            'app.kubernetes.io/name': 'nats',
+            'app.kubernetes.io/instance': spec.name,
+            'app.kubernetes.io/managed-by': 'typekro',
+          },
         },
+      }).withIncludeWhen(ownsTargetNamespace);
+      const _repository = natsHelmRepository({
+        id: 'natsHelmRepository',
+        name: repositoryName,
+        namespace: repositoryNamespace,
+        url: repositoryUrl,
+      });
+      const server = natsHelmRelease({
+        id: 'natsHelmRelease',
+        name: spec.name,
+        namespace: targetNamespace,
+        chart: 'nats',
+        version: spec.version ?? DEFAULT_NATS_VERSION,
+        values: serverValues,
+        repositoryName,
+        repositoryNamespace,
+        repositoryUrl,
+      });
+      const controller = singleton(nackControllerBootstrap, {
+        id: controllerSingletonId,
+        spec: controllerSpec,
+      });
+      // The sourceRef values are Kubernetes identity, while these explicit
+      // graph edges are lifecycle authority: repository before releases on
+      // create, releases before repository on destroy.
+      server.dependsOn(_repository);
+      const serverStatus = helmReleaseConditionSummary(server);
+      const ready = Cel.expr<boolean>(serverStatus.ready, ' && ', controller.status.ready);
+      const failed = Cel.expr<boolean>(serverStatus.failed, ' || ', controller.status.failed);
+      return {
+        ready,
+        failed,
+        phase: Cel.expr<'Ready' | 'Installing' | 'Failed'>(
+          failed,
+          ' ? "Failed" : (',
+          ready,
+          ' ? "Ready" : "Installing")'
+        ),
+        serverVersion: spec.version ?? DEFAULT_NATS_VERSION,
+        controllerVersion: controllerSpec.version ?? DEFAULT_NACK_VERSION,
+        endpoint,
+      };
+    },
+    {
+      schemaFieldValidations: {
+        nackVersion: `self == ${JSON.stringify(controllerSpec.version ?? DEFAULT_NACK_VERSION)}`,
+        nackValues: `self == ${JSON.stringify(controllerSpec.values ?? {})}`,
       },
-    }).withIncludeWhen(ownsTargetNamespace);
-    const _repository = natsHelmRepository({
-      id: 'natsHelmRepository',
-      name: repositoryName,
-      namespace: repositoryNamespace,
-      url: repositoryUrl,
-    });
-    const server = natsHelmRelease({
-      id: 'natsHelmRelease',
-      name: spec.name,
-      namespace: targetNamespace,
-      chart: 'nats',
-      version: spec.version ?? DEFAULT_NATS_VERSION,
-      values: serverValues,
-      repositoryName,
-      repositoryNamespace,
-      repositoryUrl,
-    });
-    const controller = natsHelmRelease({
-      id: 'nackHelmRelease',
-      name: 'nack',
-      namespace: targetNamespace,
-      chart: 'nack',
-      version: spec.nackVersion ?? DEFAULT_NACK_VERSION,
-      values: nackValues,
-      repositoryName,
-      repositoryNamespace,
-      repositoryUrl,
-    });
-    // The sourceRef values are Kubernetes identity, while these explicit
-    // graph edges are lifecycle authority: repository before releases on
-    // create, releases before repository on destroy.
-    server.dependsOn(_repository);
-    controller.dependsOn(_repository);
-    return {
-      ...helmReleaseConditionSummary(server, controller),
-      serverVersion: spec.version ?? DEFAULT_NATS_VERSION,
-      controllerVersion: spec.nackVersion ?? DEFAULT_NACK_VERSION,
-      endpoint,
-    };
-  }
-);
+    }
+  );
+}
+
+/** Install an official NATS cluster backed by the shared NACK controller. */
+export const natsBootstrap = makeNatsBootstrap();
 
 /** Explicit lifecycle alias for shared platform ownership. */
 export const natsInstallation = natsBootstrap;
@@ -167,5 +196,26 @@ export const natsInstallation = natsBootstrap;
 function validateReplicaCount(value: number | undefined): void {
   if (value !== undefined && (!Number.isInteger(value) || value < 1)) {
     throw new Error('NATS replicas must be an integer greater than or equal to 1.');
+  }
+}
+
+function validateLegacyControllerConfig(
+  spec: NatsBootstrapConfig,
+  controllerSpec: typeof NackControllerBootstrapConfigSchema.infer
+): void {
+  if (spec.nackVersion !== undefined && spec.nackVersion !== controllerSpec.version) {
+    throw new Error(
+      'nackVersion is now build-time singleton configuration. Move it to ' +
+        'makeNatsBootstrap({ controller: { version } }).'
+    );
+  }
+  if (
+    spec.nackValues !== undefined &&
+    stableSerialize(spec.nackValues) !== stableSerialize(controllerSpec.values ?? {})
+  ) {
+    throw new Error(
+      'nackValues is now build-time singleton configuration. Move it to ' +
+        'makeNatsBootstrap({ controller: { values } }).'
+    );
   }
 }

--- a/src/factories/nats/compositions/nats-bootstrap.ts
+++ b/src/factories/nats/compositions/nats-bootstrap.ts
@@ -1,7 +1,17 @@
 import { mergeValuesExpression } from '../../../core/aspects/values-merge.js';
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
+import {
+  createBunCompatibleKubernetesObjectApi,
+  getKubeConfig,
+} from '../../../core/kubernetes/index.js';
 import { Cel } from '../../../core/references/cel.js';
 import { singleton, stableSerialize } from '../../../core/singleton/singleton.js';
+import type {
+  DirectResourceFactory,
+  KroResourceFactory,
+  PublicFactoryOptions,
+  ResourceFactoryDeployOptions,
+} from '../../../core/types/deployment.js';
 import { isKubernetesRef } from '../../../utils/type-guards.js';
 import { helmReleaseConditionSummary } from '../../helm/status.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
@@ -15,17 +25,20 @@ import {
   natsHelmRepository,
 } from '../resources/helm.js';
 import {
-  type NatsBootstrapConfig,
-  type NatsBootstrapBuildOptions,
   type NackControllerBootstrapConfigSchema,
+  type NatsBootstrapBuildOptions,
+  type NatsBootstrapConfig,
   NatsBootstrapConfigSchema,
   NatsBootstrapStatusSchema,
   type NatsHelmValues,
 } from '../types.js';
 import { nackControllerBootstrap } from './nack-controller-bootstrap.js';
+import { retireLegacyNackController } from './nack-controller-migration.js';
 
 const DEFAULT_NATS_NAMESPACE = 'nats-system';
 const DEFAULT_NACK_NAMESPACE = 'typekro-nack-system';
+type NatsBootstrapSchemaSpec = typeof NatsBootstrapConfigSchema.infer;
+type NatsBootstrapSchemaStatus = typeof NatsBootstrapStatusSchema.infer;
 
 /**
  * Build a NATS installation composition backed by one cluster-wide NACK owner.
@@ -45,7 +58,7 @@ export function makeNatsBootstrap(options: NatsBootstrapBuildOptions = {}) {
     ...(options.controller?.values ? { values: options.controller.values } : {}),
   };
 
-  return kubernetesComposition(
+  const composition = kubernetesComposition(
     {
       name: 'nats-bootstrap',
       kind: 'NatsBootstrap',
@@ -181,10 +194,71 @@ export function makeNatsBootstrap(options: NatsBootstrapBuildOptions = {}) {
     {
       schemaFieldValidations: {
         nackVersion: `self == ${JSON.stringify(controllerSpec.version ?? DEFAULT_NACK_VERSION)}`,
-        nackValues: `self == ${JSON.stringify(controllerSpec.values ?? {})}`,
+        // Open-object fields have a structural schema type while CEL literals
+        // are maps. Widen both operands before comparison so Kubernetes CEL
+        // can validate the deprecated compatibility assertion.
+        nackValues: `dyn(self) == dyn(${JSON.stringify(controllerSpec.values ?? {})})`,
       },
     }
   );
+
+  const originalFactory = composition.factory.bind(composition);
+  function natsBootstrapFactory(
+    mode: 'kro',
+    factoryOptions?: PublicFactoryOptions
+  ): KroResourceFactory<NatsBootstrapSchemaSpec, NatsBootstrapSchemaStatus>;
+  function natsBootstrapFactory(
+    mode: 'direct',
+    factoryOptions?: PublicFactoryOptions
+  ): DirectResourceFactory<NatsBootstrapSchemaSpec, NatsBootstrapSchemaStatus>;
+  function natsBootstrapFactory(
+    mode: 'kro' | 'direct',
+    factoryOptions?: PublicFactoryOptions
+  ):
+    | KroResourceFactory<NatsBootstrapSchemaSpec, NatsBootstrapSchemaStatus>
+    | DirectResourceFactory<NatsBootstrapSchemaSpec, NatsBootstrapSchemaStatus> {
+    if (mode === 'kro') {
+      return originalFactory('kro', factoryOptions);
+    }
+
+    const factory = originalFactory('direct', factoryOptions);
+    const originalDeploy = factory.deploy.bind(factory);
+    factory.deploy = async (
+      spec: NatsBootstrapSchemaSpec,
+      deployOptions?: ResourceFactoryDeployOptions
+    ) => {
+      // Direct mode does not prune graph nodes removed by a library upgrade.
+      // The singleton owner is synchronously made Ready by originalDeploy()
+      // before this retirement runs, so the v0.33.5 controller is never
+      // removed until its replacement can reconcile.
+      const deployed = await originalDeploy(spec, deployOptions);
+      const kubeConfig = factoryOptions?.kubeConfig ?? getKubeConfig();
+      const abortSignals = [factoryOptions?.abortSignal, deployOptions?.abortSignal].filter(
+        (signal): signal is AbortSignal => signal !== undefined
+      );
+      const abortSignal =
+        abortSignals.length > 1
+          ? AbortSignal.any(abortSignals)
+          : abortSignals.length === 1
+            ? abortSignals[0]
+            : undefined;
+      await retireLegacyNackController({
+        namespace: spec.namespace ?? DEFAULT_NATS_NAMESPACE,
+        instanceName: spec.name,
+        kubernetesApi: createBunCompatibleKubernetesObjectApi(
+          kubeConfig,
+          factoryOptions?.httpTimeouts
+        ),
+        ...(factoryOptions?.timeout !== undefined ? { timeout: factoryOptions.timeout } : {}),
+        ...(abortSignal ? { abortSignal } : {}),
+      });
+      return deployed;
+    };
+    return factory;
+  }
+
+  (composition as { factory: typeof composition.factory }).factory = natsBootstrapFactory;
+  return composition;
 }
 
 /** Install an official NATS cluster backed by the shared NACK controller. */

--- a/src/factories/nats/resources/helm.ts
+++ b/src/factories/nats/resources/helm.ts
@@ -8,6 +8,7 @@ import type { NatsHelmValues } from '../types.js';
 
 export const DEFAULT_NATS_REPOSITORY_URL = 'https://nats-io.github.io/k8s/helm/charts/';
 export const DEFAULT_NATS_REPOSITORY_NAME = 'nats';
+export const DEFAULT_NACK_REPOSITORY_NAME = 'nack-controller';
 export const DEFAULT_NATS_VERSION = '2.14.0';
 export const DEFAULT_NACK_VERSION = '0.34.0';
 

--- a/src/factories/nats/types.ts
+++ b/src/factories/nats/types.ts
@@ -6,6 +6,10 @@ export const NatsBootstrapConfigSchema = type({
   'namespace?': 'string',
   'namespaceOwnership?': '"owned" | "external"',
   'version?': 'string',
+  /**
+   * @deprecated Configure the shared controller through
+   * `makeNatsBootstrap({ controller: { version } })`.
+   */
   'nackVersion?': 'string',
   'repositoryName?': 'string',
   'repositoryNamespace?': 'string',
@@ -15,6 +19,10 @@ export const NatsBootstrapConfigSchema = type({
   'storageClassName?': 'string',
   'pvcRetentionPolicy?': '"retain" | "delete"',
   'values?': 'Record<string, unknown>',
+  /**
+   * @deprecated Configure the shared controller through
+   * `makeNatsBootstrap({ controller: { values } })`.
+   */
   'nackValues?': 'Record<string, unknown>',
 });
 
@@ -26,6 +34,27 @@ export type NatsBootstrapConfig = Omit<
   nackValues?: TypeKroChartValue<Record<string, unknown>>;
 };
 
+/**
+ * Build-time ownership settings for the shared NACK controller.
+ *
+ * These cannot be runtime fields because every NATS consumer must resolve to
+ * one identical singleton owner. A schema-proxy value could make the shared
+ * controller's identity depend on an individual consumer instance.
+ */
+export interface NatsBootstrapBuildOptions {
+  readonly controller?: {
+    /** Stable TypeKro singleton identity shared by every consumer. */
+    readonly singletonId?: string;
+    readonly name?: string;
+    readonly namespace?: string;
+    readonly namespaceOwnership?: 'owned' | 'external';
+    readonly version?: string;
+    readonly repositoryName?: string;
+    readonly repositoryUrl?: string;
+    readonly values?: Record<string, unknown>;
+  };
+}
+
 export const NatsBootstrapStatusSchema = type({
   ready: 'boolean',
   failed: 'boolean',
@@ -36,6 +65,39 @@ export const NatsBootstrapStatusSchema = type({
 });
 
 export type NatsBootstrapStatus = typeof NatsBootstrapStatusSchema.infer;
+
+/**
+ * Configuration for the cluster-wide NACK controller owner.
+ *
+ * NACK's non-namespaced chart resources include fixed-name ClusterRoles and
+ * ClusterRoleBindings. TypeKro therefore owns exactly one controller and lets
+ * every NATS installation reference it through `singleton(...)`.
+ */
+export const NackControllerBootstrapConfigSchema = type({
+  name: 'string',
+  namespace: 'string',
+  'namespaceOwnership?': '"owned" | "external"',
+  'version?': 'string',
+  'repositoryName?': 'string',
+  'repositoryUrl?': 'string',
+  'values?': 'Record<string, unknown>',
+});
+
+export type NackControllerBootstrapConfig = Omit<
+  typeof NackControllerBootstrapConfigSchema.infer,
+  'values'
+> & {
+  values?: TypeKroChartValue<Record<string, unknown>>;
+};
+
+export const NackControllerBootstrapStatusSchema = type({
+  ready: 'boolean',
+  failed: 'boolean',
+  phase: '"Ready" | "Installing" | "Failed"',
+  version: 'string',
+});
+
+export type NackControllerBootstrapStatus = typeof NackControllerBootstrapStatusSchema.infer;
 
 export const JetStreamStreamConfigSchema = type({
   name: 'string',

--- a/test/factories/nats/factory-modes.test.ts
+++ b/test/factories/nats/factory-modes.test.ts
@@ -139,9 +139,82 @@ describe('NATS and JetStream factories', () => {
     expect(yaml).toContain(`version: ${DEFAULT_NACK_VERSION}`);
     expect(yaml).toMatch(/jetstream:\s*\n\s+controlLoop: true\s*\n\s+enabled: true/);
     expect(yaml).toContain('namespaced: false');
+    expect(yaml).toContain('nameOverride: nack');
+    expect(yaml).toContain('namespaceOverride: typekro-nack-system');
+    expect(yaml).toContain('serviceAccountName: nack-controller');
+    expect(yaml).toContain('useLegacyNames: false');
+    expect(yaml).toContain('readOnly: false');
+    expect(yaml).toContain('automountServiceAccountToken: true');
     // Omitting jetstream.nats.url selects NACK's official -crd-connect mode.
     // Stream/Consumer/Account resources carry their own target connection.
     expect(yaml).not.toContain('url: nats://');
+  });
+
+  it('protects singleton routing and lifecycle values from Helm passthrough overrides', async () => {
+    const customized = makeNatsBootstrap({
+      controller: {
+        values: {
+          namespaced: true,
+          readOnly: true,
+          nameOverride: 'unsafe-name',
+          namespaceOverride: 'unsafe-namespace',
+          serviceAccountName: 'jetstream-controller',
+          useLegacyNames: true,
+          jetstream: {
+            enabled: false,
+            controlLoop: false,
+          },
+          resources: { requests: { cpu: '100m' } },
+        },
+      },
+    });
+    const declarations = await customized
+      .factory('direct', { namespace: 'typekro-system', waitForReady: false })
+      .toAlchemyResources({
+        name: 'application-events',
+        namespace: 'application-system',
+        namespaceOwnership: 'external',
+      });
+    const controller = declarations.find(
+      (declaration) => declaration.props.resourceId === 'nackHelmRelease'
+    );
+
+    expect(controller?.props.resource.spec?.values).toMatchObject({
+      namespaced: false,
+      readOnly: false,
+      automountServiceAccountToken: true,
+      nameOverride: 'nack',
+      namespaceOverride: 'typekro-nack-system',
+      serviceAccountName: 'nack-controller',
+      useLegacyNames: false,
+      jetstream: {
+        enabled: true,
+        controlLoop: true,
+      },
+      resources: { requests: { cpu: '100m' } },
+    });
+
+    expect(() =>
+      nackControllerBootstrap.factory('direct', { namespace: 'typekro-singletons' }).toYaml({
+        name: 'nack',
+        namespace: 'typekro-nack-system',
+        values: {
+          jetstream: {
+            nats: { url: 'nats://one.example:4222' },
+          },
+        },
+      })
+    ).toThrow(/values\.jetstream\.nats must be omitted/);
+
+    const rgd = nackControllerBootstrap
+      .factory('kro', { namespace: 'typekro-singletons' })
+      .toYaml();
+    expect(rgd).toContain('values: object | validation="');
+    expect(rgd).toContain('size(self.jetstream.nats) == 0');
+    expect(rgd).toContain('size(self.jetstream.tls) == 0');
+    expect(rgd).toContain('arg.startsWith');
+    expect(rgd).toContain('!has(self.rbacRules)');
+    expect(rgd).toContain('"serviceAccountName": string(schema.spec.name) + "-controller"');
   });
 
   it('serializes bootstrap in KRO mode and hoists an owned workload Namespace out of the graph', () => {
@@ -157,7 +230,7 @@ describe('NATS and JetStream factories', () => {
     expect(rgd).toContain('replicas: integer | minimum=1');
     expect(rgd).toContain('pvcRetentionPolicy: string | enum="delete,retain"');
     expect(rgd).toContain('namespaceOwnership: string | enum="external,owned"');
-    expect(rgd).toContain('nackValues: object | validation="self == {}"');
+    expect(rgd).toContain('nackValues: object | validation="dyn(self) == dyn({})"');
     expect(rgd).toContain('nackVersion: string | validation="self == \\"0.34.0\\""');
     expect(rgd).toContain('schema.spec.pvcRetentionPolicy');
     expect(rgd).toContain('Delete');

--- a/test/factories/nats/factory-modes.test.ts
+++ b/test/factories/nats/factory-modes.test.ts
@@ -141,7 +141,7 @@ describe('NATS and JetStream factories', () => {
     expect(yaml).toContain('namespaced: false');
     expect(yaml).toContain('nameOverride: nack');
     expect(yaml).toContain('namespaceOverride: typekro-nack-system');
-    expect(yaml).toContain('serviceAccountName: nack-controller');
+    expect(yaml).toContain('serviceAccountName: typekro-nack-controller');
     expect(yaml).toContain('useLegacyNames: false');
     expect(yaml).toContain('readOnly: false');
     expect(yaml).toContain('automountServiceAccountToken: true');
@@ -185,7 +185,7 @@ describe('NATS and JetStream factories', () => {
       automountServiceAccountToken: true,
       nameOverride: 'nack',
       namespaceOverride: 'typekro-nack-system',
-      serviceAccountName: 'nack-controller',
+      serviceAccountName: 'typekro-nack-controller',
       useLegacyNames: false,
       jetstream: {
         enabled: true,
@@ -214,7 +214,21 @@ describe('NATS and JetStream factories', () => {
     expect(rgd).toContain('size(self.jetstream.tls) == 0');
     expect(rgd).toContain('arg.startsWith');
     expect(rgd).toContain('!has(self.rbacRules)');
-    expect(rgd).toContain('"serviceAccountName": string(schema.spec.name) + "-controller"');
+    expect(rgd).toContain(
+      '"serviceAccountName": "typekro-" + string(schema.spec.name) + "-controller"'
+    );
+  });
+
+  it('keeps every controller name disjoint from the v0.33.5 jetstream-controller identity', () => {
+    const yaml = nackControllerBootstrap
+      .factory('direct', { namespace: 'typekro-singletons' })
+      .toYaml({
+        name: 'jetstream',
+        namespace: 'typekro-nack-system',
+      });
+
+    expect(yaml).toContain('serviceAccountName: typekro-jetstream-controller');
+    expect(yaml).not.toMatch(/serviceAccountName: jetstream-controller(?:\s|$)/);
   });
 
   it('serializes bootstrap in KRO mode and hoists an owned workload Namespace out of the graph', () => {

--- a/test/factories/nats/factory-modes.test.ts
+++ b/test/factories/nats/factory-modes.test.ts
@@ -3,7 +3,11 @@ import { type } from 'arktype';
 import { resourceFromDirectArtifactRecordForTest } from '../../../src/alchemy/resource-registration.js';
 import { kubernetesComposition } from '../../../src/core/composition/imperative.js';
 import { Cel } from '../../../src/core/references/cel.js';
-import { natsBootstrap } from '../../../src/factories/nats/compositions/nats-bootstrap.js';
+import { nackControllerBootstrap } from '../../../src/factories/nats/compositions/nack-controller-bootstrap.js';
+import {
+  makeNatsBootstrap,
+  natsBootstrap,
+} from '../../../src/factories/nats/compositions/nats-bootstrap.js';
 import {
   DEFAULT_NACK_VERSION,
   DEFAULT_NATS_VERSION,
@@ -68,7 +72,7 @@ const streamResources = kubernetesComposition(
 );
 
 describe('NATS and JetStream factories', () => {
-  it('emits official NATS and NACK installations with persistent JetStream defaults', () => {
+  it('emits the instance-owned NATS server with persistent JetStream defaults', () => {
     const yaml = natsBootstrap.factory('direct', { namespace: 'typekro-system' }).toYaml({
       name: 'nats',
       namespace: 'nats-system',
@@ -77,15 +81,14 @@ describe('NATS and JetStream factories', () => {
     });
     const docs = documents(yaml);
 
-    expect(docs.map(kind).filter((value) => value === 'HelmRelease')).toHaveLength(2);
+    expect(docs.map(kind).filter((value) => value === 'HelmRelease')).toHaveLength(1);
     expect(docs.map(kind)).toContain('Namespace');
     expect(docs.map(kind)).toContain('HelmRepository');
     expect(yaml).toContain(`version: ${DEFAULT_NATS_VERSION}`);
-    expect(yaml).toContain(`version: ${DEFAULT_NACK_VERSION}`);
+    expect(yaml).not.toContain(`version: ${DEFAULT_NACK_VERSION}`);
     expect(yaml).toMatch(/jetstream:\s*\n\s+enabled: true/);
     expect(yaml).toMatch(/cluster:\s*\n\s+enabled: true\s*\n\s+replicas: 3/);
     expect(yaml).toContain('size: 20Gi');
-    expect(yaml).toContain('url: nats://nats.nats-system.svc:4222');
     expect(yaml).toContain('fullnameOverride: nats');
     expect(yaml).toMatch(
       /statefulSet:\s*\n\s+merge:\s*\n\s+spec:\s*\n\s+persistentVolumeClaimRetentionPolicy:\s*\n\s+whenDeleted: Retain\s*\n\s+whenScaled: Retain/
@@ -120,19 +123,42 @@ describe('NATS and JetStream factories', () => {
       namespace: 'nats-system',
     });
     expect(customName).toContain('fullnameOverride: application-events');
-    expect(customName).toContain('url: nats://application-events.nats-system.svc:4222');
+  });
+
+  it('owns one cluster-wide NACK controller in CRD-connect mode', () => {
+    const yaml = nackControllerBootstrap
+      .factory('direct', { namespace: 'typekro-singletons' })
+      .toYaml({
+        name: 'nack',
+        namespace: 'typekro-nack-system',
+        version: DEFAULT_NACK_VERSION,
+      });
+    const docs = documents(yaml);
+
+    expect(docs.map(kind)).toEqual(['Namespace', 'HelmRepository', 'HelmRelease']);
+    expect(yaml).toContain(`version: ${DEFAULT_NACK_VERSION}`);
+    expect(yaml).toMatch(/jetstream:\s*\n\s+controlLoop: true\s*\n\s+enabled: true/);
+    expect(yaml).toContain('namespaced: false');
+    // Omitting jetstream.nats.url selects NACK's official -crd-connect mode.
+    // Stream/Consumer/Account resources carry their own target connection.
+    expect(yaml).not.toContain('url: nats://');
   });
 
   it('serializes bootstrap in KRO mode and hoists an owned workload Namespace out of the graph', () => {
     const factory = natsBootstrap.factory('kro', { namespace: 'typekro-system' });
     const rgd = factory.toYaml();
-    expect(rgd).toContain('kind: ResourceGraphDefinition');
+    expect(rgd.match(/kind: ResourceGraphDefinition/g)).toHaveLength(2);
+    expect(rgd).toContain('name: nack-controller-bootstrap');
+    expect(rgd).toContain('kind: NackControllerBootstrap');
+    expect(rgd).toContain('namespace: typekro-singletons');
     expect(rgd).toContain('kind: HelmRelease');
     expect(rgd).toContain('has(schema.spec.namespace) ? schema.spec.namespace');
     expect(rgd).toContain('(has(schema.spec.replicas) ? schema.spec.replicas : 1) > 1');
     expect(rgd).toContain('replicas: integer | minimum=1');
     expect(rgd).toContain('pvcRetentionPolicy: string | enum="delete,retain"');
     expect(rgd).toContain('namespaceOwnership: string | enum="external,owned"');
+    expect(rgd).toContain('nackValues: object | validation="self == {}"');
+    expect(rgd).toContain('nackVersion: string | validation="self == \\"0.34.0\\""');
     expect(rgd).toContain('schema.spec.pvcRetentionPolicy');
     expect(rgd).toContain('Delete');
     // The owned workload Namespace (named after spec.namespace) is hoisted OUT of
@@ -143,8 +169,8 @@ describe('NATS and JetStream factories', () => {
     expect(minimal).toContain('kind: NatsBootstrap');
     expect(minimal).toContain('name: nats');
     expect(minimal).not.toContain('spec:\n  name: nats\n  namespace:');
-    expect(rgd).toContain('string(schema.spec.name)');
-    expect(rgd).toContain('.svc:4222');
+    expect(minimal).toContain('kind: NackControllerBootstrap');
+    expect(minimal).toContain('name: nack-controller');
 
     const clustered = factory.toYaml({ name: 'nats', replicas: 3 });
     expect(clustered).toContain('replicas: 3');
@@ -178,10 +204,10 @@ describe('NATS and JetStream factories', () => {
       namespaceOwnership: 'external',
     });
     expect(external).toContain('kind: NatsBootstrap');
-    expect(external).not.toContain('typekro.io/kro-instance-namespace');
+    expect(external).toContain("typekro.io/hoisted-namespaces: '[]'");
   });
 
-  it('orders the repository before both releases in direct Alchemy materialization', async () => {
+  it('materializes one singleton NACK owner and an independent NATS server graph', async () => {
     const declarations = await natsBootstrap
       .factory('direct', { namespace: 'typekro-system', waitForReady: false })
       .toAlchemyResources({
@@ -190,17 +216,82 @@ describe('NATS and JetStream factories', () => {
         namespaceOwnership: 'external',
       });
     const byResourceId = new Map(
-      declarations.map((declaration) => [declaration.props.resourceId, declaration]),
+      declarations.map((declaration) => [declaration.props.resourceId, declaration])
     );
     const repository = byResourceId.get('natsHelmRepository');
     const server = byResourceId.get('natsHelmRelease');
+    const controllerNamespace = byResourceId.get('nackNamespace');
+    const controllerRepository = byResourceId.get('nackHelmRepository');
     const controller = byResourceId.get('nackHelmRelease');
 
     expect(repository).toBeDefined();
+    expect(controllerNamespace).toBeDefined();
+    expect(controllerRepository).toBeDefined();
+    expect(controller).toBeDefined();
+    expect(controllerNamespace?.props.resource.metadata?.name).toBe('typekro-nack-system');
+    expect(controller?.props.resource.metadata?.namespace).toBe('typekro-nack-system');
+    expect(controller?.props.resource.spec?.values).toMatchObject({
+      jetstream: { enabled: true, controlLoop: true },
+      namespaced: false,
+    });
+    expect(controller?.props.resource.spec?.values).not.toHaveProperty('jetstream.nats.url');
     expect(server?.dependsOn).toContain(repository?.id);
-    expect(controller?.dependsOn).toContain(repository?.id);
+    expect(controller?.dependsOn).toContain(controllerRepository?.id);
     expect(declarations.indexOf(repository!)).toBeLessThan(declarations.indexOf(server!));
-    expect(declarations.indexOf(repository!)).toBeLessThan(declarations.indexOf(controller!));
+    expect(declarations.indexOf(controllerRepository!)).toBeLessThan(
+      declarations.indexOf(controller!)
+    );
+    expect(new Set(declarations.map((declaration) => declaration.id)).size).toBe(
+      declarations.length
+    );
+  });
+
+  it('accepts NACK singleton customization only as concrete build-time configuration', async () => {
+    const customized = makeNatsBootstrap({
+      controller: {
+        version: '0.34.1',
+        values: { resources: { requests: { cpu: '100m' } } },
+      },
+    });
+    const declarations = await customized
+      .factory('direct', { namespace: 'typekro-system', waitForReady: false })
+      .toAlchemyResources({
+        name: 'application-events',
+        namespace: 'application-system',
+        namespaceOwnership: 'external',
+      });
+    const controller = declarations.find(
+      (declaration) => declaration.props.resourceId === 'nackHelmRelease'
+    );
+
+    expect(controller?.props.resource.spec?.chart?.spec?.version).toBe('0.34.1');
+    expect(controller?.props.resource.spec?.values).toMatchObject({
+      jetstream: { enabled: true, controlLoop: true },
+      namespaced: false,
+      resources: { requests: { cpu: '100m' } },
+    });
+    expect(() =>
+      customized.factory('direct', { namespace: 'typekro-system' }).toYaml({
+        name: 'application-events',
+        namespace: 'application-system',
+        nackVersion: '0.34.0',
+      })
+    ).toThrow(/nackVersion is now build-time singleton configuration/);
+    expect(() =>
+      customized.factory('direct', { namespace: 'typekro-system' }).toYaml({
+        name: 'application-events',
+        namespace: 'application-system',
+        nackValues: { resources: { requests: { cpu: '200m' } } },
+      })
+    ).toThrow(/nackValues is now build-time singleton configuration/);
+    expect(() =>
+      customized.factory('direct', { namespace: 'typekro-system' }).toYaml({
+        name: 'application-events',
+        namespace: 'application-system',
+        nackVersion: '0.34.1',
+        nackValues: { resources: { requests: { cpu: '100m' } } },
+      })
+    ).not.toThrow();
   });
 
   it('materializes custom values in direct Alchemy without leaking the merge marker', async () => {

--- a/test/factories/nats/nack-controller-migration.test.ts
+++ b/test/factories/nats/nack-controller-migration.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test';
+import type { KubernetesObject, KubernetesObjectApi } from '@kubernetes/client-node';
+import { retireLegacyNackController } from '../../../src/factories/nats/compositions/nack-controller-migration.js';
+
+function legacyRelease(overrides: Partial<KubernetesObject['metadata']> = {}): KubernetesObject {
+  return {
+    apiVersion: 'helm.toolkit.fluxcd.io/v2',
+    kind: 'HelmRelease',
+    metadata: {
+      name: 'nack',
+      namespace: 'nats-system',
+      uid: 'legacy-uid',
+      labels: {
+        'typekro.io/factory-name': 'nats-bootstrap',
+        'typekro.io/instance-name': 'nats',
+      },
+      annotations: {
+        'typekro.io/factory-name': 'nats-bootstrap',
+        'typekro.io/instance-name': 'nats',
+        'typekro.io/resource-id': 'nackHelmRelease',
+      },
+      ...overrides,
+    },
+    spec: {
+      chart: {
+        spec: {
+          chart: 'nack',
+        },
+      },
+    },
+  } as unknown as KubernetesObject;
+}
+
+describe('legacy NACK controller retirement', () => {
+  it('deletes only the exact v0.33.5 child with a UID precondition', async () => {
+    const live = legacyRelease();
+    const reads: unknown[] = [live, { code: 404 }];
+    const deletions: unknown[][] = [];
+    const api = {
+      read: async () => {
+        const result = reads.shift();
+        if (result instanceof Error) throw result;
+        if (
+          result &&
+          typeof result === 'object' &&
+          'code' in result &&
+          (result as { code?: number }).code === 404
+        ) {
+          throw result;
+        }
+        return result;
+      },
+      delete: async (...args: unknown[]) => {
+        deletions.push(args);
+        return {};
+      },
+    } as unknown as KubernetesObjectApi;
+
+    await retireLegacyNackController({
+      namespace: 'nats-system',
+      instanceName: 'nats',
+      kubernetesApi: api,
+    });
+
+    expect(deletions).toHaveLength(1);
+    expect(deletions[0]?.[0]).toBe(live);
+    expect(deletions[0]?.[5]).toBe('Foreground');
+    expect(deletions[0]?.[6]).toEqual({ preconditions: { uid: 'legacy-uid' } });
+  });
+
+  it('is idempotent when the legacy release is already absent', async () => {
+    let deleted = false;
+    const api = {
+      read: async () => {
+        throw { code: 404 };
+      },
+      delete: async () => {
+        deleted = true;
+        return {};
+      },
+    } as unknown as KubernetesObjectApi;
+
+    await retireLegacyNackController({
+      namespace: 'nats-system',
+      instanceName: 'nats',
+      kubernetesApi: api,
+    });
+    expect(deleted).toBe(false);
+  });
+
+  it('fails closed for a same-named release without exact TypeKro ownership', async () => {
+    let deleted = false;
+    const api = {
+      read: async () =>
+        legacyRelease({
+          annotations: {
+            'typekro.io/factory-name': 'another-factory',
+            'typekro.io/instance-name': 'nats',
+            'typekro.io/resource-id': 'nackHelmRelease',
+          },
+        }),
+      delete: async () => {
+        deleted = true;
+        return {};
+      },
+    } as unknown as KubernetesObjectApi;
+
+    await expect(
+      retireLegacyNackController({
+        namespace: 'nats-system',
+        instanceName: 'nats',
+        kubernetesApi: api,
+      })
+    ).rejects.toThrow(/Refusing to retire HelmRelease/);
+    expect(deleted).toBe(false);
+  });
+
+  it('fails closed if a replacement object appears while deletion is pending', async () => {
+    const api = {
+      read: async () => legacyRelease({ uid: crypto.randomUUID() }),
+      delete: async () => ({}),
+    } as unknown as KubernetesObjectApi;
+
+    await expect(
+      retireLegacyNackController({
+        namespace: 'nats-system',
+        instanceName: 'nats',
+        kubernetesApi: api,
+      })
+    ).rejects.toThrow(/UID changed/);
+  });
+});

--- a/test/factories/nats/nack-controller-migration.test.ts
+++ b/test/factories/nats/nack-controller-migration.test.ts
@@ -31,6 +31,34 @@ function legacyRelease(overrides: Partial<KubernetesObject['metadata']> = {}): K
   } as unknown as KubernetesObject;
 }
 
+function currentNatsRelease(): KubernetesObject {
+  return {
+    apiVersion: 'helm.toolkit.fluxcd.io/v2',
+    kind: 'HelmRelease',
+    metadata: {
+      name: 'nack',
+      namespace: 'nats-system',
+      uid: 'current-nats-uid',
+      labels: {
+        'typekro.io/factory-name': 'nats-bootstrap',
+        'typekro.io/instance-name': 'nack',
+      },
+      annotations: {
+        'typekro.io/factory-name': 'nats-bootstrap',
+        'typekro.io/instance-name': 'nack',
+        'typekro.io/resource-id': 'natsHelmRelease',
+      },
+    },
+    spec: {
+      chart: {
+        spec: {
+          chart: 'nats',
+        },
+      },
+    },
+  } as unknown as KubernetesObject;
+}
+
 describe('legacy NACK controller retirement', () => {
   it('deletes only the exact v0.33.5 child with a UID precondition', async () => {
     const live = legacyRelease();
@@ -85,6 +113,47 @@ describe('legacy NACK controller retirement', () => {
       instanceName: 'nats',
       kubernetesApi: api,
     });
+    expect(deleted).toBe(false);
+  });
+
+  it('treats an exact current NATS server named nack as no legacy controller', async () => {
+    let deleted = false;
+    const api = {
+      read: async () => currentNatsRelease(),
+      delete: async () => {
+        deleted = true;
+        return {};
+      },
+    } as unknown as KubernetesObjectApi;
+
+    await retireLegacyNackController({
+      namespace: 'nats-system',
+      instanceName: 'nack',
+      kubernetesApi: api,
+    });
+    expect(deleted).toBe(false);
+  });
+
+  it('still fails closed for a NATS server identity owned by another instance', async () => {
+    let deleted = false;
+    const current = currentNatsRelease();
+    current.metadata!.annotations!['typekro.io/instance-name'] = 'another-instance';
+    current.metadata!.labels!['typekro.io/instance-name'] = 'another-instance';
+    const api = {
+      read: async () => current,
+      delete: async () => {
+        deleted = true;
+        return {};
+      },
+    } as unknown as KubernetesObjectApi;
+
+    await expect(
+      retireLegacyNackController({
+        namespace: 'nats-system',
+        instanceName: 'nack',
+        kubernetesApi: api,
+      })
+    ).rejects.toThrow(/Refusing to retire HelmRelease/);
     expect(deleted).toBe(false);
   });
 

--- a/test/integration/nats/jetstream-resources.test.ts
+++ b/test/integration/nats/jetstream-resources.test.ts
@@ -13,7 +13,8 @@ import { describe, expect, it, setDefaultTimeout } from 'bun:test';
 import { type } from 'arktype';
 import { kubernetesComposition } from '../../../src/core/composition/imperative.js';
 import { Cel } from '../../../src/core/references/cel.js';
-import { natsBootstrap } from '../../../src/factories/nats/compositions/nats-bootstrap.js';
+import { nackControllerBootstrap } from '../../../src/factories/nats/compositions/nack-controller-bootstrap.js';
+import { makeNatsBootstrap } from '../../../src/factories/nats/compositions/nats-bootstrap.js';
 import {
   DEFAULT_NACK_VERSION,
   DEFAULT_NATS_VERSION,
@@ -238,13 +239,28 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
   const controlNamespace = `tk-nats-control-${suffix}`.slice(0, 63);
   const targetNamespace = `tk-nats-${suffix}`.slice(0, 63);
   const appNamespace = `tk-nats-app-${suffix}`.slice(0, 63);
+  const controllerName = `nack-${suffix}`.slice(0, 63);
+  const controllerNamespace = `tk-nack-${suffix}`.slice(0, 63);
+  const controllerSingletonId = `nack-${suffix}`.slice(0, 63);
+  const controllerValues = {
+    nameOverride: controllerName,
+    serviceAccountName: controllerName,
+  };
+  const isolatedNats = makeNatsBootstrap({
+    controller: {
+      singletonId: controllerSingletonId,
+      name: controllerName,
+      namespace: controllerNamespace,
+      values: controllerValues,
+    },
+  });
   const kubeConfig = getIntegrationTestKubeConfig();
   const storageClassName = await requireTestStorageClass({
     kubeConfig,
     envVar: 'TYPEKRO_NATS_STORAGE_CLASS',
   });
 
-  const platformFactory = natsBootstrap.factory(mode, {
+  const platformFactory = isolatedNats.factory(mode, {
     namespace: controlNamespace,
     waitForReady: true,
     timeout: 900_000,
@@ -260,11 +276,19 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
   let controlNamespaceLease: TestNamespaceLease | undefined;
   let appNamespaceLease: TestNamespaceLease | undefined;
   let targetNamespaceLease: TestNamespaceLease | undefined;
+  let controllerNamespaceLease: TestNamespaceLease | undefined;
+  const controllerFactory = nackControllerBootstrap.factory(mode, {
+    namespace: 'typekro-singletons',
+    waitForReady: true,
+    timeout: 600_000,
+    kubeConfig,
+  });
 
   try {
     controlNamespaceLease = await createTestNamespace(controlNamespace, kubeConfig);
     appNamespaceLease = await createTestNamespace(appNamespace, kubeConfig);
     await assertTestNamespaceAbsent(targetNamespace, kubeConfig);
+    await assertTestNamespaceAbsent(controllerNamespace, kubeConfig);
 
     let platform: Awaited<ReturnType<typeof platformFactory.deploy>>;
     try {
@@ -290,6 +314,10 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
     targetNamespaceLease = await captureTestNamespaceLease(targetNamespace, kubeConfig);
     if (!targetNamespaceLease) {
       throw new Error(`NATS platform did not create expected namespace ${targetNamespace}`);
+    }
+    controllerNamespaceLease ??= await captureTestNamespaceLease(controllerNamespace, kubeConfig);
+    if (!controllerNamespaceLease) {
+      throw new Error(`NACK singleton did not create expected namespace ${controllerNamespace}`);
     }
 
     expect(platform.status).toMatchObject({
@@ -385,6 +413,24 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
       )
     );
   }
+  try {
+    await deleteTestFactoryInstanceAndRecoverNamespaces(
+      controllerFactory,
+      controllerSingletonId,
+      controllerNamespaceLease ? [controllerNamespaceLease] : [],
+      kubeConfig,
+      30_000,
+      mode === 'direct' ? { scopes: ['cluster'] } : {}
+    );
+  } catch (error: unknown) {
+    cleanupFailures.push(
+      new Error(
+        `${mode} cleanup failed for shared NACK owner: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
+    );
+  }
 
   for (const lease of [appNamespaceLease, controlNamespaceLease]) {
     if (!lease) continue;
@@ -414,5 +460,239 @@ describeOrSkip('NATS JetStream live direct and KRO integration', () => {
 
   it('projects readiness and reconciles the same resources through KRO', async () => {
     await proveMode('kro');
+  });
+
+  it('keeps the shared NACK controller alive when one of two NATS installations is deleted', async () => {
+    const suffix = `shared-${runId}`.slice(0, 36);
+    const controllerName = `nack-${suffix}`.slice(0, 63);
+    const controllerNamespace = `tk-nack-${suffix}`.slice(0, 63);
+    const controllerSingletonId = `nack-${suffix}`.slice(0, 63);
+    const controllerValues = {
+      nameOverride: controllerName,
+      serviceAccountName: controllerName,
+    };
+    const sharedNats = makeNatsBootstrap({
+      controller: {
+        singletonId: controllerSingletonId,
+        name: controllerName,
+        namespace: controllerNamespace,
+        values: controllerValues,
+      },
+    });
+    const kubeConfig = getIntegrationTestKubeConfig();
+    const objectApi = createKubernetesObjectApiClient(kubeConfig);
+    const storageClassName = await requireTestStorageClass({
+      kubeConfig,
+      envVar: 'TYPEKRO_NATS_STORAGE_CLASS',
+    });
+    const controllerFactory = nackControllerBootstrap.factory('direct', {
+      namespace: 'typekro-singletons',
+      waitForReady: true,
+      timeout: 600_000,
+      kubeConfig,
+    });
+    const installations = ['a', 'b'].map((id) => {
+      const controlNamespace = `tk-nats-control-${id}-${suffix}`.slice(0, 63);
+      const targetNamespace = `tk-nats-${id}-${suffix}`.slice(0, 63);
+      const appNamespace = `tk-nats-app-${id}-${suffix}`.slice(0, 63);
+      return {
+        id,
+        controlNamespace,
+        targetNamespace,
+        appNamespace,
+        platformFactory: sharedNats.factory('direct', {
+          namespace: controlNamespace,
+          waitForReady: true,
+          timeout: 900_000,
+          kubeConfig,
+        }),
+        resourcesFactory: liveResources.factory('direct', {
+          namespace: appNamespace,
+          waitForReady: true,
+          timeout: 600_000,
+          kubeConfig,
+        }),
+      };
+    });
+    const namespaceLeases: TestNamespaceLease[] = [];
+    let controllerNamespaceLease: TestNamespaceLease | undefined;
+    let testFailure: Error | undefined;
+
+    try {
+      for (const installation of installations) {
+        namespaceLeases.push(
+          await createTestNamespace(installation.controlNamespace, kubeConfig),
+          await createTestNamespace(installation.appNamespace, kubeConfig)
+        );
+        await assertTestNamespaceAbsent(installation.targetNamespace, kubeConfig);
+      }
+      await assertTestNamespaceAbsent(controllerNamespace, kubeConfig);
+
+      for (const installation of installations) {
+        const platform = await installation.platformFactory.deploy({
+          name: `nats-${installation.id}`,
+          namespace: installation.targetNamespace,
+          replicas: 1,
+          storageSize: '1Gi',
+          pvcRetentionPolicy: 'delete',
+          storageClassName,
+        });
+        expect(platform.status).toMatchObject({ ready: true, failed: false, phase: 'Ready' });
+        controllerNamespaceLease ??= await captureTestNamespaceLease(
+          controllerNamespace,
+          kubeConfig
+        );
+        if (!controllerNamespaceLease) {
+          throw new Error(`NACK owner did not create expected namespace ${controllerNamespace}`);
+        }
+        const resources = await installation.resourcesFactory.deploy({
+          name: `resources-${installation.id}`,
+          namespace: installation.appNamespace,
+          endpoint: `nats://nats-${installation.id}.${installation.targetNamespace}.svc:4222`,
+          description: `shared controller ${installation.id}`,
+        });
+        expect(resources.status).toMatchObject({ ready: true });
+      }
+
+      const deploymentIdentity = {
+        apiVersion: 'apps/v1',
+        kind: 'Deployment',
+        metadata: { name: controllerName, namespace: controllerNamespace },
+      };
+      const roleIdentity = {
+        apiVersion: 'rbac.authorization.k8s.io/v1',
+        kind: 'ClusterRole',
+        metadata: { name: `${controllerName}-cluster-role` },
+      };
+      const controllerDeployment = await objectApi.read(deploymentIdentity);
+      const controllerRole = await objectApi.read(roleIdentity);
+      const deploymentUid = controllerDeployment.metadata?.uid;
+      const roleUid = controllerRole.metadata?.uid;
+      if (!deploymentUid || !roleUid) {
+        throw new Error('Shared NACK controller resources have no Kubernetes UID');
+      }
+
+      const first = installations[0];
+      const second = installations[1];
+      if (!first || !second) {
+        throw new Error('Expected two NATS installations');
+      }
+      const firstTargetLease = await captureTestNamespaceLease(first.targetNamespace, kubeConfig);
+      await deleteTestFactoryInstanceAndRecoverNamespaces(
+        first.resourcesFactory,
+        `resources-${first.id}`,
+        [],
+        kubeConfig
+      );
+      await deleteTestFactoryInstanceAndRecoverNamespaces(
+        first.platformFactory,
+        `nats-${first.id}`,
+        firstTargetLease ? [firstTargetLease] : [],
+        kubeConfig,
+        30_000,
+        { scopes: ['cluster'] }
+      );
+
+      expect((await objectApi.read(deploymentIdentity)).metadata?.uid).toBe(deploymentUid);
+      expect((await objectApi.read(roleIdentity)).metadata?.uid).toBe(roleUid);
+
+      const updated = await second.resourcesFactory.deploy({
+        name: `resources-${second.id}`,
+        namespace: second.appNamespace,
+        endpoint: `nats://nats-${second.id}.${second.targetNamespace}.svc:4222`,
+        description: 'reconciled after sibling deletion',
+      });
+      expect(updated.status).toMatchObject({ ready: true });
+      const survivingStream = await readJetStreamResource(
+        'Stream',
+        'application-events',
+        second.appNamespace,
+        kubeConfig
+      );
+      expectCurrentJetStreamReadiness(survivingStream);
+      expect(survivingStream.spec?.description).toBe('reconciled after sibling deletion');
+    } catch (error: unknown) {
+      testFailure = error instanceof Error ? error : new Error(String(error));
+    }
+
+    const cleanupFailures: Error[] = [];
+    for (const installation of installations) {
+      try {
+        await deleteTestFactoryInstanceAndRecoverNamespaces(
+          installation.resourcesFactory,
+          `resources-${installation.id}`,
+          [],
+          kubeConfig
+        );
+      } catch (error: unknown) {
+        cleanupFailures.push(
+          new Error(
+            `Shared-controller resource cleanup failed for ${installation.id}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          )
+        );
+      }
+      try {
+        const targetLease = await captureTestNamespaceLease(
+          installation.targetNamespace,
+          kubeConfig
+        );
+        await deleteTestFactoryInstanceAndRecoverNamespaces(
+          installation.platformFactory,
+          `nats-${installation.id}`,
+          targetLease ? [targetLease] : [],
+          kubeConfig,
+          30_000,
+          { scopes: ['cluster'] }
+        );
+      } catch (error: unknown) {
+        cleanupFailures.push(
+          new Error(
+            `Shared-controller platform cleanup failed for ${installation.id}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          )
+        );
+      }
+    }
+    try {
+      await deleteTestFactoryInstanceAndRecoverNamespaces(
+        controllerFactory,
+        controllerName,
+        controllerNamespaceLease ? [controllerNamespaceLease] : [],
+        kubeConfig,
+        30_000,
+        { scopes: ['cluster'] }
+      );
+    } catch (error: unknown) {
+      cleanupFailures.push(
+        new Error(
+          `Shared NACK owner cleanup failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      );
+    }
+    for (const lease of namespaceLeases) {
+      try {
+        await deleteTestNamespaceAndWait(lease, kubeConfig);
+      } catch (error: unknown) {
+        cleanupFailures.push(
+          new Error(
+            `Shared-controller namespace cleanup failed for ${lease.name}: ${
+              error instanceof Error ? error.message : String(error)
+            }`
+          )
+        );
+      }
+    }
+    const failures = [...(testFailure ? [testFailure] : []), ...cleanupFailures];
+    if (failures.length > 0) {
+      throw new AggregateError(
+        failures,
+        'Shared NACK controller lifecycle proof did not complete safely'
+      );
+    }
   });
 });

--- a/test/integration/nats/jetstream-resources.test.ts
+++ b/test/integration/nats/jetstream-resources.test.ts
@@ -709,13 +709,13 @@ async function proveV0335Upgrade(mode: 'direct' | 'kro'): Promise<void> {
           spec?: { values?: { serviceAccountName?: string } };
         }
       ).spec?.values?.serviceAccountName
-    ).toBe(`${controllerName}-controller`);
+    ).toBe(`typekro-${controllerName}-controller`);
     expect(
       (
         await objectApi.read({
           apiVersion: 'rbac.authorization.k8s.io/v1',
           kind: 'ClusterRole',
-          metadata: { name: `${controllerName}-controller-cluster-role` },
+          metadata: { name: `typekro-${controllerName}-controller-cluster-role` },
         })
       ).metadata?.uid
     ).toBeTruthy();
@@ -935,7 +935,7 @@ describeOrSkip('NATS JetStream live direct and KRO integration', () => {
       const roleIdentity = {
         apiVersion: 'rbac.authorization.k8s.io/v1',
         kind: 'ClusterRole',
-        metadata: { name: `${controllerName}-controller-cluster-role` },
+        metadata: { name: `typekro-${controllerName}-controller-cluster-role` },
       };
       const controllerDeployment = await objectApi.read(deploymentIdentity);
       const controllerRole = await objectApi.read(roleIdentity);

--- a/test/integration/nats/jetstream-resources.test.ts
+++ b/test/integration/nats/jetstream-resources.test.ts
@@ -11,18 +11,32 @@
 
 import { describe, expect, it, setDefaultTimeout } from 'bun:test';
 import { type } from 'arktype';
+import { mergeValuesExpression } from '../../../src/core/aspects/values-merge.js';
 import { kubernetesComposition } from '../../../src/core/composition/imperative.js';
 import { Cel } from '../../../src/core/references/cel.js';
+import { helmReleaseConditionSummary } from '../../../src/factories/helm/status.js';
+import { namespace } from '../../../src/factories/kubernetes/core/namespace.js';
 import { nackControllerBootstrap } from '../../../src/factories/nats/compositions/nack-controller-bootstrap.js';
 import { makeNatsBootstrap } from '../../../src/factories/nats/compositions/nats-bootstrap.js';
 import {
   DEFAULT_NACK_VERSION,
+  DEFAULT_NATS_REPOSITORY_NAME,
+  DEFAULT_NATS_REPOSITORY_URL,
   DEFAULT_NATS_VERSION,
+  natsHelmRelease,
+  natsHelmRepository,
 } from '../../../src/factories/nats/resources/helm.js';
 import {
   jetStreamConsumer,
   jetStreamStream,
 } from '../../../src/factories/nats/resources/jetstream.js';
+import {
+  type NatsBootstrapConfig,
+  NatsBootstrapConfigSchema,
+  NatsBootstrapStatusSchema,
+  type NatsHelmValues,
+} from '../../../src/factories/nats/types.js';
+import { isKubernetesRef } from '../../../src/utils/type-guards.js';
 import {
   assertTestNamespaceAbsent,
   captureTestNamespaceLease,
@@ -35,8 +49,10 @@ import {
   deleteTestResourceAndWait,
   getIntegrationTestKubeConfig,
   isClusterAvailable,
+  isNotFoundError,
   requireTestStorageClass,
   type TestNamespaceLease,
+  waitForResourceAbsent,
 } from '../shared-kubeconfig.js';
 
 const clusterAvailable = await isClusterAvailable();
@@ -92,6 +108,128 @@ const liveResources = kubernetesComposition(
         ' == ',
         consumer.metadata.generation
       ),
+    };
+  }
+);
+
+/**
+ * Frozen v0.33.5 graph used as upgrade input. Keep this local rather than
+ * importing current NATS implementation details: the regression must begin
+ * with the released per-installation HelmRelease/nack topology.
+ */
+const legacyV0335NatsBootstrap = kubernetesComposition(
+  {
+    name: 'nats-bootstrap',
+    kind: 'NatsBootstrap',
+    spec: NatsBootstrapConfigSchema,
+    status: NatsBootstrapStatusSchema,
+  },
+  (spec: NatsBootstrapConfig) => {
+    const graphMode = isKubernetesRef(spec.name);
+    const targetNamespace = graphMode
+      ? Cel.expr<string>('has(schema.spec.namespace) ? schema.spec.namespace : "nats-system"')
+      : (spec.namespace ?? 'nats-system');
+    const ownsNamespace = graphMode
+      ? Cel.expr<boolean>(
+          '!has(schema.spec.namespaceOwnership) || schema.spec.namespaceOwnership == "owned"'
+        )
+      : spec.namespaceOwnership !== 'external';
+    const replicas = graphMode
+      ? Cel.expr<number>('has(schema.spec.replicas) ? schema.spec.replicas : 1')
+      : (spec.replicas ?? 1);
+    const endpoint = graphMode
+      ? Cel.expr<string>(
+          '"nats://" + string(schema.spec.name) + "." + string(has(schema.spec.namespace) ? schema.spec.namespace : "nats-system") + ".svc:4222"'
+        )
+      : `nats://${spec.name}.${targetNamespace}.svc:4222`;
+    const repositoryName = spec.repositoryName ?? DEFAULT_NATS_REPOSITORY_NAME;
+    const repositoryNamespace = spec.repositoryNamespace ?? targetNamespace;
+    const repositoryUrl = spec.repositoryUrl ?? DEFAULT_NATS_REPOSITORY_URL;
+    const serverDefaults: NatsHelmValues = {
+      fullnameOverride: spec.name,
+      config: {
+        cluster: {
+          enabled: graphMode ? Cel.expr<boolean>(replicas, ' > 1') : replicas > 1,
+          replicas,
+        },
+        jetstream: {
+          enabled: true,
+          fileStore: {
+            enabled: true,
+            pvc: {
+              enabled: true,
+              size: spec.storageSize ?? '10Gi',
+              ...(spec.storageClassName && { storageClassName: spec.storageClassName }),
+            },
+          },
+        },
+      },
+      natsBox: { enabled: true },
+      statefulSet: {
+        merge: {
+          spec: {
+            persistentVolumeClaimRetentionPolicy: {
+              whenDeleted: 'Delete',
+              whenScaled: 'Retain',
+            },
+          },
+        },
+      },
+    };
+    const nackDefaults: NatsHelmValues = {
+      jetstream: {
+        enabled: true,
+        nats: { url: endpoint },
+        controlLoop: true,
+      },
+      namespaced: false,
+    };
+    const serverValues = spec.values
+      ? mergeValuesExpression(serverDefaults, spec.values)
+      : serverDefaults;
+    const nackValues = spec.nackValues
+      ? mergeValuesExpression(nackDefaults, spec.nackValues)
+      : nackDefaults;
+
+    namespace({
+      id: 'natsNamespace',
+      metadata: { name: targetNamespace },
+    }).withIncludeWhen(ownsNamespace);
+    const repository = natsHelmRepository({
+      id: 'natsHelmRepository',
+      name: repositoryName,
+      namespace: repositoryNamespace,
+      url: repositoryUrl,
+    });
+    const server = natsHelmRelease({
+      id: 'natsHelmRelease',
+      name: spec.name,
+      namespace: targetNamespace,
+      chart: 'nats',
+      version: spec.version ?? DEFAULT_NATS_VERSION,
+      values: serverValues,
+      repositoryName,
+      repositoryNamespace,
+      repositoryUrl,
+    });
+    const controller = natsHelmRelease({
+      id: 'nackHelmRelease',
+      name: 'nack',
+      namespace: targetNamespace,
+      chart: 'nack',
+      version: spec.nackVersion ?? DEFAULT_NACK_VERSION,
+      values: nackValues,
+      repositoryName,
+      repositoryNamespace,
+      repositoryUrl,
+    });
+    server.dependsOn(repository);
+    controller.dependsOn(repository);
+    return {
+      ...helmReleaseConditionSummary(server, controller),
+      serverVersion: spec.version ?? DEFAULT_NATS_VERSION,
+      controllerVersion: spec.nackVersion ?? DEFAULT_NACK_VERSION,
+      endpoint,
     };
   }
 );
@@ -453,6 +591,233 @@ async function proveMode(mode: 'direct' | 'kro'): Promise<void> {
   }
 }
 
+async function proveV0335Upgrade(mode: 'direct' | 'kro'): Promise<void> {
+  const suffix = `upgrade-${mode}-${runId}`.slice(0, 38);
+  const controlNamespace = `tk-nats-control-${suffix}`.slice(0, 63);
+  const targetNamespace = `tk-nats-${suffix}`.slice(0, 63);
+  const appNamespace = `tk-nats-app-${suffix}`.slice(0, 63);
+  const controllerName = `nack-${suffix}`.slice(0, 52);
+  const controllerNamespace = `tk-nack-${suffix}`.slice(0, 63);
+  const controllerSingletonId = `nack-${suffix}`.slice(0, 63);
+  const upgradedNats = makeNatsBootstrap({
+    controller: {
+      singletonId: controllerSingletonId,
+      name: controllerName,
+      namespace: controllerNamespace,
+    },
+  });
+  const kubeConfig = getIntegrationTestKubeConfig();
+  const objectApi = createKubernetesObjectApiClient(kubeConfig);
+  const storageClassName = await requireTestStorageClass({
+    kubeConfig,
+    envVar: 'TYPEKRO_NATS_STORAGE_CLASS',
+  });
+  const factoryOptions = {
+    namespace: controlNamespace,
+    waitForReady: true,
+    timeout: 900_000,
+    kubeConfig,
+  } as const;
+  const legacyFactory = legacyV0335NatsBootstrap.factory(mode, factoryOptions);
+  const currentFactory = upgradedNats.factory(mode, factoryOptions);
+  const resourcesFactory = liveResources.factory(mode, {
+    namespace: appNamespace,
+    waitForReady: true,
+    timeout: 600_000,
+    kubeConfig,
+  });
+  const controllerFactory = nackControllerBootstrap.factory(mode, {
+    namespace: 'typekro-singletons',
+    waitForReady: true,
+    timeout: 600_000,
+    kubeConfig,
+  });
+  const spec = {
+    name: 'nats',
+    namespace: targetNamespace,
+    replicas: 1,
+    storageSize: '1Gi',
+    pvcRetentionPolicy: 'delete' as const,
+    storageClassName,
+  };
+  let controlLease: TestNamespaceLease | undefined;
+  let appLease: TestNamespaceLease | undefined;
+  let targetLease: TestNamespaceLease | undefined;
+  let controllerLease: TestNamespaceLease | undefined;
+  let testFailure: Error | undefined;
+  let legacyDeployed = false;
+  let currentDeployed = false;
+
+  try {
+    controlLease = await createTestNamespace(controlNamespace, kubeConfig);
+    appLease = await createTestNamespace(appNamespace, kubeConfig);
+    await assertTestNamespaceAbsent(targetNamespace, kubeConfig);
+    await assertTestNamespaceAbsent(controllerNamespace, kubeConfig);
+
+    const legacy = await legacyFactory.deploy(spec);
+    legacyDeployed = true;
+    expect(legacy.status).toMatchObject({ ready: true, failed: false, phase: 'Ready' });
+    targetLease = await captureTestNamespaceLease(targetNamespace, kubeConfig);
+    if (!targetLease) {
+      throw new Error(`v0.33.5 fixture did not create ${targetNamespace}`);
+    }
+
+    const legacyReleaseIdentity = {
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: { name: 'nack', namespace: targetNamespace },
+    };
+    const legacyRoleIdentity = {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: { name: 'jetstream-controller-cluster-role' },
+    };
+    expect((await objectApi.read(legacyReleaseIdentity)).metadata?.uid).toBeTruthy();
+    expect((await objectApi.read(legacyRoleIdentity)).metadata?.uid).toBeTruthy();
+
+    const endpoint = `nats://nats.${targetNamespace}.svc:4222`;
+    const beforeUpgrade = await resourcesFactory.deploy({
+      name: 'resources',
+      namespace: appNamespace,
+      endpoint,
+      description: 'v0.33.5 controller',
+    });
+    expect(beforeUpgrade.status).toMatchObject({ ready: true });
+
+    const upgraded = await currentFactory.deploy(spec);
+    currentDeployed = true;
+    expect(upgraded.status).toMatchObject({
+      ready: true,
+      failed: false,
+      phase: 'Ready',
+      controllerVersion: DEFAULT_NACK_VERSION,
+    });
+    controllerLease = await captureTestNamespaceLease(controllerNamespace, kubeConfig);
+    if (!controllerLease) {
+      throw new Error(`Singleton upgrade did not create ${controllerNamespace}`);
+    }
+
+    const singletonRelease = await objectApi.read({
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: { name: controllerName, namespace: controllerNamespace },
+    });
+    expect(singletonRelease.metadata?.uid).toBeTruthy();
+    expect(
+      (
+        singletonRelease as typeof singletonRelease & {
+          spec?: { values?: { serviceAccountName?: string } };
+        }
+      ).spec?.values?.serviceAccountName
+    ).toBe(`${controllerName}-controller`);
+    expect(
+      (
+        await objectApi.read({
+          apiVersion: 'rbac.authorization.k8s.io/v1',
+          kind: 'ClusterRole',
+          metadata: { name: `${controllerName}-controller-cluster-role` },
+        })
+      ).metadata?.uid
+    ).toBeTruthy();
+
+    await waitForResourceAbsent(legacyReleaseIdentity, kubeConfig, 180_000);
+    await waitForResourceAbsent(legacyRoleIdentity, kubeConfig, 180_000);
+
+    const afterUpgrade = await resourcesFactory.deploy({
+      name: 'resources',
+      namespace: appNamespace,
+      endpoint,
+      description: 'singleton controller',
+    });
+    expect(afterUpgrade.status).toMatchObject({ ready: true });
+    const stream = await readJetStreamResource(
+      'Stream',
+      'application-events',
+      appNamespace,
+      kubeConfig
+    );
+    expectCurrentJetStreamReadiness(stream);
+    expect(stream.spec?.description).toBe('singleton controller');
+  } catch (error: unknown) {
+    testFailure = error instanceof Error ? error : new Error(String(error));
+  }
+
+  const cleanupFailures: Error[] = [];
+  try {
+    await deleteTestFactoryInstanceAndRecoverNamespaces(
+      resourcesFactory,
+      'resources',
+      [],
+      kubeConfig
+    );
+  } catch (error: unknown) {
+    cleanupFailures.push(
+      new Error(
+        `${mode} upgrade resource cleanup failed: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+  }
+  const platformCleanupFactory = currentDeployed
+    ? currentFactory
+    : legacyDeployed
+      ? legacyFactory
+      : undefined;
+  if (platformCleanupFactory) {
+    try {
+      await deleteTestFactoryInstanceAndRecoverNamespaces(
+        platformCleanupFactory,
+        'nats',
+        targetLease ? [targetLease] : [],
+        kubeConfig,
+        30_000,
+        mode === 'direct' ? { scopes: ['cluster'] } : {}
+      );
+    } catch (error: unknown) {
+      if (!isNotFoundError(error)) {
+        cleanupFailures.push(
+          new Error(
+            `${mode} upgrade platform cleanup failed: ${error instanceof Error ? error.message : String(error)}`
+          )
+        );
+      }
+    }
+  }
+  try {
+    await deleteTestFactoryInstanceAndRecoverNamespaces(
+      controllerFactory,
+      controllerSingletonId,
+      controllerLease ? [controllerLease] : [],
+      kubeConfig,
+      30_000,
+      mode === 'direct' ? { scopes: ['cluster'] } : {}
+    );
+  } catch (error: unknown) {
+    cleanupFailures.push(
+      new Error(
+        `${mode} upgrade singleton cleanup failed: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+  }
+  for (const lease of [appLease, controlLease]) {
+    if (!lease) continue;
+    try {
+      await deleteTestNamespaceAndWait(lease, kubeConfig);
+    } catch (error: unknown) {
+      cleanupFailures.push(
+        new Error(
+          `${mode} upgrade namespace cleanup failed for ${lease.name}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      );
+    }
+  }
+  const failures = [...(testFailure ? [testFailure] : []), ...cleanupFailures];
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `${mode} v0.33.5 NACK singleton migration failed`);
+  }
+}
+
 describeOrSkip('NATS JetStream live direct and KRO integration', () => {
   it('installs NATS/NACK and reconciles a persisted Stream and Consumer in direct mode', async () => {
     await proveMode('direct');
@@ -460,6 +825,14 @@ describeOrSkip('NATS JetStream live direct and KRO integration', () => {
 
   it('projects readiness and reconciles the same resources through KRO', async () => {
     await proveMode('kro');
+  });
+
+  it('upgrades a direct v0.33.5 per-installation controller without Helm ownership conflict', async () => {
+    await proveV0335Upgrade('direct');
+  });
+
+  it('upgrades a KRO v0.33.5 graph after making the singleton controller ready', async () => {
+    await proveV0335Upgrade('kro');
   });
 
   it('keeps the shared NACK controller alive when one of two NATS installations is deleted', async () => {
@@ -562,7 +935,7 @@ describeOrSkip('NATS JetStream live direct and KRO integration', () => {
       const roleIdentity = {
         apiVersion: 'rbac.authorization.k8s.io/v1',
         kind: 'ClusterRole',
-        metadata: { name: `${controllerName}-cluster-role` },
+        metadata: { name: `${controllerName}-controller-cluster-role` },
       };
       const controllerDeployment = await objectApi.read(deploymentIdentity);
       const controllerRole = await objectApi.read(roleIdentity);


### PR DESCRIPTION
## What changed

- adds an explicit cluster-wide `nackControllerBootstrap` lifecycle owner
- makes `natsBootstrap` consume that owner through TypeKro `singleton(...)`
- runs the shared NACK controller in CRD-connect mode so Stream, Consumer, and Account resources retain per-resource NATS routing
- moves shared controller version and values to concrete build-time `makeNatsBootstrap({ controller: ... })` options
- retains deprecated `nackVersion` and `nackValues` schema fields as fail-closed compatibility assertions so existing KRO definitions can upgrade without removing CRD fields
- documents ownership, routing, and migration semantics

## Root cause

The official NACK chart's non-namespaced mode creates fixed-name cluster RBAC. Installing one controller per NATS application gave multiple TypeKro instances ownership of the same ClusterRole and ClusterRoleBinding. Deleting one application could remove RBAC from another live controller and stop JetStream reconciliation.

## Impact

NATS applications now own only their NATS server resources. One explicit singleton owns NACK and its cluster-scoped RBAC, so deleting one consumer cannot tear down controller infrastructure required by another.

## Verification

- complete TypeKro unit suite: 5,292 passed, 13 skipped, 1 todo, 0 failed
- focused NATS factory suite: 9 passed
- library, examples, and test typechecks passed
- Biome lint and `git diff --check` passed
- OrbStack direct integration passed
- OrbStack KRO integration passed
- OrbStack two-installation lifecycle proof passed: after deleting installation A, the shared controller Deployment and ClusterRole UIDs were unchanged and installation B reconciled a Stream update
- integration cleanup verified no test namespaces or isolated cluster RBAC remained