### PR TITLE
chore: release v0.33.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.33.5",
+  "version": "0.33.6",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
- release the fixes merged in #152, #153, and #154
- bump the package version to 0.33.6

## Verification
- full unit suite passed in the release commit hook (5,306 passed, 13 skipped, 1 todo, 0 failed)