### PR TITLE
fix: adopt retained KRO CRDs after RGD recreation

### DIFF
--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -28,7 +28,10 @@ import { DEFAULT_DEPLOYMENT_TIMEOUT } from '../core/config/defaults.js';
 import { CEL_EXPRESSION_BRAND } from '../core/constants/brands.js';
 import { ResourceReplacementTimeoutError } from '../core/deployment/errors.js';
 import { isNotFoundError } from '../core/deployment/k8s-helpers.js';
-import { migrateLegacyKroArtifactBindingCrd } from '../core/deployment/kro-artifact-binding-migration.js';
+import {
+  migrateLegacyKroArtifactBindingCrd,
+  repairRetainedKroGeneratedCrdOwnership,
+} from '../core/deployment/kro-artifact-binding-migration.js';
 import {
   decideNamespaceOwnershipCreateFirst,
   deleteNamespaceIfEmpty,
@@ -477,6 +480,7 @@ async function deployKroResource<T extends Enhanced<unknown, unknown>>(
   abortSignal?: AbortSignal,
   dependencies: {
     migrateLegacyArtifactBindings?: typeof migrateLegacyKroArtifactBindingCrd;
+    repairRetainedCrdOwnership?: typeof repairRetainedKroGeneratedCrdOwnership;
     kubeConfigForMigration?: () => KubeConfig;
   } = {}
 ): Promise<TypeKroResource<T>> {
@@ -581,6 +585,16 @@ async function deployKroResource<T extends Enhanced<unknown, unknown>>(
       seedResources,
       abortSignal
     );
+    if (
+      effectiveProps.deploymentStrategy === 'kro' &&
+      (resourceForDeploy as { kind?: string }).kind === 'ResourceGraphDefinition'
+    ) {
+      await (dependencies.repairRetainedCrdOwnership ?? repairRetainedKroGeneratedCrdOwnership)(
+        dependencies.kubeConfigForMigration?.() ??
+          _createClientProvider(effectiveProps, 'retained-crd-adoption'),
+        resourceForDeploy as unknown as KubernetesResource
+      );
+    }
     _logDeploymentSuccess(logger, KRO_RESOURCE_TYPE, effectiveProps, resourceProperties);
     return resourceProperties as unknown as TypeKroResource<T>;
   } catch (error: unknown) {

--- a/src/core/deployment/kro-artifact-binding-migration.ts
+++ b/src/core/deployment/kro-artifact-binding-migration.ts
@@ -8,6 +8,9 @@ import { KRO_ARTIFACT_BINDINGS_SPEC_FIELD } from '../planning/values.js';
 
 const STABLE_BINDING_SCHEMA = 'map[string]map[string]string';
 const MAX_CRD_PATCH_ATTEMPTS = 5;
+const KRO_OWNED_LABEL = 'kro.run/owned';
+const KRO_RGD_ID_LABEL = 'kro.run/resource-graph-definition-id';
+const KRO_RGD_NAME_LABEL = 'kro.run/resource-graph-definition-name';
 type MigrationApi = Pick<
   ReturnType<typeof createBunCompatibleKubernetesObjectApi>,
   'read' | 'list' | 'replace'
@@ -192,7 +195,11 @@ async function replaceRgdWithRetry(
   throw new Error(`Could not replace ResourceGraphDefinition ${rgdName}`);
 }
 
-async function requestRgdReconcile(api: MigrationApi, rgdName: string): Promise<void> {
+async function requestRgdReconcile(
+  api: MigrationApi,
+  rgdName: string,
+  reason: 'artifact-binding-migration' | 'retained-crd-adoption' = 'artifact-binding-migration'
+): Promise<void> {
   const live = (await api.read({
     apiVersion: 'kro.run/v1alpha1',
     kind: 'ResourceGraphDefinition',
@@ -206,12 +213,95 @@ async function requestRgdReconcile(api: MigrationApi, rgdName: string): Promise<
         name: rgdName,
         annotations: {
           ...live.metadata?.annotations,
-          'typekro.io/artifact-binding-migration-retry': new Date().toISOString(),
+          [`typekro.io/${reason}-retry`]: new Date().toISOString(),
         },
       },
     },
     live
   );
+}
+
+/**
+ * Repairs KRO's retained-CRD adoption edge after an RGD is recreated.
+ *
+ * KRO 0.9.2 recognizes a generated CRD with the same RGD name and a stale RGD
+ * UID as adoptable. When its schema and names are otherwise unchanged, however,
+ * KRO returns before patching the ownership labels. The dynamic instance
+ * controller can then disappear while terminating instances retain KRO's
+ * finalizer indefinitely. TypeKro deliberately retains generated CRDs for safe
+ * reuse, so it must close that adoption gap until KRO does so itself.
+ */
+export async function repairRetainedKroGeneratedCrdOwnership(
+  kubeConfig: KubeConfig,
+  desiredResource: KubernetesObject,
+  dependencies: { readonly api?: MigrationApi } = {}
+): Promise<void> {
+  const desiredRgd = desiredResource as ResourceGraphDefinition;
+  const rgdName = desiredRgd.metadata?.name;
+  const apiVersion = desiredRgd.spec?.schema?.apiVersion;
+  const kind = desiredRgd.spec?.schema?.kind;
+  if (!rgdName || !apiVersion || !kind) return;
+
+  const api = dependencies.api ?? createBunCompatibleKubernetesObjectApi(kubeConfig);
+  const liveRgd = (await api.read({
+    apiVersion: 'kro.run/v1alpha1',
+    kind: 'ResourceGraphDefinition',
+    metadata: { name: rgdName },
+  })) as ResourceGraphDefinition;
+  const liveRgdUid = liveRgd.metadata?.uid;
+  if (!liveRgdUid) {
+    throw new Error(
+      `Cannot adopt the retained generated CRD for ${rgdName}: the live ResourceGraphDefinition has no UID`
+    );
+  }
+
+  const group =
+    desiredRgd.spec?.schema?.group ??
+    (apiVersion.includes('/') ? apiVersion.slice(0, apiVersion.lastIndexOf('/')) : 'kro.run');
+  for (let attempt = 1; attempt <= MAX_CRD_PATCH_ATTEMPTS; attempt += 1) {
+    const crd = await findGeneratedCrd(api, group, kind);
+    if (!crd?.metadata?.name) return;
+    const labels = crd.metadata.labels ?? {};
+    if (labels[KRO_OWNED_LABEL] !== 'true') {
+      throw new Error(
+        `Cannot adopt generated CRD ${crd.metadata.name} for ResourceGraphDefinition ${rgdName}: the CRD is not marked as KRO-owned`
+      );
+    }
+    if (labels[KRO_RGD_NAME_LABEL] !== rgdName) {
+      throw new Error(
+        `Cannot adopt generated CRD ${crd.metadata.name} for ResourceGraphDefinition ${rgdName}: it belongs to ${labels[KRO_RGD_NAME_LABEL] ?? 'an unknown ResourceGraphDefinition'}`
+      );
+    }
+    if (labels[KRO_RGD_ID_LABEL] === liveRgdUid) return;
+    if (!crd.metadata.resourceVersion) {
+      throw new Error(
+        `Cannot adopt generated CRD ${crd.metadata.name}: the live resource has no resourceVersion`
+      );
+    }
+
+    try {
+      await api.replace({
+        ...crd,
+        apiVersion: 'apiextensions.k8s.io/v1',
+        kind: 'CustomResourceDefinition',
+        metadata: {
+          ...crd.metadata,
+          labels: {
+            ...labels,
+            [KRO_RGD_ID_LABEL]: liveRgdUid,
+          },
+        },
+      });
+      await requestRgdReconcile(api, rgdName, 'retained-crd-adoption');
+      return;
+    } catch (error: unknown) {
+      if (getErrorStatusCode(error) !== 409 || attempt === MAX_CRD_PATCH_ATTEMPTS) {
+        throw new Error(
+          `Could not adopt generated CRD ${crd.metadata.name} for ResourceGraphDefinition ${rgdName} after ${attempt} attempt${attempt === 1 ? '' : 's'}: ${ensureError(error).message}`
+        );
+      }
+    }
+  }
 }
 
 /**

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -151,7 +151,10 @@ import {
 import { DirectDeploymentEngine } from './engine.js';
 import { logHandleSnapshot } from './handle-tracing.js';
 import { isNotFoundError } from './k8s-helpers.js';
-import { migrateLegacyKroArtifactBindingCrd } from './kro-artifact-binding-migration.js';
+import {
+  migrateLegacyKroArtifactBindingCrd,
+  repairRetainedKroGeneratedCrdOwnership,
+} from './kro-artifact-binding-migration.js';
 import { assertKroInstanceSpecPreserved } from './kro-instance-admission.js';
 import {
   assertKroInstanceNamespaceOwnershipSafe,
@@ -2135,6 +2138,7 @@ export class KroResourceFactoryImpl<
             timeout: member.factory.factoryOptions.timeout || DEFAULT_RGD_TIMEOUT,
             ...(abortSignal ? { abortSignal } : {}),
           });
+          await member.factory.repairRetainedCrdOwnership(resource);
           await member.factory.waitForCRDReadyWithEngine(deploymentEngine, abortSignal);
           continue;
         }
@@ -4725,6 +4729,10 @@ export class KroResourceFactoryImpl<
     await migrateLegacyKroArtifactBindingCrd(this.getKubeConfig(), rgdManifest);
   }
 
+  private async repairRetainedCrdOwnership(rgdManifest: k8s.KubernetesObject): Promise<void> {
+    await repairRetainedKroGeneratedCrdOwnership(this.getKubeConfig(), rgdManifest);
+  }
+
   /**
    * Ensure the ResourceGraphDefinition is deployed using DirectDeploymentEngine.
    *
@@ -4801,6 +4809,7 @@ export class KroResourceFactoryImpl<
         timeout: this.factoryOptions.timeout || DEFAULT_RGD_TIMEOUT,
         ...(abortSignal ? { abortSignal } : {}),
       });
+      await this.repairRetainedCrdOwnership(rgdWithMetadata);
       this.logger.info('RGD accepted, waiting for CRD', { rgdName: this.rgdName });
 
       // Wait for the CRD to be created by Kro using DirectDeploymentEngine

--- a/test/core/kro-artifact-binding-migration.test.ts
+++ b/test/core/kro-artifact-binding-migration.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, mock, test } from 'bun:test';
 import type { KubeConfig, KubernetesObject } from '@kubernetes/client-node';
 import { ApiException } from '@kubernetes/client-node/dist/gen/apis/exception.js';
-import { migrateLegacyKroArtifactBindingCrd } from '../../src/core/deployment/kro-artifact-binding-migration.js';
+import {
+  migrateLegacyKroArtifactBindingCrd,
+  repairRetainedKroGeneratedCrdOwnership,
+} from '../../src/core/deployment/kro-artifact-binding-migration.js';
 import {
   kroArtifactOutputField,
   kroArtifactRequirementField,
@@ -81,6 +84,162 @@ function legacyCrd(resourceVersion: string): KubernetesObject {
 }
 
 describe('KRO artifact-binding migration', () => {
+  test('adopts a retained generated CRD after its RGD is recreated', async () => {
+    const desired = desiredRgd();
+    const liveRgd = {
+      ...desired,
+      metadata: {
+        name: 'application',
+        uid: 'new-rgd-uid',
+        resourceVersion: '20',
+      },
+    } as KubernetesObject;
+    const crd = legacyCrd('10');
+    crd.metadata = {
+      ...crd.metadata,
+      labels: {
+        'kro.run/owned': 'true',
+        'kro.run/resource-graph-definition-name': 'application',
+        'kro.run/resource-graph-definition-id': 'deleted-rgd-uid',
+        retained: 'true',
+      },
+    };
+    const replace = mock(async (resource: KubernetesObject) => resource);
+
+    await repairRetainedKroGeneratedCrdOwnership({} as KubeConfig, desired, {
+      api: {
+        read: mock(async () => liveRgd),
+        list: mock(async () => ({ items: [crd] })),
+        replace,
+      } as never,
+    });
+
+    const replacements = replace.mock.calls.map(([resource]) => resource as KubernetesObject);
+    expect(replacements[0]).toMatchObject({
+      apiVersion: 'apiextensions.k8s.io/v1',
+      kind: 'CustomResourceDefinition',
+      metadata: {
+        resourceVersion: '10',
+        labels: {
+          retained: 'true',
+          'kro.run/resource-graph-definition-id': 'new-rgd-uid',
+        },
+      },
+    });
+    expect(replacements[1]).toMatchObject({
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'ResourceGraphDefinition',
+      metadata: {
+        name: 'application',
+        resourceVersion: '20',
+        annotations: {
+          'typekro.io/retained-crd-adoption-retry': expect.any(String),
+        },
+      },
+    });
+  });
+
+  test('retries generated CRD adoption after optimistic-concurrency conflicts', async () => {
+    const desired = desiredRgd();
+    const generatedCrd = legacyCrd('10');
+    generatedCrd.metadata = {
+      ...generatedCrd.metadata,
+      labels: {
+        'kro.run/owned': 'true',
+        'kro.run/resource-graph-definition-name': 'application',
+        'kro.run/resource-graph-definition-id': 'deleted-rgd-uid',
+      },
+    };
+    let listCount = 0;
+    const list = mock(async () => {
+      const crd = structuredClone(generatedCrd);
+      crd.metadata = { ...crd.metadata, resourceVersion: String(10 + listCount++) };
+      return { items: [crd] };
+    });
+    const replace = mock(async (resource: KubernetesObject) => {
+      if (
+        resource.kind === 'CustomResourceDefinition' &&
+        resource.metadata?.resourceVersion === '10'
+      ) {
+        throw new ApiException(409, 'Conflict', undefined, {});
+      }
+      return resource;
+    });
+
+    await repairRetainedKroGeneratedCrdOwnership({} as KubeConfig, desired, {
+      api: {
+        read: mock(async () => ({
+          ...desired,
+          metadata: { name: 'application', uid: 'new-rgd-uid', resourceVersion: '20' },
+        })),
+        list,
+        replace,
+      } as never,
+    });
+
+    const crdReplacements = replace.mock.calls
+      .map(([resource]) => resource as KubernetesObject)
+      .filter((resource) => resource.kind === 'CustomResourceDefinition');
+    expect(crdReplacements.map((resource) => resource.metadata?.resourceVersion)).toEqual([
+      '10',
+      '11',
+    ]);
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+
+  test('fails closed when the generated CRD belongs to another RGD', async () => {
+    const desired = desiredRgd();
+    const crd = legacyCrd('10');
+    crd.metadata = {
+      ...crd.metadata,
+      labels: {
+        'kro.run/owned': 'true',
+        'kro.run/resource-graph-definition-name': 'another-application',
+        'kro.run/resource-graph-definition-id': 'another-rgd-uid',
+      },
+    };
+
+    await expect(
+      repairRetainedKroGeneratedCrdOwnership({} as KubeConfig, desired, {
+        api: {
+          read: mock(async () => ({
+            ...desired,
+            metadata: { name: 'application', uid: 'new-rgd-uid', resourceVersion: '20' },
+          })),
+          list: mock(async () => ({ items: [crd] })),
+          replace: mock(async (resource: KubernetesObject) => resource),
+        } as never,
+      })
+    ).rejects.toThrow('it belongs to another-application');
+  });
+
+  test('leaves a generated CRD already owned by the current RGD unchanged', async () => {
+    const desired = desiredRgd();
+    const crd = legacyCrd('10');
+    crd.metadata = {
+      ...crd.metadata,
+      labels: {
+        'kro.run/owned': 'true',
+        'kro.run/resource-graph-definition-name': 'application',
+        'kro.run/resource-graph-definition-id': 'current-rgd-uid',
+      },
+    };
+    const replace = mock(async (resource: KubernetesObject) => resource);
+
+    await repairRetainedKroGeneratedCrdOwnership({} as KubeConfig, desired, {
+      api: {
+        read: mock(async () => ({
+          ...desired,
+          metadata: { name: 'application', uid: 'current-rgd-uid', resourceVersion: '20' },
+        })),
+        list: mock(async () => ({ items: [crd] })),
+        replace,
+      } as never,
+    });
+
+    expect(replace).not.toHaveBeenCalled();
+  });
+
   test('treats a real client 404 as an absent RGD', async () => {
     const read = mock(async () => {
       throw new ApiException(404, 'Not Found', undefined, {});

--- a/test/core/kro-artifact-bundle-standalone.test.ts
+++ b/test/core/kro-artifact-bundle-standalone.test.ts
@@ -44,6 +44,7 @@ describe('standalone KRO artifact-bundle execution', () => {
     replace(factoryPrototype, 'executeClosuresBeforeRGD', async () => []);
     replace(factoryPrototype, 'addRgdSchemaStatusPruneMarkers', async () => {});
     replace(factoryPrototype, 'migrateLegacyArtifactBindings', async () => {});
+    replace(factoryPrototype, 'repairRetainedCrdOwnership', async () => {});
     replace(factoryPrototype, 'dispose', async () => {});
     replace(
       enginePrototype,
@@ -98,6 +99,7 @@ describe('standalone KRO artifact-bundle execution', () => {
     replace(factoryPrototype, 'executeClosuresBeforeRGD', async () => []);
     replace(factoryPrototype, 'addRgdSchemaStatusPruneMarkers', async () => {});
     replace(factoryPrototype, 'migrateLegacyArtifactBindings', async () => {});
+    replace(factoryPrototype, 'repairRetainedCrdOwnership', async () => {});
     replace(factoryPrototype, 'waitForCRDReadyWithEngine', async () => {});
     replace(factoryPrototype, 'waitForKroInstanceReady', async () => {});
     replace(factoryPrototype, 'createEnhancedProxy', async (spec: unknown, name: string) => ({
@@ -205,6 +207,7 @@ describe('standalone KRO artifact-bundle execution', () => {
     replace(factoryPrototype, 'executeClosuresBeforeRGD', async () => []);
     replace(factoryPrototype, 'addRgdSchemaStatusPruneMarkers', async () => {});
     replace(factoryPrototype, 'migrateLegacyArtifactBindings', async () => {});
+    replace(factoryPrototype, 'repairRetainedCrdOwnership', async () => {});
     replace(factoryPrototype, 'waitForCRDReadyWithEngine', async () => {});
     replace(factoryPrototype, 'waitForKroInstanceReady', async () => {});
     replace(factoryPrototype, 'createEnhancedProxy', async (spec: unknown, name: string) => ({
@@ -272,6 +275,7 @@ describe('standalone KRO artifact-bundle execution', () => {
     replace(factoryPrototype, 'executeClosuresBeforeRGD', async () => []);
     replace(factoryPrototype, 'addRgdSchemaStatusPruneMarkers', async () => {});
     replace(factoryPrototype, 'migrateLegacyArtifactBindings', async () => {});
+    replace(factoryPrototype, 'repairRetainedCrdOwnership', async () => {});
     replace(factoryPrototype, 'waitForCRDReadyWithEngine', async () => {});
     replace(factoryPrototype, 'waitForKroInstanceReady', async () => {});
     replace(

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -592,6 +592,9 @@ describe('KroResourceFactory: RGD deployment engine lifecycle', () => {
     internals.migrateLegacyArtifactBindings = async () => {
       events.push('migrate');
     };
+    internals.repairRetainedCrdOwnership = async () => {
+      events.push('adopt');
+    };
     internals.createEnhancedProxy = async (spec: TestSpec) => ({
       apiVersion: 'tests.typekro.dev/v1alpha1',
       kind: 'ArtifactMigrationPath',
@@ -616,6 +619,9 @@ describe('KroResourceFactory: RGD deployment engine lifecycle', () => {
       expect(events).toContain('migrate');
       expect(events.indexOf('migrate')).toBeLessThan(
         events.indexOf('deploy:ResourceGraphDefinition')
+      );
+      expect(events.indexOf('deploy:ResourceGraphDefinition')).toBeLessThan(
+        events.indexOf('adopt')
       );
     } finally {
       proto.deployResource = originalDeployResource;
@@ -642,6 +648,8 @@ describe('KroResourceFactory: RGD deployment engine lifecycle', () => {
       disposed = true;
     };
     (factory as unknown as Record<string, unknown>).migrateLegacyArtifactBindings = async () =>
+      undefined;
+    (factory as unknown as Record<string, unknown>).repairRetainedCrdOwnership = async () =>
       undefined;
 
     try {

--- a/test/unit/alchemy/kro-artifact-binding-migration.test.ts
+++ b/test/unit/alchemy/kro-artifact-binding-migration.test.ts
@@ -35,6 +35,9 @@ describe('Alchemy KRO artifact-binding migration', () => {
     const migrate = mock(async () => {
       events.push('migrate');
     });
+    const repair = mock(async () => {
+      events.push('adopt');
+    });
 
     await deployKroResourceForTest(
       {
@@ -46,11 +49,13 @@ describe('Alchemy KRO artifact-binding migration', () => {
       undefined,
       {
         migrateLegacyArtifactBindings: migrate,
+        repairRetainedCrdOwnership: repair,
         kubeConfigForMigration: createMockKubeConfig,
       }
     );
 
     expect(migrate).toHaveBeenCalledTimes(1);
-    expect(events).toEqual(['migrate', 'deploy']);
+    expect(repair).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(['migrate', 'deploy', 'adopt']);
   });
 });


### PR DESCRIPTION
## What changed

- repair retained KRO-generated CRD ownership after a ResourceGraphDefinition is recreated
- preserve the complete CRD and optimistic-concurrency metadata while updating only the stale RGD UID label
- request a fresh RGD reconciliation after adoption
- run the repair in both standalone/imperative and Alchemy KRO deployment paths
- fail closed on conflicting CRD ownership and retry Kubernetes 409 conflicts

## Root cause

KRO 0.9.2 recognizes a retained generated CRD whose RGD name matches but whose RGD UID is stale. When the schema and names are otherwise unchanged, KRO returns before updating the CRD ownership labels. TypeKro intentionally retains generated CRDs for safe reuse, so a recreated RGD can report ready while its dynamic instance controller is not safely re-established; terminating instances may then retain `kro.run/finalizer` indefinitely.

## Developer impact

Normal TypeKro deployment now repairs the retained-CRD ownership boundary immediately after the RGD is applied and before waiting for/using the generated kind. Existing current ownership is a no-op. Conflicting or unverifiable ownership fails closed.

## Validation

- 5,310 full tests passed; 13 skipped; 1 existing todo; 0 failed
- 150 focused KRO artifact-bundle, migration, factory, and Alchemy tests passed
- library, examples, and test typechecks passed
- lint and full build passed
- live OrbStack reproduction updated the retained CRD from the deleted RGD UID to the current live RGD UID while preserving the healthy Developer instance

## Upstream limitation observed

A KRO 0.9.2 instance whose deletion began before controller adoption may still require the upstream controller process to rebuild its in-memory dynamic-controller registry before it replays that old deletion. This PR does not strip finalizers or report false success; `deleteInstance()` continues to return a structured retryable `FINALIZERS_REMAIN` result in that case.