### PR TITLE
Fix Alchemy RGD teardown ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Alchemy KRO teardown no longer mistakes the declaration set's own terminating
+  instance for a foreign consumer of its ResourceGraphDefinition. The RGD now
+  remains a hard, finalizer-aware deletion gate instead of reporting success,
+  dropping retry state, and leaking the live definition.
 - NATS bootstraps now consume one explicit cluster-wide NACK singleton in
   CRD-connect mode instead of installing a competing non-namespaced controller
   per NATS instance. The official NACK chart uses fixed ClusterRole and

--- a/src/alchemy/deployers.ts
+++ b/src/alchemy/deployers.ts
@@ -39,13 +39,25 @@ export class ResourceGraphDefinitionDeletionDeferredError extends Error {
   }
 }
 
+export class ResourceGraphDefinitionOwnedInstancePendingError extends Error {
+  constructor(rgdName: string) {
+    super(
+      `ResourceGraphDefinition deletion must retry because its owned KRO instance still exists for ${rgdName}`
+    );
+    this.name = 'ResourceGraphDefinitionOwnedInstancePendingError';
+  }
+}
+
 interface KroTypeKroDeployerOptions {
   /** Validate that the API server preserved the desired KRO instance spec. */
   validateInstanceSpec?: boolean;
   /** Finalizer-safe KRO instance deletion supplied by the owning factory. */
   deleteInstance?: (name: string, abortSignal?: AbortSignal) => Promise<ResourceDeletionResult>;
-  /** True when an RGD still has live instances and must be preserved. */
-  shouldSkipRgdDelete?: (rgdName: string, abortSignal?: AbortSignal) => Promise<boolean>;
+  /** Three-way ownership decision for a definition whose instances may still exist. */
+  rgdDeletionDecision?: (
+    rgdName: string,
+    abortSignal?: AbortSignal
+  ) => Promise<'delete' | 'retain-shared' | 'retry-owned'>;
   /** Delete the RGD when no CR instance exists; the generated CRD is retained for safe reuse. */
   deleteResourceGraphDefinition?: (rgdName: string, abortSignal?: AbortSignal) => Promise<void>;
 }
@@ -292,11 +304,14 @@ export class KroTypeKroDeployer implements TypeKroDeployer {
     if (resource.kind === 'ResourceGraphDefinition') {
       if (this.deployerOptions.deleteInstance) {
         const rgdName = resource.metadata?.name || 'unnamed';
-        const shouldSkip =
+        const decision =
           (await (options.abortSignal
-            ? this.deployerOptions.shouldSkipRgdDelete?.(rgdName, options.abortSignal)
-            : this.deployerOptions.shouldSkipRgdDelete?.(rgdName))) ?? true;
-        if (shouldSkip) {
+            ? this.deployerOptions.rgdDeletionDecision?.(rgdName, options.abortSignal)
+            : this.deployerOptions.rgdDeletionDecision?.(rgdName))) ?? 'retry-owned';
+        if (decision === 'retry-owned') {
+          throw new ResourceGraphDefinitionOwnedInstancePendingError(rgdName);
+        }
+        if (decision === 'retain-shared') {
           logger.debug('Deferring Alchemy RGD delete while KRO instances still exist', {
             name: resource.metadata?.name,
           });

--- a/src/alchemy/kro-delete.ts
+++ b/src/alchemy/kro-delete.ts
@@ -218,31 +218,40 @@ export async function hasKroInstances(
  *
  * The owned instance may still be terminating when Alchemy reaches the RGD
  * delete. Treating it as a shared consumer drops the RGD state entry and makes
- * the deletion impossible to retry. Letting the RGD deletion proceed instead
- * provides a hard, finalizer-aware gate: it completes after the owned instance
- * drains, or fails without losing state.
+ * the deletion impossible to retry. Deleting the RGD would stop KRO's instance
+ * controller before its finalizer drains. Keep the declaration state retryable
+ * until the owned instance is absent; retain the RGD when only foreign
+ * instances remain; delete it only when the instance set is empty.
  */
-export async function hasForeignKroInstances(
+export type KroRgdDeletionDecision = 'delete' | 'retain-shared' | 'retry-owned';
+
+export async function decideKroRgdDeletion(
   kubeConfig: KubeConfig,
   options: KroDeletionOptions,
   abortSignal?: AbortSignal
-): Promise<boolean> {
-  return hasForeignKroInstancesWithApi(kubeConfig, options, undefined, abortSignal);
+): Promise<KroRgdDeletionDecision> {
+  return decideKroRgdDeletionWithApi(kubeConfig, options, undefined, abortSignal);
 }
 
-async function hasForeignKroInstancesWithApi(
+async function decideKroRgdDeletionWithApi(
   kubeConfig: KubeConfig,
   options: KroDeletionOptions,
   customApi?: CustomObjectListApi,
   abortSignal?: AbortSignal
-): Promise<boolean> {
+): Promise<KroRgdDeletionDecision> {
   const instances = await listKroInstances(kubeConfig, options, customApi, abortSignal);
-  if (!options.instanceName) return instances.length > 0;
-  return shouldPreserveRgd(instances, options.instanceName, true, options.namespace);
+  if (instances.length === 0) return 'delete';
+  if (!options.instanceName) return 'retry-owned';
+  const ownedExists = instances.some(
+    (instance) => instance.metadata?.name === options.instanceName
+      && instance.metadata?.namespace === options.namespace
+  );
+  if (ownedExists) return 'retry-owned';
+  return 'retain-shared';
 }
 
 /** Internal test hook for declaration-set-aware shared RGD classification. */
-export const hasForeignKroInstancesForTest = hasForeignKroInstancesWithApi;
+export const decideKroRgdDeletionForTest = decideKroRgdDeletionWithApi;
 
 export async function deleteKroDefinition(
   kubeConfig: KubeConfig,

--- a/src/alchemy/kro-delete.ts
+++ b/src/alchemy/kro-delete.ts
@@ -21,6 +21,12 @@ export interface KroDeletionOptions {
   kind: string;
   namespace: string;
   rgdName: string;
+  /**
+   * Instance owned by the same Alchemy declaration set as the RGD. The RGD delete
+   * must not classify this instance as a foreign/shared consumer: reverse-topology
+   * teardown may still be draining it when the RGD delete begins.
+   */
+  instanceName?: string;
   group?: string;
   plural?: string;
   timeout?: number;
@@ -205,6 +211,38 @@ export async function hasKroInstances(
 ): Promise<boolean> {
   return (await listKroInstances(kubeConfig, options, undefined, abortSignal)).length > 0;
 }
+
+/**
+ * Return whether an RGD is used by an instance other than the instance owned by
+ * the current Alchemy declaration set.
+ *
+ * The owned instance may still be terminating when Alchemy reaches the RGD
+ * delete. Treating it as a shared consumer drops the RGD state entry and makes
+ * the deletion impossible to retry. Letting the RGD deletion proceed instead
+ * provides a hard, finalizer-aware gate: it completes after the owned instance
+ * drains, or fails without losing state.
+ */
+export async function hasForeignKroInstances(
+  kubeConfig: KubeConfig,
+  options: KroDeletionOptions,
+  abortSignal?: AbortSignal
+): Promise<boolean> {
+  return hasForeignKroInstancesWithApi(kubeConfig, options, undefined, abortSignal);
+}
+
+async function hasForeignKroInstancesWithApi(
+  kubeConfig: KubeConfig,
+  options: KroDeletionOptions,
+  customApi?: CustomObjectListApi,
+  abortSignal?: AbortSignal
+): Promise<boolean> {
+  const instances = await listKroInstances(kubeConfig, options, customApi, abortSignal);
+  if (!options.instanceName) return instances.length > 0;
+  return shouldPreserveRgd(instances, options.instanceName, true, options.namespace);
+}
+
+/** Internal test hook for declaration-set-aware shared RGD classification. */
+export const hasForeignKroInstancesForTest = hasForeignKroInstancesWithApi;
 
 export async function deleteKroDefinition(
   kubeConfig: KubeConfig,

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -83,7 +83,7 @@ import type { KroDeletionOptions } from './kro-delete.js';
 import {
   deleteKroDefinition,
   deleteKroInstanceFinalizerSafe,
-  hasForeignKroInstances,
+  decideKroRgdDeletion,
 } from './kro-delete.js';
 import type {
   AlchemyResourceDeclaration,
@@ -1555,7 +1555,10 @@ async function _createDeployer<T extends Enhanced<unknown, unknown>>(
     return new DirectTypeKroDeployer(engine);
   }
 
-  const kroDeletion = props.kroDeletion ?? inferKroDeletionOptions(props);
+  const kroDeletion = enrichKroDeletionOptions(
+    props,
+    props.kroDeletion ?? inferKroDeletionOptions(props)
+  );
   const validateInstanceSpec = shouldValidateKroInstanceAdmission(props);
   return new KroTypeKroDeployer(engine, {
     ...(validateInstanceSpec ? { validateInstanceSpec: true } : {}),
@@ -1563,8 +1566,8 @@ async function _createDeployer<T extends Enhanced<unknown, unknown>>(
       ? {
           deleteInstance: (name: string, abortSignal?: AbortSignal) =>
             deleteKroInstanceFinalizerSafe(kc, name, kroDeletion, abortSignal),
-          shouldSkipRgdDelete: (_rgdName: string, abortSignal?: AbortSignal) =>
-            hasForeignKroInstances(kc, kroDeletion, abortSignal),
+          rgdDeletionDecision: (_rgdName: string, abortSignal?: AbortSignal) =>
+            decideKroRgdDeletion(kc, kroDeletion, abortSignal),
           deleteResourceGraphDefinition: (_rgdName: string, abortSignal?: AbortSignal) =>
             deleteKroDefinition(kc, kroDeletion, undefined, abortSignal),
         }
@@ -1668,8 +1671,37 @@ function inferKroDeletionOptions<T extends Enhanced<unknown, unknown>>(
   };
 }
 
+function enrichKroDeletionOptions<T extends Enhanced<unknown, unknown>>(
+  props: TypeKroResourceProps<T>,
+  options: KroDeletionOptions | undefined
+): KroDeletionOptions | undefined {
+  if (!options || options.instanceName || !props.kroArtifactBundle) return options;
+  try {
+    const bundle = decodeKroArtifactBundle(props.kroArtifactBundle);
+    const operationId = bundle.root.instanceOperationId;
+    const operation = operationId
+      ? bundle.operations.find((candidate) => candidate.id === operationId)
+      : undefined;
+    if (!operation || operation.role !== 'instance') return options;
+    const instance = materializeKroArtifactBundleOperation(operation);
+    const instanceName = instance.metadata?.name;
+    const namespace = instance.metadata?.namespace;
+    if (typeof instanceName !== 'string' || !instanceName) return options;
+    return {
+      ...options,
+      instanceName,
+      ...(typeof namespace === 'string' && namespace ? { namespace } : {}),
+    };
+  } catch {
+    // Legacy/incomplete state remains fail-closed: an unclassified live
+    // instance returns retry-owned and the Alchemy state entry is retained.
+    return options;
+  }
+}
+
 /** Internal test hook for legacy Alchemy KRO state rehydration. */
 export const inferKroDeletionOptionsForTest = inferKroDeletionOptions;
+export const enrichKroDeletionOptionsForTest = enrichKroDeletionOptions;
 
 async function _resolveDeployer<T extends Enhanced<unknown, unknown>>(
   props: TypeKroResourceProps<T>,

--- a/src/alchemy/resource-registration.ts
+++ b/src/alchemy/resource-registration.ts
@@ -83,7 +83,7 @@ import type { KroDeletionOptions } from './kro-delete.js';
 import {
   deleteKroDefinition,
   deleteKroInstanceFinalizerSafe,
-  hasKroInstances,
+  hasForeignKroInstances,
 } from './kro-delete.js';
 import type {
   AlchemyResourceDeclaration,
@@ -1564,7 +1564,7 @@ async function _createDeployer<T extends Enhanced<unknown, unknown>>(
           deleteInstance: (name: string, abortSignal?: AbortSignal) =>
             deleteKroInstanceFinalizerSafe(kc, name, kroDeletion, abortSignal),
           shouldSkipRgdDelete: (_rgdName: string, abortSignal?: AbortSignal) =>
-            hasKroInstances(kc, kroDeletion, abortSignal),
+            hasForeignKroInstances(kc, kroDeletion, abortSignal),
           deleteResourceGraphDefinition: (_rgdName: string, abortSignal?: AbortSignal) =>
             deleteKroDefinition(kc, kroDeletion, undefined, abortSignal),
         }

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -3740,7 +3740,8 @@ export class KroResourceFactoryImpl<
       );
     }
     this.assertBundleCapabilities(undefined, { host: 'alchemy', output: 'live' });
-    const kroDeletion = this.createAlchemyKroDeletionOptions(instanceNamespace);
+    const instanceName = opts?.instanceNameOverride ?? generateInstanceName(spec, this.name);
+    const kroDeletion = this.createAlchemyKroDeletionOptions(instanceNamespace, instanceName);
     const prerequisiteDeclarations = this.prerequisiteAlchemyDeclarations(kubeConfigOptions);
     const prerequisiteIds = prerequisiteDeclarations.map((decl) => decl.id);
 
@@ -3837,7 +3838,6 @@ export class KroResourceFactoryImpl<
 
     // 2. CR instance declaration (one per deploy call). Depends on the RGD so alchemy applies the
     // instance only after the RGD's CRD is established (else the CR apply races a missing kind).
-    const instanceName = opts?.instanceNameOverride ?? generateInstanceName(spec, this.name);
     const crdInstanceManifest = this.createCustomResourceInstance(
       instanceName,
       spec,
@@ -3913,13 +3913,17 @@ export class KroResourceFactoryImpl<
   }
 
   /** Build the finalizer-safe, shared-RGD-aware deletion metadata for this factory's instances. */
-  private createAlchemyKroDeletionOptions(instanceNamespace = this.namespace): KroDeletionOptions {
+  private createAlchemyKroDeletionOptions(
+    instanceNamespace = this.namespace,
+    instanceName?: string
+  ): KroDeletionOptions {
     return {
       apiVersion: this.schemaDefinition.apiVersion,
       kind: this.schemaDefinition.kind,
       ...(this.schemaDefinition.group && { group: this.schemaDefinition.group }),
       namespace: instanceNamespace,
       rgdName: this.rgdName,
+      ...(instanceName ? { instanceName } : {}),
       ...(this.discoveredPlural && { plural: this.discoveredPlural }),
       timeout: this.factoryOptions.timeout ?? 300000,
     };
@@ -3963,6 +3967,7 @@ export class KroResourceFactoryImpl<
         ? String(materializePlanValue(instanceIdentity.namespace))
         : this.namespace,
       rgdName: String(materializePlanValue(rgdIdentity.name)),
+      instanceName: String(materializePlanValue(instanceIdentity.name)),
       ...(group ? { group } : {}),
       timeout: this.factoryOptions.timeout ?? 300000,
     };

--- a/test/core/kro-factory-characterization.test.ts
+++ b/test/core/kro-factory-characterization.test.ts
@@ -1168,6 +1168,8 @@ describe('KroResourceFactory: toAlchemyResources (alchemy v2)', () => {
     expect(rgd.props.kubeConfigOptions?.cluster).toBeUndefined();
     expect(rgd.props.kroDeletion?.rgdName).toBe(factory.rgdName);
     expect(rgd.props.kroDeletion?.kind).toBe('TestApp');
+    expect(rgd.props.kroDeletion?.instanceName).toBe('web');
+    expect(instance.props.kroDeletion?.instanceName).toBe('web');
 
     // Instance: one per deploy. Ready-gated by default (matching the imperative deploy path), so a
     // declarative converge blocks until the CR's KRO-managed resources are actually ready.

--- a/test/unit/alchemy-deployers.test.ts
+++ b/test/unit/alchemy-deployers.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   deleteKroDefinition,
   deleteKroInstanceFinalizerSafeForTest,
+  hasForeignKroInstancesForTest,
   listKroInstancesForTest,
 } from '../../src/alchemy/kro-delete.js';
 import {
@@ -833,6 +834,52 @@ describe('KroTypeKroDeployer', () => {
 
     expect(listCalls).toEqual([{ group: 'example.com', version: 'v1alpha1', plural: 'testapps' }]);
     expect(instances[0]?.metadata?.namespace).toBe('apps-b');
+  });
+
+  it('does not mistake the declaration-set instance for a shared RGD consumer', async () => {
+    const listClusterCustomObject = mock(() =>
+      Promise.resolve({
+        items: [{ metadata: { name: 'owned-instance', namespace: 'apps-a' } }],
+      })
+    );
+
+    const shared = await hasForeignKroInstancesForTest(
+      {} as any,
+      {
+        apiVersion: 'example.com/v1alpha1',
+        group: 'example.com',
+        kind: 'TestApp',
+        namespace: 'apps-a',
+        rgdName: 'test-app',
+        plural: 'testapps',
+        instanceName: 'owned-instance',
+      },
+      { listClusterCustomObject }
+    );
+
+    expect(shared).toBe(false);
+
+    listClusterCustomObject.mockResolvedValue({
+      items: [
+        { metadata: { name: 'owned-instance', namespace: 'apps-a' } },
+        { metadata: { name: 'other-instance', namespace: 'apps-b' } },
+      ],
+    });
+    await expect(
+      hasForeignKroInstancesForTest(
+        {} as any,
+        {
+          apiVersion: 'example.com/v1alpha1',
+          group: 'example.com',
+          kind: 'TestApp',
+          namespace: 'apps-a',
+          rgdName: 'test-app',
+          plural: 'testapps',
+          instanceName: 'owned-instance',
+        },
+        { listClusterCustomObject }
+      )
+    ).resolves.toBe(true);
   });
 
   it('deletes KRO instance then removes RGD (leaves the CRD for out-of-band GC) when no instances remain', async () => {

--- a/test/unit/alchemy-deployers.test.ts
+++ b/test/unit/alchemy-deployers.test.ts
@@ -9,11 +9,12 @@ import {
   DirectTypeKroDeployer,
   KroTypeKroDeployer,
   ResourceGraphDefinitionDeletionDeferredError,
+  ResourceGraphDefinitionOwnedInstancePendingError,
 } from '../../src/alchemy/deployers.js';
 import {
   deleteKroDefinition,
   deleteKroInstanceFinalizerSafeForTest,
-  hasForeignKroInstancesForTest,
+  decideKroRgdDeletionForTest,
   listKroInstancesForTest,
 } from '../../src/alchemy/kro-delete.js';
 import {
@@ -836,14 +837,14 @@ describe('KroTypeKroDeployer', () => {
     expect(instances[0]?.metadata?.namespace).toBe('apps-b');
   });
 
-  it('does not mistake the declaration-set instance for a shared RGD consumer', async () => {
+  it('retries while the declaration-set instance exists and retains only foreign consumers', async () => {
     const listClusterCustomObject = mock(() =>
       Promise.resolve({
         items: [{ metadata: { name: 'owned-instance', namespace: 'apps-a' } }],
       })
     );
 
-    const shared = await hasForeignKroInstancesForTest(
+    const decision = await decideKroRgdDeletionForTest(
       {} as any,
       {
         apiVersion: 'example.com/v1alpha1',
@@ -857,7 +858,7 @@ describe('KroTypeKroDeployer', () => {
       { listClusterCustomObject }
     );
 
-    expect(shared).toBe(false);
+    expect(decision).toBe('retry-owned');
 
     listClusterCustomObject.mockResolvedValue({
       items: [
@@ -866,7 +867,7 @@ describe('KroTypeKroDeployer', () => {
       ],
     });
     await expect(
-      hasForeignKroInstancesForTest(
+      decideKroRgdDeletionForTest(
         {} as any,
         {
           apiVersion: 'example.com/v1alpha1',
@@ -879,7 +880,26 @@ describe('KroTypeKroDeployer', () => {
         },
         { listClusterCustomObject }
       )
-    ).resolves.toBe(true);
+    ).resolves.toBe('retry-owned');
+
+    listClusterCustomObject.mockResolvedValue({
+      items: [{ metadata: { name: 'other-instance', namespace: 'apps-b' } }],
+    });
+    await expect(
+      decideKroRgdDeletionForTest(
+        {} as any,
+        {
+          apiVersion: 'example.com/v1alpha1',
+          group: 'example.com',
+          kind: 'TestApp',
+          namespace: 'apps-a',
+          rgdName: 'test-app',
+          plural: 'testapps',
+          instanceName: 'owned-instance',
+        },
+        { listClusterCustomObject }
+      )
+    ).resolves.toBe('retain-shared');
   });
 
   it('deletes KRO instance then removes RGD (leaves the CRD for out-of-band GC) when no instances remain', async () => {
@@ -1216,8 +1236,8 @@ describe('KroTypeKroDeployer', () => {
   it('defers ResourceGraphDefinition state deletion while KRO instances still exist', async () => {
     const mockEngine = createMockEngine() as any;
     const deleteInstance = mock(() => Promise.resolve(completeKroDeletion()));
-    const shouldSkipRgdDelete = mock(() => Promise.resolve(true));
-    const deployer = new KroTypeKroDeployer(mockEngine, { deleteInstance, shouldSkipRgdDelete });
+    const rgdDeletionDecision = mock(() => Promise.resolve('retain-shared' as const));
+    const deployer = new KroTypeKroDeployer(mockEngine, { deleteInstance, rgdDeletionDecision });
     const rgd = {
       apiVersion: 'kro.run/v1alpha1',
       kind: 'ResourceGraphDefinition',
@@ -1233,18 +1253,39 @@ describe('KroTypeKroDeployer', () => {
     ).rejects.toBeInstanceOf(ResourceGraphDefinitionDeletionDeferredError);
 
     expect(deleteInstance).not.toHaveBeenCalled();
-    expect(shouldSkipRgdDelete).toHaveBeenCalledWith('test-app');
+    expect(rgdDeletionDecision).toHaveBeenCalledWith('test-app');
+    expect(mockEngine.deleteResource).not.toHaveBeenCalled();
+  });
+
+  it('fails without dropping state while the owned KRO instance still exists', async () => {
+    const mockEngine = createMockEngine() as any;
+    const rgdDeletionDecision = mock(() => Promise.resolve('retry-owned' as const));
+    const deployer = new KroTypeKroDeployer(mockEngine, {
+      deleteInstance: mock(() => Promise.resolve(completeKroDeletion())),
+      rgdDeletionDecision,
+    });
+    const rgd = {
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'ResourceGraphDefinition',
+      metadata: { name: 'test-app' },
+      spec: {},
+    } as any;
+
+    await expect(
+      deployer.delete(rgd, { mode: 'kro', namespace: 'test-ns' })
+    ).rejects.toBeInstanceOf(ResourceGraphDefinitionOwnedInstancePendingError);
+    expect(rgdDeletionDecision).toHaveBeenCalledWith('test-app');
     expect(mockEngine.deleteResource).not.toHaveBeenCalled();
   });
 
   it('deletes ResourceGraphDefinitions when no KRO instances were registered', async () => {
     const mockEngine = createMockEngine() as any;
     const deleteInstance = mock(() => Promise.resolve(completeKroDeletion()));
-    const shouldSkipRgdDelete = mock(() => Promise.resolve(false));
+    const rgdDeletionDecision = mock(() => Promise.resolve('delete' as const));
     const deleteResourceGraphDefinition = mock(() => Promise.resolve());
     const deployer = new KroTypeKroDeployer(mockEngine, {
       deleteInstance,
-      shouldSkipRgdDelete,
+      rgdDeletionDecision,
       deleteResourceGraphDefinition,
     });
     const rgd = {
@@ -1257,7 +1298,7 @@ describe('KroTypeKroDeployer', () => {
     await deployer.delete(rgd, { mode: 'kro', namespace: 'test-ns' });
 
     expect(deleteInstance).not.toHaveBeenCalled();
-    expect(shouldSkipRgdDelete).toHaveBeenCalledWith('test-app');
+    expect(rgdDeletionDecision).toHaveBeenCalledWith('test-app');
     expect(deleteResourceGraphDefinition).toHaveBeenCalledWith('test-app');
     expect(mockEngine.deleteResource).not.toHaveBeenCalled();
   });
@@ -1347,7 +1388,7 @@ describe('KroTypeKroDeployer', () => {
     const deleteResourceGraphDefinition = mock(() => Promise.reject(new Error('RBAC denied')));
     const deployer = new KroTypeKroDeployer(mockEngine, {
       deleteInstance: mock(() => Promise.resolve(completeKroDeletion())),
-      shouldSkipRgdDelete: mock(() => Promise.resolve(false)),
+      rgdDeletionDecision: mock(() => Promise.resolve('delete' as const)),
       deleteResourceGraphDefinition,
     });
     const rgd = {

--- a/test/unit/alchemy/kro-artifact-rehydration.test.ts
+++ b/test/unit/alchemy/kro-artifact-rehydration.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
 import * as Redacted from 'effect/Redacted';
 
-import { resourceFromKroArtifactBundleForTest } from '../../../src/alchemy/resource-registration.js';
+import {
+  enrichKroDeletionOptionsForTest,
+  resourceFromKroArtifactBundleForTest,
+} from '../../../src/alchemy/resource-registration.js';
 import type {
   AlchemyResourceDeclaration,
   TypeKroResource,
@@ -78,6 +81,28 @@ async function restoredRootInstance() {
 }
 
 describe('KRO Alchemy artifact-bundle rehydration', () => {
+  it('repairs pre-upgrade RGD deletion state from the persisted artifact bundle', async () => {
+    const { declarations } = await restoredRootInstance();
+    const rgd = declarations.find(
+      (declaration) => declaration.props.resource.kind === 'ResourceGraphDefinition'
+    );
+    expect(rgd).toBeDefined();
+
+    const legacyProps = JSON.parse(JSON.stringify(rgd!.props)) as TypeKroResourceProps<
+      Enhanced<unknown, unknown>
+    >;
+    expect(legacyProps.kroDeletion).toBeDefined();
+    delete legacyProps.kroDeletion!.instanceName;
+
+    expect(
+      enrichKroDeletionOptionsForTest(legacyProps, legacyProps.kroDeletion)
+    ).toMatchObject({
+      instanceName: 'demo',
+      namespace: 'apps',
+      rgdName: 'alchemy-kro-artifact-rehydration',
+    });
+  });
+
   it('materializes provider outputs after a KRO bundle state round trip', async () => {
     const composition = toResourceGraph(
       {


### PR DESCRIPTION
## What changed

- persist the exact KRO instance owned by each Alchemy RGD declaration set
- exclude only that instance from shared-definition detection during reverse-topology teardown
- preserve the existing retention behavior when a genuinely foreign instance still uses the RGD
- add regression coverage for owned versus foreign instances and serialized deletion metadata

## Why

Alchemy could reach an RGD delete while its own instance was still terminating. TypeKro treated that instance as a shared consumer, swallowed the deferred deletion, and allowed Alchemy to drop the state entry. The destroy then reported success while leaving the live RGD behind with no retry handle.

The owned instance is now distinguished from foreign consumers. Its RGD remains a hard, finalizer-aware deletion gate: the delete completes after the owned instance drains, or fails without losing retry state.

## Validation

- 187 focused tests passed
- full TypeKro unit suite passed: 5,307 passed, 13 skipped, 1 todo
- `bun run build` passed, including lint, library/examples/tests typecheck, and builds
- `git diff --check` passed
- the repaired TypeKro deletion lifecycle removed the zero-instance RGD leaked by the original Applik8s OrbStack teardown
