### PR TITLE
chore: release v0.33.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.33.6",
+  "version": "0.33.7",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Release

Bumps TypeKro to `v0.33.7` after merging:

- #156: repair retained KRO CRD ownership after RGD recreation
- #157: preserve Alchemy RGD teardown state until the owned instance drains
- #158: upgrade and enforce the patched `js-yaml` dependency floor

All three PR CI runs passed. The combined heads were also verified locally with 212 focused tests, full library/examples/test typechecking, a frozen install, and `git diff --check`.