### PR TITLE
fix security dependency pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TypeKro's frozen and published dependency graphs now pin `js-yaml` 4.3.1
+  and `angular-expressions` 1.5.2 so both runtime dependencies include their
+  current security patches.
 - Alchemy KRO teardown no longer mistakes the declaration set's own terminating
   instance for a foreign consumer of its ResourceGraphDefinition. The RGD now
   remains a hard, finalizer-aware deletion gate instead of reporting success,

--- a/bun.lock
+++ b/bun.lock
@@ -11,13 +11,13 @@
         "@kubernetes/client-node": "1.3.0",
         "acorn": "8.15.0",
         "alchemy": "2.0.0-beta.58",
-        "angular-expressions": "1.5.1",
+        "angular-expressions": "1.5.2",
         "arktype": "^2.2.0",
         "cel-js": "^0.8.2",
         "effect": "4.0.0-beta.84",
         "estraverse": "^5.3.0",
         "ignore": "^7.0.5",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "pino": "^9.8.0",
         "re2js": "2.8.6",
       },
@@ -54,7 +54,7 @@
     "@effect/platform-node-shared": "4.0.0-beta.84",
     "@effect/vitest": "4.0.0-beta.84",
     "effect": "4.0.0-beta.84",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
   },
   "packages": {
     "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
@@ -767,7 +767,7 @@
 
     "algoliasearch": ["algoliasearch@5.35.0", "", { "dependencies": { "@algolia/abtesting": "1.1.0", "@algolia/client-abtesting": "5.35.0", "@algolia/client-analytics": "5.35.0", "@algolia/client-common": "5.35.0", "@algolia/client-insights": "5.35.0", "@algolia/client-personalization": "5.35.0", "@algolia/client-query-suggestions": "5.35.0", "@algolia/client-search": "5.35.0", "@algolia/ingestion": "1.35.0", "@algolia/monitoring": "1.35.0", "@algolia/recommend": "5.35.0", "@algolia/requester-browser-xhr": "5.35.0", "@algolia/requester-fetch": "5.35.0", "@algolia/requester-node-http": "5.35.0" } }, "sha512-Y+moNhsqgLmvJdgTsO4GZNgsaDWv8AOGAaPeIeHKlDn/XunoAqYbA+XNpBd1dW8GOXAUDyxC9Rxc7AV4kpFcIg=="],
 
-    "angular-expressions": ["angular-expressions@1.5.1", "", {}, "sha512-Ukcyuye0eb15zuvMFR7Kziuf7gV0gYAZXMevNI40rXF8f9k+/yk8+r5edFWRFOwnqSvAEFoP2bKNXaXgYa+Ayw=="],
+    "angular-expressions": ["angular-expressions@1.5.2", "", {}, "sha512-VxC5xNLdIVcynUNUjWwkHcWTX/HGa+Cy5il+CRLzFxEVptRY3Jqf35y6auSEWXmGMF+6TMoy81gPQCzwMNYTVw=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -1227,7 +1227,7 @@
 
     "js-base64": ["js-base64@3.7.7", "", {}, "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "jsep": ["jsep@1.4.0", "", {}, "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="],
 

--- a/package.json
+++ b/package.json
@@ -223,13 +223,13 @@
     "@kubernetes/client-node": "1.3.0",
     "acorn": "8.15.0",
     "alchemy": "2.0.0-beta.58",
-    "angular-expressions": "1.5.1",
+    "angular-expressions": "1.5.2",
     "arktype": "^2.2.0",
     "cel-js": "^0.8.2",
     "effect": "4.0.0-beta.84",
     "estraverse": "^5.3.0",
     "ignore": "^7.0.5",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "pino": "^9.8.0",
     "re2js": "2.8.6"
   },
@@ -260,7 +260,7 @@
     "typescript": ">=5.0.0"
   },
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "effect": "4.0.0-beta.84",
     "@effect/platform-bun": "4.0.0-beta.84",
     "@effect/platform-node-shared": "4.0.0-beta.84",

--- a/test/unit/dependency-security.test.ts
+++ b/test/unit/dependency-security.test.ts
@@ -3,17 +3,19 @@ import { describe, expect, it } from 'bun:test';
 const lockfileUrl = new URL('../../bun.lock', import.meta.url);
 const packageUrl = new URL('../../package.json', import.meta.url);
 
-function atLeastPatched(version: string): boolean {
+function atLeastJsYamlPatch(version: string): boolean {
   const [major = 0, minor = 0, patch = 0] = version.split('.').map(Number);
-  return major > 4 || (major === 4 && (minor > 3 || (minor === 3 && patch >= 0)));
+  return major > 4 || (major === 4 && (minor > 3 || (minor === 3 && patch >= 1)));
 }
 
 describe('dependency security invariants', () => {
-  it('pins every frozen js-yaml installation to 4.3.0 or newer', async () => {
+  it('pins every frozen js-yaml installation to 4.3.1 or newer', async () => {
     const manifest = (await Bun.file(packageUrl).json()) as {
+      dependencies?: Record<string, string>;
       overrides?: Record<string, string>;
     };
-    expect(manifest.overrides?.['js-yaml']).toBe('4.3.0');
+    expect(manifest.dependencies?.['js-yaml']).toBe('4.3.1');
+    expect(manifest.overrides?.['js-yaml']).toBe('4.3.1');
 
     const lockfile = await Bun.file(lockfileUrl).text();
     const installedVersions = [
@@ -21,6 +23,18 @@ describe('dependency security invariants', () => {
     ].map((match) => match[1]!);
 
     expect(installedVersions.length).toBeGreaterThan(0);
-    expect(installedVersions.every(atLeastPatched)).toBe(true);
+    expect(installedVersions.every(atLeastJsYamlPatch)).toBe(true);
+  });
+
+  it('pins angular-expressions to its patched release', async () => {
+    const manifest = (await Bun.file(packageUrl).json()) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(manifest.dependencies?.['angular-expressions']).toBe('1.5.2');
+
+    const lockfile = await Bun.file(lockfileUrl).text();
+    expect(lockfile).toContain(
+      '"angular-expressions": ["angular-expressions@1.5.2"',
+    );
   });
 });


### PR DESCRIPTION
## What changed

- pin `js-yaml` to 4.3.1 in both the direct dependency and repository-wide override
- pin `angular-expressions` to 1.5.2
- strengthen the frozen dependency regression tests for both patched versions
- document the dependency hardening in the unreleased changelog

## Why

TypeKro 0.33.7 pins `js-yaml` 4.3.0 and `angular-expressions` 1.5.1. Current npm audit data reports security fixes in 4.3.1 and 1.5.2 respectively. Because both packages participate in TypeKro's parsing/evaluation build path, the published package and frozen checkout should carry the patched versions rather than relying on downstream deduplication.

## Impact

This is a patch-level dependency update. TypeKro's public API and generated manifests are unchanged. The evaluator compatibility suite passes against `angular-expressions` 1.5.2, and the lockfile override ensures transitive `js-yaml` consumers converge on 4.3.1.

## Verification

- 5,315 tests passed; 13 skipped; 1 todo; 0 failed
- focused evaluator/security suite: 70 passed
- library, examples, and test TypeScript projects passed
- build and lint passed
- `git diff --check` passed
