### PR TITLE
chore: release v0.33.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.33.7",
+  "version": "0.33.8",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

- release TypeKro v0.33.8
- include patched `js-yaml` 4.3.1 and `angular-expressions` 1.5.2 dependencies
- include the Alchemy beta.74, Distilled AWS rc.6, and Effect rc.110 runtime cohort
- strengthen single-version dependency cohort enforcement
- publish the current Discord invitation and resolve #161

## Verification

- `bun install --frozen-lockfile`
- `bun run check:effect-cohort`
- dependency cohort and security tests (4 passed)
- `bun run build`
- merged-tree unit suite (5,317 passed; 13 skipped; 1 todo; 0 failed)
- merged-tree Alchemy and OrbStack lifecycle suite (164 passed; 0 failed)
- packed Node/Bun import budgets passed
