### PR TITLE
fix(clickstack): infer namespace ownership from namespace presence

### DIFF
--- a/docs/api/clickhouse/index.md
+++ b/docs/api/clickhouse/index.md
@@ -144,6 +144,30 @@ User names become CHI configuration path fragments (`<name>/password_sha256_hex`
 
 In `makeClickHouseCluster`, declared user names become **literal keys** in the generated runtime spec schema — `spec.users.signoz.passwordSha256Hex` — so each declared user's credential is a required, typed, ref-safe field.
 
+For credentials generated or managed by another controller, select the Secret-backed
+runtime shape when constructing the cluster. The CHI contains only the Secret
+reference; the cleartext password never enters the TypeKro instance or deployment
+state:
+
+```typescript
+const clickhouse = makeClickHouseCluster({
+  users: [{ name: 'otelcollector', credentialSource: 'secret' }],
+});
+
+clickhouse({
+  // ...name, namespace, version, storage...
+  users: {
+    otelcollector: {
+      passwordSecretRef: { name: 'clickhouse-credentials', key: 'password' },
+    },
+  },
+});
+```
+
+The low-level `clickHouseInstallation()` accepts the same
+`passwordSecretRef: { name, key }` field. A user must not declare both a Secret
+reference and `passwordSha256Hex`.
+
 ## Status Contract
 
 `makeClickHouseCluster` exposes a typed service contract so downstream compositions (e.g. a SigNoz factory) never reconstruct Altinity hostnames by hand:

--- a/docs/api/clickstack/index.md
+++ b/docs/api/clickstack/index.md
@@ -7,15 +7,37 @@ OFFICIAL `clickstack` Helm chart (3.0.x, MIT) from
 **external ClickHouse** you already run (e.g. an Altinity-operator-managed
 [`ClickHouseInstallation`](../clickhouse/)).
 
-## Secrets Caveat
+## Secret-backed credentials
 
-`clickhouse.password`, `clickhouse.appPassword`, and `apiKey` travel as **plaintext** runtime spec
-values all the way into the generated HelmRelease's `spec.values.hyperdx.secrets.*` — a Kubernetes
-object stored in etcd, readable by anyone with read access to the HelmRelease/RGD instance
-(`kubectl get helmrelease -o yaml`). This is unlike `clickstackK8sTelemetry`'s `apiKeySecret` (a
-`secretKeyRef` env var — the value never appears in any CR spec). There is currently **no
-existing-Secret alternative** for these three fields. Do not treat this family as production-ready
-for credentials that need stronger-than-etcd-RBAC protection until that gap is closed.
+The default variant retains the original convenient inline fields (`clickhouse.password`,
+`clickhouse.appPassword`, and `apiKey`). Those values appear in the HelmRelease spec and are suitable
+only when etcd/RBAC exposure is acceptable.
+
+Production compositions should select the build-time Secret-values contract. The runtime schema then
+requires `credentialsSecret`, removes the plaintext credential fields, and Flux loads a complete Helm
+values document without copying its bytes into the RGD, instance, or HelmRelease:
+
+```typescript
+const bootstrap = makeClickstackBootstrap({
+  credentials: { source: 'secretValues' },
+});
+
+await bootstrap.factory('kro').deploy({
+  name: 'clickstack',
+  namespace: 'observability',
+  clickhouse: {
+    host: 'clickhouse-observability.clickhouse.svc.cluster.local',
+    username: 'otelcollector',
+  },
+  credentialsSecret: {
+    name: 'clickstack-credentials',
+    valuesKey: 'values.yaml',
+  },
+});
+```
+
+The Secret key must contain a Helm values YAML document. TypeKro does not own that externally supplied
+Secret; its creator remains responsible for rotation and lifecycle.
 
 ## Import
 
@@ -79,7 +101,7 @@ HyperDX requires MongoDB for app state (dashboards, alerts, users — metadata o
 ## Build-Time Options vs Runtime Spec
 
 Build-time (constructor — must be concrete; schema refs are rejected loudly): the Mongo mode + storage,
-static raw chart `values`, RGD `name`/`kind`. Runtime spec (proxy-safe): release
+credential transport, static raw chart `values`, RGD `name`/`kind`. Runtime spec (proxy-safe): release
 name, namespace, chart version, the ClickHouse connection, API key, HyperDX conveniences.
 
 Omit the runtime `namespace` to use the default `clickstack` Namespace and let the composition own its

--- a/docs/api/clickstack/index.md
+++ b/docs/api/clickstack/index.md
@@ -79,8 +79,13 @@ HyperDX requires MongoDB for app state (dashboards, alerts, users — metadata o
 ## Build-Time Options vs Runtime Spec
 
 Build-time (constructor — must be concrete; schema refs are rejected loudly): the Mongo mode + storage,
-static raw chart `values`, RGD `name`/`kind`. Runtime spec (proxy-safe): release name, namespace, chart
-version, the ClickHouse connection, API key, HyperDX conveniences.
+static raw chart `values`, RGD `name`/`kind`. Runtime spec (proxy-safe): release
+name, namespace, chart version, the ClickHouse connection, API key, HyperDX conveniences.
+
+Omit the runtime `namespace` to use the default `clickstack` Namespace and let the composition own its
+lifecycle. Supplying `namespace` means that the caller or a parent application graph owns it; ClickStack
+installs into the named Namespace without creating or deleting it. This keeps the common call declarative
+while ensuring a Namespace has exactly one lifecycle authority.
 
 Note `customValues` is **not part of the runtime schema** — it's absent from `bootstrapBaseShape`, so
 KRO-mode callers (whose spec is validated against that schema, and whose values come out as CEL) cannot

--- a/src/core/planning/planner.ts
+++ b/src/core/planning/planner.ts
@@ -363,6 +363,90 @@ function canonicalizeStatusResourceReferences(
   }
 }
 
+function nestedStatusMappingValue(
+  mapping: string,
+  specSchema: SchemaIR,
+  resourceIds?: ReadonlySet<string>
+): PlanValue {
+  if (mapping.includes('__KUBERNETES_REF_') || mapping.includes('${')) {
+    return lowerPlanValue(mapping, { specSchema, resourceIds }).value;
+  }
+  try {
+    const literal = JSON.parse(mapping) as unknown;
+    if (
+      literal === null ||
+      typeof literal === 'string' ||
+      typeof literal === 'number' ||
+      typeof literal === 'boolean'
+    ) {
+      return lowerPlanValue(literal, { specSchema, resourceIds }).value;
+    }
+  } catch {
+    // A non-JSON mapping is an analyzed CEL expression.
+  }
+  return { kind: 'expression', expression: expressionIR(mapping) };
+}
+
+/**
+ * Nested compositions are authoring-time virtual resources. Canonical plans
+ * must lower their status references to the concrete child-resource
+ * expression captured during composition flattening; deployment runtimes
+ * cannot bind a virtual resource id after reconciliation.
+ */
+function resolveNestedStatusReferences(
+  value: PlanValue,
+  nestedStatusMappings: Readonly<Record<string, string>>,
+  specSchema: SchemaIR,
+  resourceIds?: ReadonlySet<string>
+): PlanValue {
+  if (value.kind === 'sensitive-value') {
+    return {
+      ...value,
+      value: resolveNestedStatusReferences(
+        value.value,
+        nestedStatusMappings,
+        specSchema,
+        resourceIds
+      ),
+    };
+  }
+  if (
+    value.kind === 'reference' &&
+    value.source === 'resource' &&
+    value.resourceId &&
+    value.nestedComposition
+  ) {
+    const fieldPath = value.fieldPath.replace(/^status\./, '');
+    const mapping = nestedStatusMappings[`__nestedStatus:${value.resourceId}:${fieldPath}`];
+    return mapping === undefined
+      ? value
+      : nestedStatusMappingValue(mapping, specSchema, resourceIds);
+  }
+  if (value.kind === 'array') {
+    return {
+      ...value,
+      items: value.items.map((item) =>
+        resolveNestedStatusReferences(item, nestedStatusMappings, specSchema, resourceIds)
+      ),
+    };
+  }
+  if (value.kind === 'object') {
+    return {
+      ...value,
+      entries: value.entries.map((entry) => ({
+        ...entry,
+        value: resolveNestedStatusReferences(
+          entry.value,
+          nestedStatusMappings,
+          specSchema,
+          resourceIds
+        ),
+      })),
+    };
+  }
+  return value;
+}
+
 function resourceFieldValue(
   desired: PlanValue,
   fieldPath: string,
@@ -570,6 +654,7 @@ function statusProjections(
   statusMappings: Readonly<Record<string, unknown>>,
   diagnostics: PlanDiagnostic[],
   specSchema: SchemaIR,
+  nestedStatusMappings: Readonly<Record<string, string>> = {},
   sensitiveSpecPaths: ReadonlySet<string> = new Set(),
   resourceIds?: ReadonlySet<string>,
   resourceAliases: ReadonlyMap<string, string> = new Map(),
@@ -589,7 +674,15 @@ function statusProjections(
     .filter((key) => !key.startsWith('__'))
     .sort()) {
     const lowered = lowerPlanValue(statusMappings[key], { specSchema, resourceIds });
-    const canonicalValue = canonicalizeStatusResourceReferences(lowered.value, resourceAliases);
+    const canonicalValue = canonicalizeStatusResourceReferences(
+      resolveNestedStatusReferences(
+        lowered.value,
+        nestedStatusMappings,
+        specSchema,
+        resourceIds
+      ),
+      resourceAliases
+    );
     const value = markSensitiveResourceReferences(
       markSensitiveSpecReferences(canonicalValue, sensitiveSpecPaths),
       resourceNodes,
@@ -665,6 +758,7 @@ function buildStatusContract<TSpec extends KroCompatibleType>(
     capture.ir.statusMappings,
     diagnostics,
     specSchema,
+    capture.ir.nestedStatusMappings,
     sensitiveSpecPaths,
     identityContext.resourceIds,
     identityContext.resourceAliases,

--- a/src/factories/clickhouse/compositions/clickhouse-cluster.ts
+++ b/src/factories/clickhouse/compositions/clickhouse-cluster.ts
@@ -59,7 +59,11 @@ interface ResolvedTopology {
   replicas: number;
   shards: number;
   keeper: boolean;
-  users: readonly { name: string; networksIp: readonly string[] }[];
+  users: readonly {
+    name: string;
+    networksIp: readonly string[];
+    credentialSource: 'sha256Hex' | 'secret';
+  }[];
 }
 
 function resolveTopology(topology: ClickHouseClusterTopology): ResolvedTopology {
@@ -80,6 +84,7 @@ function resolveTopology(topology: ClickHouseClusterTopology): ResolvedTopology 
     users: (topology.users ?? []).map((user) => ({
       name: user.name,
       networksIp: user.networksIp ?? DEFAULT_USER_NETWORKS_IP,
+      credentialSource: user.credentialSource ?? 'sha256Hex',
     })),
   };
 }
@@ -113,7 +118,17 @@ function buildSpecSchema(topology: ResolvedTopology) {
 
   if (topology.users.length > 0) {
     definition.users = Object.fromEntries(
-      topology.users.map((user) => [user.name, { passwordSha256Hex: 'string' }])
+      topology.users.map((user) => [
+        user.name,
+        user.credentialSource === 'secret'
+          ? {
+              passwordSecretRef: {
+                name: 'string > 0',
+                key: 'string > 0',
+              },
+            }
+          : { passwordSha256Hex: 'string' },
+      ])
     );
   }
 
@@ -177,12 +192,25 @@ export function makeClickHouseCluster(
       // Runtime credentials pair with build-time user names by LITERAL key:
       // `spec.users.<name>.passwordSha256Hex` is a plain schema path, so it
       // serializes to clean CEL. Names/networks come from the topology.
-      const users: ClickHouseUser[] = resolved.users.map((user) => ({
-        name: user.name,
+      const users: ClickHouseUser[] = resolved.users.map((user) => {
         // biome-ignore lint/style/noNonNullAssertion: the generated schema requires one users.<name> entry per declared user
-        passwordSha256Hex: spec.users![user.name]!.passwordSha256Hex,
-        networksIp: [...user.networksIp],
-      }));
+        const credential = spec.users![user.name]!;
+        return {
+          name: user.name,
+          ...(user.credentialSource === 'secret'
+            ? {
+                passwordSecretRef: (
+                  credential as { passwordSecretRef: { name: string; key: string } }
+                ).passwordSecretRef,
+              }
+            : {
+                passwordSha256Hex: (
+                  credential as { passwordSha256Hex: string }
+                ).passwordSha256Hex,
+              }),
+          networksIp: [...user.networksIp],
+        };
+      });
 
       const clickhouse = clickHouseInstallation({
         name: spec.name,

--- a/src/factories/clickhouse/resources/installation.ts
+++ b/src/factories/clickhouse/resources/installation.ts
@@ -183,8 +183,18 @@ function compileUsers(
 ): Record<string, unknown> {
   const compiled: Record<string, unknown> = {};
   for (const user of users) {
+    if (user.passwordSha256Hex !== undefined && user.passwordSecretRef !== undefined) {
+      throw new Error(
+        `clickHouseInstallation: user '${user.name}' must declare only one of passwordSha256Hex or passwordSecretRef`
+      );
+    }
     if (user.passwordSha256Hex !== undefined) {
       compiled[`${user.name}/password_sha256_hex`] = user.passwordSha256Hex;
+    }
+    if (user.passwordSecretRef !== undefined) {
+      compiled[`${user.name}/password`] = {
+        valueFrom: { secretKeyRef: user.passwordSecretRef },
+      };
     }
     if (user.networksIp !== undefined) {
       compiled[`${user.name}/networks/ip`] = user.networksIp;

--- a/src/factories/clickhouse/types.ts
+++ b/src/factories/clickhouse/types.ts
@@ -200,6 +200,11 @@ export const ClickHouseUserSchema = type({
   name: 'string',
   /** SHA256 hex digest of the user password (value position — refs OK). */
   'passwordSha256Hex?': 'string',
+  /** Existing Secret key containing the cleartext password (value position — refs OK). */
+  'passwordSecretRef?': {
+    name: 'string > 0',
+    key: 'string > 0',
+  },
   /** Allowed source networks, e.g. ['::/0'] (value position — refs OK). */
   'networksIp?': 'string[]',
 });
@@ -417,6 +422,8 @@ export interface ClickHouseClusterUserTopology {
   readonly name: string;
   /** Allowed source networks (default: ['::/0']). */
   readonly networksIp?: readonly string[];
+  /** Runtime credential representation (default: precomputed SHA256 hex). */
+  readonly credentialSource?: 'sha256Hex' | 'secret';
 }
 
 /**
@@ -499,7 +506,11 @@ export type ClickHouseClusterSpec = ClickHouseClusterSpecBase & {
   /** Keeper connection (required iff the topology enables keeper). */
   keeper?: ClickHouseClusterKeeperSpec;
   /** Per-declared-user runtime credentials, keyed by build-time user name. */
-  users?: Record<string, { passwordSha256Hex: string }>;
+  users?: Record<
+    string,
+    | { passwordSha256Hex: string }
+    | { passwordSecretRef: { name: string; key: string } }
+  >;
 };
 
 /**

--- a/src/factories/clickstack/compositions/clickstack-bootstrap.ts
+++ b/src/factories/clickstack/compositions/clickstack-bootstrap.ts
@@ -19,7 +19,7 @@
  * hits a JS branch on a proxy.
  *
  * What gets deployed:
- * 1. The target Namespace.
+ * 1. The default target Namespace when no external namespace is supplied.
  * 2. The shared ClickStack HelmRepository singleton.
  * 3. Internal-Mongo variant only: a minimal single-replica Mongo
  *    StatefulSet + Service (`mongo:7`, no operator/CRDs/auth — APP METADATA
@@ -117,6 +117,20 @@ interface ResolvedBuildConfig {
   values?: Record<string, unknown>;
 }
 
+function createDefaultClickStackNamespace(spec: ClickStackBootstrapRuntimeConfig): void {
+  namespace({
+    metadata: {
+      name: DEFAULT_CLICKSTACK_NAMESPACE,
+      labels: {
+        'app.kubernetes.io/name': 'clickstack',
+        'app.kubernetes.io/instance': spec.name,
+        'app.kubernetes.io/managed-by': 'typekro',
+      },
+    },
+    id: 'clickstackNamespace',
+  });
+}
+
 /**
  * Shared composition body. `build` is CONCRETE (construction-time), so every
  * plain-JS branch below is on build config — never on the (possibly
@@ -141,18 +155,6 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
     const helmValues = mapClickStackConfigToHelmValues(spec, {
       mongoMode: build.mongoMode,
       ...(build.values !== undefined && { values: build.values }),
-    });
-
-    const _clickstackNamespace = namespace({
-      metadata: {
-        name: resolvedNamespace,
-        labels: {
-          'app.kubernetes.io/name': 'clickstack',
-          'app.kubernetes.io/instance': spec.name,
-          'app.kubernetes.io/managed-by': 'typekro',
-        },
-      },
-      id: 'clickstackNamespace',
     });
 
     // One cluster-level Flux source shared by every ClickStack instance —
@@ -269,7 +271,10 @@ function buildInternalComposition(options: ClickStackInternalMongoBuildOptions) 
       spec: ClickStackBootstrapConfigSchema,
       status: ClickStackBootstrapStatusSchema,
     },
-    (spec: ClickStackBootstrapConfig) => bootstrapBody(spec, build)
+    (spec: ClickStackBootstrapConfig) => {
+      if (!spec.namespace) createDefaultClickStackNamespace(spec);
+      return bootstrapBody(spec, build);
+    }
   );
 }
 
@@ -285,7 +290,10 @@ function buildExternalComposition(options: ClickStackExternalMongoBuildOptions) 
       spec: ClickStackExternalMongoBootstrapConfigSchema,
       status: ClickStackBootstrapStatusSchema,
     },
-    (spec: ClickStackExternalMongoBootstrapConfig) => bootstrapBody(spec, build)
+    (spec: ClickStackExternalMongoBootstrapConfig) => {
+      if (!spec.namespace) createDefaultClickStackNamespace(spec);
+      return bootstrapBody(spec, build);
+    }
   );
 }
 

--- a/src/factories/clickstack/compositions/clickstack-bootstrap.ts
+++ b/src/factories/clickstack/compositions/clickstack-bootstrap.ts
@@ -12,7 +12,7 @@
  *
  * BUILD-TIME vs RUNTIME: `makeClickstackBootstrap(options)` constructs a
  * composition VARIANT. Options that decide WHICH resources exist (the Mongo
- * mode + its storage shape) and the static raw chart values are build-time —
+ * mode + its storage shape), credential transport, and static raw chart values are build-time —
  * plain JS may branch on them because they are always concrete. The runtime
  * spec carries only proxy-safe values (names, namespaces, endpoints,
  * versions, credentials); a user composing with `schema.spec.*` refs never
@@ -100,6 +100,8 @@ import {
   type ClickStackBuildOptions,
   type ClickStackExternalMongoBootstrapConfig,
   ClickStackExternalMongoBootstrapConfigSchema,
+  ClickStackSecretValuesBootstrapConfigSchema,
+  ClickStackSecretValuesExternalMongoBootstrapConfigSchema,
   type ClickStackExternalMongoBuildOptions,
   type ClickStackInternalMongoBuildOptions,
   type ClickStackMongoStorageOptions,
@@ -113,6 +115,7 @@ import { clickstackHelmRepositoryBootstrap } from './clickstack-helm-repository.
 /** Concrete, resolved build choices the composition body branches on. */
 interface ResolvedBuildConfig {
   mongoMode: 'internal' | 'external';
+  credentialsSource: 'inline' | 'secretValues';
   storage?: ClickStackMongoStorageOptions;
   values?: Record<string, unknown>;
 }
@@ -154,6 +157,7 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
 
     const helmValues = mapClickStackConfigToHelmValues(spec, {
       mongoMode: build.mongoMode,
+      credentialsSource: build.credentialsSource,
       ...(build.values !== undefined && { values: build.values }),
     });
 
@@ -200,6 +204,17 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
       namespace: resolvedNamespace,
       version: resolvedVersion,
       values: helmValues,
+      ...(build.credentialsSource === 'secretValues' && {
+        valuesFrom: [
+          {
+            kind: 'Secret' as const,
+            name: spec.credentialsSecret?.name as string,
+            valuesKey: isKubernetesRef(spec.credentialsSecret?.valuesKey)
+              ? Cel.default(spec.credentialsSecret?.valuesKey, 'values.yaml')
+              : (spec.credentialsSecret?.valuesKey ?? 'values.yaml'),
+          },
+        ],
+      }),
       id: 'clickstackHelmRelease',
     });
 
@@ -261,6 +276,7 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
 function buildInternalComposition(options: ClickStackInternalMongoBuildOptions) {
   const build: ResolvedBuildConfig = {
     mongoMode: 'internal',
+    credentialsSource: options.credentials?.source ?? 'inline',
     ...(options.mongo?.storage !== undefined && { storage: options.mongo.storage }),
     ...(options.values !== undefined && { values: options.values }),
   };
@@ -268,7 +284,10 @@ function buildInternalComposition(options: ClickStackInternalMongoBuildOptions) 
     {
       name: options.name ?? 'clickstack-bootstrap',
       kind: options.kind ?? 'ClickStackBootstrap',
-      spec: ClickStackBootstrapConfigSchema,
+      spec:
+        build.credentialsSource === 'secretValues'
+          ? ClickStackSecretValuesBootstrapConfigSchema
+          : ClickStackBootstrapConfigSchema,
       status: ClickStackBootstrapStatusSchema,
     },
     (spec: ClickStackBootstrapConfig) => {
@@ -281,13 +300,17 @@ function buildInternalComposition(options: ClickStackInternalMongoBuildOptions) 
 function buildExternalComposition(options: ClickStackExternalMongoBuildOptions) {
   const build: ResolvedBuildConfig = {
     mongoMode: 'external',
+    credentialsSource: options.credentials?.source ?? 'inline',
     ...(options.values !== undefined && { values: options.values }),
   };
   return kubernetesComposition(
     {
       name: options.name ?? 'clickstack-bootstrap-external-mongo',
       kind: options.kind ?? 'ClickStackExternalMongoBootstrap',
-      spec: ClickStackExternalMongoBootstrapConfigSchema,
+      spec:
+        build.credentialsSource === 'secretValues'
+          ? ClickStackSecretValuesExternalMongoBootstrapConfigSchema
+          : ClickStackExternalMongoBootstrapConfigSchema,
       status: ClickStackBootstrapStatusSchema,
     },
     (spec: ClickStackExternalMongoBootstrapConfig) => {
@@ -307,8 +330,8 @@ export type ClickStackExternalMongoBootstrapComposition = ReturnType<
 
 /**
  * Construct a ClickStack bootstrap composition variant. Build-time options
- * select WHICH resources exist (Mongo mode/storage) and bake static raw chart
- * values; everything per-instance stays in the runtime spec.
+ * select WHICH resources exist (Mongo mode/storage), credential transport,
+ * and bake static raw chart values; everything per-instance stays in the runtime spec.
  */
 export function makeClickstackBootstrap(
   options?: ClickStackInternalMongoBuildOptions
@@ -324,7 +347,7 @@ export function makeClickstackBootstrap(
   if (containsKubernetesRefs(options)) {
     throw new Error(
       'makeClickstackBootstrap: build-time options contain a schema/resource reference. ' +
-        'Build-time options (mongo mode/storage, static chart values, name/kind) are fixed at ' +
+        'Build-time options (mongo mode/storage, credential transport, static chart values, name/kind) are fixed at ' +
         'construction — move per-instance values into the runtime spec instead.'
     );
   }

--- a/src/factories/clickstack/resources/helm.ts
+++ b/src/factories/clickstack/resources/helm.ts
@@ -153,6 +153,7 @@ export function clickstackHelmRelease(
       kind: 'HelmRepository',
     },
     driftDetection: { mode: 'enabled' },
+    ...(config.valuesFrom && { valuesFrom: config.valuesFrom }),
     values: config.values || {},
     ...(config.id && { id: config.id }),
   }).withReadinessEvaluator(

--- a/src/factories/clickstack/types.ts
+++ b/src/factories/clickstack/types.ts
@@ -42,7 +42,8 @@
 
 import { type } from 'arktype';
 import type { ValuesMergeExpression } from '../../core/aspects/values-merge.js';
-import type { TypeKroChartValues } from '../../core/types/common.js';
+import type { TypeKroChartValues, TypeKroValue } from '../../core/types/common.js';
+import type { HelmReleaseValuesFromSource } from '../helm/types.js';
 
 // ============================================================================
 // ClickHouse version-coupling guidance
@@ -192,6 +193,15 @@ export type ClickStackMongoBuildOptions =
 /** Shared build-time options for both bootstrap variants. */
 interface ClickStackBuildOptionsBase {
   /**
+   * Credential transport selected when the composition is constructed.
+   *
+   * `secretValues` replaces the plaintext credential fields in the runtime
+   * schema with a required Secret reference. Flux loads the complete Helm
+   * values document from that Secret, so secret bytes never enter the RGD,
+   * instance, or HelmRelease spec.
+   */
+  credentials?: { source: 'secretValues' };
+  /**
    * Static raw official-chart values merged at construction time (they win
    * over the typed mapping), EXCEPT the hard pins — `clickhouse.enabled: false`,
    * `mongodb.enabled: false`, and `fullnameOverride` (the status contract's
@@ -229,45 +239,30 @@ export type ClickStackBuildOptions =
 // Bootstrap runtime spec (external ClickHouse)
 // ============================================================================
 
-const bootstrapBaseShape = {
+const bootstrapClickHouseShape = {
+  /** DNS host of the external ClickHouse service (no scheme, no port). */
+  host: 'string',
+  /** Native TCP port (default: 9000) → `CLICKHOUSE_ENDPOINT`/`CLICKHOUSE_SERVER_ENDPOINT`. */
+  'nativePort?': 'number.integer',
+  /** HTTP port (default: 8123) → HyperDX UI `defaultConnections` host. */
+  'httpPort?': 'number.integer',
+  /** OTel export target database (default: 'default') → `HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE`. */
+  'database?': 'string',
+  /** Ingest/collector user (default: 'default'). */
+  'username?': 'string',
+  /** Read-mostly UI user for HyperDX connections (default: `username`). */
+  'appUsername?': 'string',
+} as const;
+
+const bootstrapShapeWithoutCredentials = {
   /** Release name for the Helm installation. */
   name: 'string',
   /** Namespace for the stack (default: 'clickstack'). */
   'namespace?': 'string',
   /** Chart version (default: '3.0.1'). */
   'version?': 'string',
-  // SECRETS CAVEAT: `password`/`appPassword` below (and `apiKey` further
-  // down) travel as PLAINTEXT runtime spec values all the way into the
-  // generated HelmRelease's `spec.values.hyperdx.secrets.*` — a Kubernetes
-  // object stored in etcd, readable by anyone with read access to the
-  // HelmRelease/RGD instance (`kubectl get helmrelease -o yaml`), unlike
-  // `k8s-telemetry.ts`'s `apiKeySecret` (a `secretKeyRef` env var — the
-  // value never appears in any CR spec). There is currently NO
-  // existing-Secret / secretKeyRef alternative for these three fields.
-  // Treat them as no more protected than any other spec field; do not
-  // consider this family production-ready for credentials that need
-  // stronger-than-etcd-RBAC protection until that gap is closed.
   /** External ClickHouse connection (REQUIRED — external-only build-around). */
-  clickhouse: {
-    /** DNS host of the external ClickHouse service (no scheme, no port). */
-    host: 'string',
-    /** Native TCP port (default: 9000) → `CLICKHOUSE_ENDPOINT`/`CLICKHOUSE_SERVER_ENDPOINT`. */
-    'nativePort?': 'number.integer',
-    /** HTTP port (default: 8123) → HyperDX UI `defaultConnections` host. */
-    'httpPort?': 'number.integer',
-    /** OTel export target database (default: 'default') → `HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE`. */
-    'database?': 'string',
-    /** Ingest/collector user (default: 'default') → `hyperdx.config.CLICKHOUSE_USER`. Needs SELECT,INSERT,CREATE,SHOW on the database. */
-    'username?': 'string',
-    /** Ingest/collector password → `hyperdx.secrets.CLICKHOUSE_PASSWORD` (default: ''). PLAINTEXT in the HelmRelease spec — see the secrets caveat above. */
-    'password?': 'string',
-    /** Read-mostly UI user for HyperDX connections (default: `username`). Needs SHOW + SELECT. */
-    'appUsername?': 'string',
-    /** UI user password → `hyperdx.secrets.CLICKHOUSE_APP_PASSWORD` (default: `password`). PLAINTEXT in the HelmRelease spec — see the secrets caveat above. */
-    'appPassword?': 'string',
-  },
-  /** HyperDX ingestion API key → `hyperdx.secrets.HYPERDX_API_KEY`. PLAINTEXT in the HelmRelease spec — see the secrets caveat above `clickhouse`. */
-  'apiKey?': 'string',
+  clickhouse: bootstrapClickHouseShape,
   /** HyperDX app (UI/API) conveniences. */
   'hyperdx?': {
     'replicas?': 'number.integer',
@@ -276,6 +271,22 @@ const bootstrapBaseShape = {
     /** Public URL of the HyperDX UI → `hyperdx.config.FRONTEND_URL`. */
     'frontendUrl?': 'string',
   },
+} as const;
+
+const bootstrapBaseShape = {
+  ...bootstrapShapeWithoutCredentials,
+  // Compatibility/convenience mode: these credential values are embedded in
+  // the HelmRelease spec. Select build.credentials.source='secretValues' for
+  // the production schema that replaces them with credentialsSecret.
+  clickhouse: {
+    ...bootstrapClickHouseShape,
+    /** Ingest/collector password → `hyperdx.secrets.CLICKHOUSE_PASSWORD` (default: ''). PLAINTEXT in the HelmRelease spec. */
+    'password?': 'string',
+    /** UI user password → `hyperdx.secrets.CLICKHOUSE_APP_PASSWORD` (default: `password`). PLAINTEXT in the HelmRelease spec. */
+    'appPassword?': 'string',
+  },
+  /** HyperDX ingestion API key → `hyperdx.secrets.HYPERDX_API_KEY`. PLAINTEXT in the HelmRelease spec. */
+  'apiKey?': 'string',
   // NOTE: `customValues` is NOT part of this schema, so KRO-mode callers
   // (validated against this shape) can't use it — the mapped values tree
   // carries CEL templates (CLICKHOUSE_ENDPOINT, defaultConnections, ...),
@@ -300,12 +311,35 @@ export const ClickStackBootstrapConfigSchema = type(bootstrapBaseShape);
 /** Runtime configuration for the internal-Mongo bootstrap variant. */
 export type ClickStackBootstrapConfig = typeof ClickStackBootstrapConfigSchema.infer;
 
+/** Runtime schema used by the build-selected Secret-values credential mode. */
+export const ClickStackSecretValuesBootstrapConfigSchema = type({
+  ...bootstrapShapeWithoutCredentials,
+  credentialsSecret: {
+    name: 'string > 0',
+    'valuesKey?': 'string > 0',
+  },
+});
+
+/** Runtime configuration for Secret-backed Helm values. */
+export type ClickStackSecretValuesBootstrapConfig =
+  typeof ClickStackSecretValuesBootstrapConfigSchema.infer;
+
 /**
  * Runtime spec for the external-Mongo variant: base + a required `mongoUri`.
  */
 export const ClickStackExternalMongoBootstrapConfigSchema = type({
   ...bootstrapBaseShape,
   /** Full MongoDB connection URI → `hyperdx.config.MONGO_URI` (verbatim). */
+  mongoUri: 'string',
+});
+
+/** External-Mongo runtime schema with Secret-backed Helm values. */
+export const ClickStackSecretValuesExternalMongoBootstrapConfigSchema = type({
+  ...bootstrapShapeWithoutCredentials,
+  credentialsSecret: {
+    name: 'string > 0',
+    'valuesKey?': 'string > 0',
+  },
   mongoUri: 'string',
 });
 
@@ -316,6 +350,7 @@ export type ClickStackExternalMongoBootstrapConfig =
 /** Widest runtime config the values mapper accepts (either variant). */
 export type ClickStackBootstrapRuntimeConfig = ClickStackBootstrapConfig & {
   mongoUri?: string;
+  credentialsSecret?: { name: string; valuesKey?: string };
   /**
    * INTERNAL, DIRECT-MODE-ONLY escape hatch — not part of the runtime
    * schema (`bootstrapBaseShape`), so KRO-mode callers can never populate
@@ -516,6 +551,8 @@ export interface ClickStackHelmReleaseConfig {
   repositoryNamespace?: string;
   /** Official clickstack chart values (graph-aware trees / runtime merges allowed). */
   values?: ClickStackMappedHelmValues;
+  /** Flux Secret/ConfigMap sources merged before inline values. */
+  valuesFrom?: TypeKroValue<HelmReleaseValuesFromSource>[];
   id?: string;
 }
 

--- a/src/factories/clickstack/utils/helm-values-mapper.ts
+++ b/src/factories/clickstack/utils/helm-values-mapper.ts
@@ -97,6 +97,8 @@ export const CLICKSTACK_CONNECTION_NAME = 'External ClickHouse';
 export interface ClickStackValuesMapperOptions {
   /** Which Mongo wiring to emit (build-time; default 'internal'). */
   mongoMode?: 'internal' | 'external';
+  /** Credential values are supplied by a Flux Secret values source. */
+  credentialsSource?: 'inline' | 'secretValues';
   /** Static raw chart values merged after the typed mapping (pins re-applied after). */
   values?: TypeKroChartValues<ClickStackHelmValues>;
 }
@@ -339,6 +341,7 @@ export function mapClickStackConfigToHelmValues(
 ): ClickStackMappedHelmValues {
   const isGraph = isKubernetesRef(config.name) || isKubernetesRef(config.clickhouse);
   const mongoMode = options.mongoMode ?? 'internal';
+  const credentialsSource = options.credentialsSource ?? 'inline';
 
   const ch = config.clickhouse;
   const hyperdxConfig: Record<string, unknown> = {};
@@ -357,10 +360,6 @@ export function mapClickStackConfigToHelmValues(
     const appUsername = Cel.expr<string>(
       `${hasSchemaPath('schema.spec.clickhouse.appUsername')} ? schema.spec.clickhouse.appUsername : ` +
         `(${hasSchemaPath('schema.spec.clickhouse.username')} ? schema.spec.clickhouse.username : "default")`
-    );
-    const appPassword = Cel.expr<string>(
-      `${hasSchemaPath('schema.spec.clickhouse.appPassword')} ? schema.spec.clickhouse.appPassword : ` +
-        `(${hasSchemaPath('schema.spec.clickhouse.password')} ? schema.spec.clickhouse.password : "")`
     );
 
     hyperdxConfig.CLICKHOUSE_ENDPOINT = Cel.template(
@@ -381,21 +380,27 @@ export function mapClickStackConfigToHelmValues(
           );
     hyperdxConfig.FRONTEND_URL = graphOptional('schema.spec.hyperdx.frontendUrl');
 
-    hyperdxSecrets.CLICKHOUSE_PASSWORD = resolve(ch.password, '');
-    hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
-    hyperdxSecrets.HYPERDX_API_KEY = graphOptional('schema.spec.apiKey');
+    if (credentialsSource === 'inline') {
+      const appPassword = Cel.expr<string>(
+        `${hasSchemaPath('schema.spec.clickhouse.appPassword')} ? schema.spec.clickhouse.appPassword : ` +
+          `(${hasSchemaPath('schema.spec.clickhouse.password')} ? schema.spec.clickhouse.password : "")`
+      );
+      hyperdxSecrets.CLICKHOUSE_PASSWORD = resolve(ch.password, '');
+      hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
+      hyperdxSecrets.HYPERDX_API_KEY = graphOptional('schema.spec.apiKey');
+      hyperdxDeployment.defaultConnections = Cel.template(
+        DEFAULT_CONNECTIONS_FORMAT,
+        ch.host,
+        httpPortStr,
+        httpPortStr,
+        appUsername,
+        appPassword
+      );
+    }
 
     hyperdxDeployment.replicas = graphOptional('schema.spec.hyperdx.replicas');
     hyperdxDeployment.resources = graphOptional('schema.spec.hyperdx.resources');
     hyperdxDeployment.image = graphOptional('schema.spec.hyperdx.image');
-    hyperdxDeployment.defaultConnections = Cel.template(
-      DEFAULT_CONNECTIONS_FORMAT,
-      ch.host,
-      httpPortStr,
-      httpPortStr,
-      appUsername,
-      appPassword
-    );
     const database = resolve(ch.database, 'default');
     hyperdxDeployment.defaultSources = Cel.template(
       DEFAULT_SOURCES_FORMAT,
@@ -409,7 +414,7 @@ export function mapClickStackConfigToHelmValues(
     const httpPort = ch.httpPort ?? 8123;
     const database = ch.database ?? 'default';
     const username = ch.username ?? 'default';
-    const password = ch.password ?? '';
+    const password = credentialsSource === 'inline' ? (ch.password ?? '') : '';
     const appUsername = ch.appUsername ?? username;
     const appPassword = ch.appPassword ?? password;
 
@@ -423,29 +428,33 @@ export function mapClickStackConfigToHelmValues(
         : `mongodb://${config.name}${CLICKSTACK_MONGO_NAME_SUFFIX}.${config.namespace ?? DEFAULT_CLICKSTACK_NAMESPACE}.svc.cluster.local:${CLICKSTACK_MONGO_PORT}/hyperdx`;
     setIfDefined(hyperdxConfig, 'FRONTEND_URL', config.hyperdx?.frontendUrl);
 
-    hyperdxSecrets.CLICKHOUSE_PASSWORD = password;
-    hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
-    setIfDefined(hyperdxSecrets, 'HYPERDX_API_KEY', config.apiKey);
+    if (credentialsSource === 'inline') {
+      hyperdxSecrets.CLICKHOUSE_PASSWORD = password;
+      hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
+      setIfDefined(hyperdxSecrets, 'HYPERDX_API_KEY', config.apiKey);
+    }
 
     setIfDefined(hyperdxDeployment, 'replicas', config.hyperdx?.replicas);
     setIfDefined(hyperdxDeployment, 'resources', config.hyperdx?.resources);
     setIfDefined(hyperdxDeployment, 'image', config.hyperdx?.image);
-    hyperdxDeployment.defaultConnections = JSON.stringify([
-      {
-        name: CLICKSTACK_CONNECTION_NAME,
-        host: `http://${ch.host}:${httpPort}`,
-        port: httpPort,
-        username: appUsername,
-        password: appPassword,
-      },
-    ]);
+    if (credentialsSource === 'inline') {
+      hyperdxDeployment.defaultConnections = JSON.stringify([
+        {
+          name: CLICKSTACK_CONNECTION_NAME,
+          host: `http://${ch.host}:${httpPort}`,
+          port: httpPort,
+          username: appUsername,
+          password: appPassword,
+        },
+      ]);
+    }
     hyperdxDeployment.defaultSources = DEFAULT_SOURCES_FORMAT.replace(/%s/g, () => database);
   }
 
   const values: ClickStackHelmValues = {
     hyperdx: {
       config: hyperdxConfig,
-      secrets: hyperdxSecrets,
+      ...(credentialsSource === 'inline' && { secrets: hyperdxSecrets }),
       deployment: hyperdxDeployment,
     },
   };

--- a/test/factories/bootstrap-instance-namespace.test.ts
+++ b/test/factories/bootstrap-instance-namespace.test.ts
@@ -210,7 +210,6 @@ describe('bootstrap factories: self-owned namespace is hoisted + retained, not r
     expect(() => {
       yaml = factory.toYaml({
         name: 'clickstack',
-        namespace: 'clickstack',
         clickhouse: {
           host: 'ch.clickstack.svc.cluster.local',
           nativePort: 9000,

--- a/test/factories/clickhouse/cluster-composition.test.ts
+++ b/test/factories/clickhouse/cluster-composition.test.ts
@@ -95,6 +95,20 @@ describe('makeClickHouseCluster (build-time topology, runtime spec)', () => {
       expect(yaml).not.toContain('__typekroSchemaKey');
     });
 
+    it('serializes build-selected Secret-backed user credentials in KRO mode', () => {
+      const clickhouse = makeClickHouseCluster({
+        users: [{ name: 'otelcollector', credentialSource: 'secret' }],
+      });
+
+      const yaml = clickhouse.toYaml();
+      expect(yaml).toContain('otelcollector/password:');
+      expect(yaml).toContain('valueFrom:');
+      expect(yaml).toContain(
+        'secretKeyRef: ${schema.spec.users.otelcollector.passwordSecretRef}'
+      );
+      expect(yaml).not.toContain('otelcollector/password_sha256_hex');
+    });
+
     it('enables keeper by default for multi-replica topologies and requires the runtime host', () => {
       const yaml = makeClickHouseCluster({ replicas: 2 }).toYaml();
       expect(yaml).toContain('zookeeper');

--- a/test/factories/clickhouse/installation.test.ts
+++ b/test/factories/clickhouse/installation.test.ts
@@ -274,6 +274,45 @@ describe('ClickHouseInstallation Factory', () => {
       });
     });
 
+    it('should compile a Secret-backed cleartext password without exposing it in the CHI', () => {
+      const chi = clickHouseInstallation({
+        name: 'test-ch',
+        version: '25.12.5',
+        storage: { size: '10Gi' },
+        users: [
+          {
+            name: 'otelcollector',
+            passwordSecretRef: { name: 'clickhouse-credentials', key: 'password' },
+          },
+        ],
+      });
+
+      expect(chi.spec.configuration?.users).toEqual({
+        'otelcollector/password': {
+          valueFrom: {
+            secretKeyRef: { name: 'clickhouse-credentials', key: 'password' },
+          },
+        },
+      });
+    });
+
+    it('should reject competing password representations for one user', () => {
+      expect(() =>
+        clickHouseInstallation({
+          name: 'test-ch',
+          version: '25.12.5',
+          storage: { size: '10Gi' },
+          users: [
+            {
+              name: 'otelcollector',
+              passwordSha256Hex: 'abc123',
+              passwordSecretRef: { name: 'clickhouse-credentials', key: 'password' },
+            },
+          ],
+        })
+      ).toThrow(/only one of passwordSha256Hex or passwordSecretRef/);
+    });
+
     it('should omit user fields that are not provided', () => {
       const chi = clickHouseInstallation({
         name: 'test-ch',

--- a/test/factories/clickstack/bootstrap-composition.test.ts
+++ b/test/factories/clickstack/bootstrap-composition.test.ts
@@ -13,8 +13,11 @@
  *  - the typed status service contract (ui/gateway/app endpoints).
  */
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { type } from 'arktype';
 import { load } from 'js-yaml';
 
+import { kubernetesComposition } from '../../../src/core/composition/imperative.js';
+import { materializePlanOutputs } from '../../../src/experimental-planning.js';
 import {
   clickstackBootstrap,
   makeClickstackBootstrap,
@@ -210,6 +213,51 @@ describe('makeClickstackBootstrap (build-time variants)', () => {
     expect(kroYaml).not.toContain('schema.spec.clickhouse.password');
     expect(kroYaml).not.toContain('schema.spec.clickhouse.appPassword');
     expect(kroYaml).not.toContain('schema.spec.apiKey');
+  });
+
+  it('lowers nested ClickStack endpoint outputs to concrete HelmRelease bindings', () => {
+    const bootstrap = makeClickstackBootstrap({ credentials: { source: 'secretValues' } });
+    const application = kubernetesComposition(
+      {
+        name: 'clickstack-output-application',
+        kind: 'ClickstackOutputApplication',
+        spec: type({
+          name: 'string',
+          namespace: 'string',
+          clickhouse: { host: 'string', username: 'string' },
+          credentialsSecret: { name: 'string', valuesKey: 'string' },
+        }),
+        status: type({ endpoint: 'string' }),
+      },
+      (spec) => {
+        const stack = bootstrap(spec as never);
+        return { endpoint: stack.status.gateway.otlpHttpEndpoint };
+      }
+    );
+    const spec = {
+      name: 'clickstack',
+      namespace: 'observability',
+      clickhouse: { host: 'clickhouse.example', username: 'otelcollector' },
+      credentialsSecret: { name: 'clickstack-credentials', valuesKey: 'values.yaml' },
+    };
+    const plan = application.plan!(spec, { strict: true });
+    const endpoint = plan.outputs.endpoint;
+
+    expect(endpoint).toMatchObject({ kind: 'template' });
+    expect(JSON.stringify(endpoint)).toContain('clickstackBootstrap1ClickstackHelmRelease');
+    expect(JSON.stringify(endpoint)).not.toContain('nestedComposition');
+    expect(
+      materializePlanOutputs({ endpoint }, {
+        resources: {
+          clickstackBootstrap1ClickstackHelmRelease: {
+            metadata: { name: 'clickstack', namespace: 'observability' },
+          },
+        },
+      })
+    ).toEqual({
+      endpoint:
+        'http://clickstack-otel-collector.observability.svc.cluster.local:4318',
+    });
   });
 
   it('keeps the existing inline-credential contract as the default variant', () => {

--- a/test/factories/clickstack/bootstrap-composition.test.ts
+++ b/test/factories/clickstack/bootstrap-composition.test.ts
@@ -182,6 +182,48 @@ describe('makeClickstackBootstrap (build-time variants)', () => {
     expect(yaml).toContain('mongoUri');
   });
 
+  it('loads credential Helm values from a required Secret in direct and KRO modes', () => {
+    const bootstrap = makeClickstackBootstrap({
+      credentials: { source: 'secretValues' },
+      name: 'clickstack-secret-values',
+      kind: 'ClickstackSecretValues',
+    });
+    const spec = {
+      name: 'clickstack',
+      namespace: 'observability',
+      clickhouse: { host: 'clickhouse.example', username: 'otelcollector' },
+      credentialsSecret: { name: 'clickstack-credentials', valuesKey: 'private-values.yaml' },
+    };
+
+    const directYaml = bootstrap.factory('direct').toYaml(spec);
+    expect(directYaml).toContain('valuesFrom:');
+    expect(directYaml).toContain('name: clickstack-credentials');
+    expect(directYaml).toContain('valuesKey: private-values.yaml');
+    expect(directYaml).not.toContain('CLICKHOUSE_PASSWORD');
+    expect(directYaml).not.toContain('CLICKHOUSE_APP_PASSWORD');
+    expect(directYaml).not.toContain('HYPERDX_API_KEY');
+
+    const kroYaml = bootstrap.toYaml();
+    expect(kroYaml).toContain('credentialsSecret');
+    expect(kroYaml).toContain('name: ${schema.spec.credentialsSecret.name}');
+    expect(kroYaml).toContain('schema.spec.credentialsSecret.valuesKey');
+    expect(kroYaml).not.toContain('schema.spec.clickhouse.password');
+    expect(kroYaml).not.toContain('schema.spec.clickhouse.appPassword');
+    expect(kroYaml).not.toContain('schema.spec.apiKey');
+  });
+
+  it('keeps the existing inline-credential contract as the default variant', () => {
+    const yaml = makeClickstackBootstrap({
+      name: 'clickstack-inline-values',
+      kind: 'ClickstackInlineValues',
+    }).toYaml();
+
+    expect(yaml).toContain('password: string');
+    expect(yaml).toContain('apiKey: string');
+    expect(yaml).not.toContain('credentialsSecret');
+    expect(yaml).not.toContain('valuesFrom:');
+  });
+
   it('rejects schema refs in build-time options with an actionable error', () => {
     expect(() =>
       makeClickstackBootstrap({

--- a/test/factories/clickstack/bootstrap-composition.test.ts
+++ b/test/factories/clickstack/bootstrap-composition.test.ts
@@ -140,6 +140,35 @@ describe('clickstackBootstrap (internal-Mongo default)', () => {
 });
 
 describe('makeClickstackBootstrap (build-time variants)', () => {
+  it('owns the default target namespace when namespace is omitted', () => {
+    const bootstrap = makeClickstackBootstrap({
+      name: 'clickstack-owned-namespace',
+      kind: 'ClickstackOwnedNamespace',
+    });
+    const spec = {
+      name: 'clickstack',
+      clickhouse: { host: 'clickhouse.example' },
+    };
+
+    expect(bootstrap.factory('direct').toYaml(spec)).toContain('kind: Namespace');
+    expect(bootstrap.factory('kro').toYaml(spec)).toContain('kind: Namespace');
+  });
+
+  it('treats an explicitly supplied target namespace as externally owned', () => {
+    const bootstrap = makeClickstackBootstrap({
+      name: 'clickstack-external-namespace',
+      kind: 'ClickstackExternalNamespace',
+    });
+    const spec = {
+      name: 'clickstack',
+      namespace: 'observability',
+      clickhouse: { host: 'clickhouse.example' },
+    };
+
+    expect(bootstrap.factory('direct').toYaml(spec)).not.toContain('kind: Namespace');
+    expect(bootstrap.factory('kro').toYaml(spec)).not.toContain('kind: Namespace');
+  });
+
   it('external-Mongo variant drops the internal Mongo resources and requires mongoUri in the spec schema', () => {
     const external = makeClickstackBootstrap({
       mongo: { mode: 'external' },

--- a/test/factories/clickstack/factory-modes.test.ts
+++ b/test/factories/clickstack/factory-modes.test.ts
@@ -120,7 +120,6 @@ function findSecretKeyRefs(value: unknown): Record<string, unknown>[] {
 
 const BOOTSTRAP_SPEC = {
   name: 'clickstack',
-  namespace: 'clickstack',
   clickhouse: {
     host: 'clickhouse-observability.clickhouse.svc.cluster.local',
     username: 'otelcollector',


### PR DESCRIPTION
## Summary
- omit the namespace field to use and own the default clickstack Namespace
- pass the namespace field to install into an externally owned destination
- preserve this lifecycle behavior in both direct and KRO factory modes
- document the convention and cover owned/external and namespace-hoisting paths

## Why
The namespace value and its lifecycle authority should not require two parallel knobs. Applik8s already owns its application namespace, so passing that namespace to ClickStack must not create a second owner.

The implementation follows TypeKro integration guidance: ordinary TypeScript branches express the condition and TypeKro differential analysis preserves it for KRO, rather than embedding explicit CEL in the integration.

## Verification
- focused ClickStack and namespace-hoisting tests: 28 passed
- full unit suite through the commit hook: 5,319 passed, 13 skipped, 1 todo, 0 failed
- full typecheck passed before the semantic revision; the revised files are covered by the full pre-commit suite