### PR TITLE
fix(clickstack): activate authenticated OTLP ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   catalog and Distilled AWS `1.0.0-rc.6`; TypeKro's Effect runtime cohort moves
   with it to `4.0.0-rc.110`. CI now locks all three dependency boundaries so a
   partial upgrade cannot silently reintroduce incompatible runtime copies.
+- ClickHouse users may now source plaintext passwords through the Altinity
+  operator's native `secretKeyRef` support, and ClickStack bootstraps may load a
+  complete credential values fragment from a Kubernetes Secret through Flux.
+  The Secret-backed ClickStack variant omits credential values and default
+  connection passwords from RGD instances and HelmRelease inline values while
+  preserving direct/KRO parity.
 - KRO artifact bindings now use a topology-independent nested string-map
   schema, so adding or removing generated artifact outputs no longer changes
   the application CRD. Imperative and Alchemy deployments automatically migrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The Secret-backed ClickStack variant omits credential values and default
   connection passwords from RGD instances and HelmRelease inline values while
   preserving direct/KRO parity.
+- ClickStack composition variants now expose explicit `namespaceOwnership`,
+  allowing parent deployment graphs to manage the workload Namespace without
+  introducing a second owner for the same Kubernetes object.
 - KRO artifact bindings now use a topology-independent nested string-map
   schema, so adding or removing generated artifact outputs no longer changes
   the application CRD. Imperative and Alchemy deployments automatically migrate

--- a/docs/api/clickhouse/index.md
+++ b/docs/api/clickhouse/index.md
@@ -99,7 +99,8 @@ The chart installs CRDs via a Helm hook (`crdHook.enabled`). When deploying thro
 - `name`, `namespace`, `version`, `clusterName`
 - `storage.size`, `storage.storageClassName`
 - `keeper.host`, `keeper.port`
-- `users.<name>.passwordSha256Hex` (one literal key per declared user)
+- `users.<name>.passwordSha256Hex` or `users.<name>.passwordSecretRef` (one
+  literal key per declared user, selected by the build-time credential source)
 - `podResources`
 
 ### Why zones are build-time (and why zone pinning exists at all)
@@ -140,9 +141,37 @@ users: [
 ]
 ```
 
+For Secret-backed credentials, select the representation when declaring the
+topology and pass only Secret coordinates at runtime:
+
+```typescript
+const clickhouse = makeClickHouseCluster({
+  users: [{ name: 'otelcollector', credentialSource: 'secret' }],
+});
+
+await clickhouse.factory('kro').deploy({
+  name: 'observability',
+  namespace: 'observability',
+  version: '25.7',
+  storage: { size: '10Gi' },
+  users: {
+    otelcollector: {
+      passwordSecretRef: {
+        name: 'clickstack-credentials',
+        key: 'clickhouse-password',
+      },
+    },
+  },
+});
+```
+
+This compiles to the Altinity operator's native `valueFrom.secretKeyRef`
+shape. The password does not enter the ClickHouseInstallation, RGD instance,
+or TypeKro state. The Secret must be in the ClickHouseInstallation namespace.
+
 User names become CHI configuration path fragments (`<name>/password_sha256_hex`, `<name>/networks/ip`), so they must be concrete — a map keyed by schema proxies would serialize `__typekroSchemaKey/...` garbage. Password hashes and network lists are plain value positions: schema refs serialize to clean CEL (proven under `TYPEKRO_STRICT_CEL=1` in the test suite).
 
-In `makeClickHouseCluster`, declared user names become **literal keys** in the generated runtime spec schema — `spec.users.signoz.passwordSha256Hex` — so each declared user's credential is a required, typed, ref-safe field.
+In `makeClickHouseCluster`, declared user names become **literal keys** in the generated runtime spec schema — for example `spec.users.signoz.passwordSha256Hex` or `spec.users.otelcollector.passwordSecretRef` — so each declared user's credential is a required, typed, ref-safe field.
 
 ## Status Contract
 

--- a/docs/api/clickstack/index.md
+++ b/docs/api/clickstack/index.md
@@ -7,15 +7,38 @@ OFFICIAL `clickstack` Helm chart (3.0.x, MIT) from
 **external ClickHouse** you already run (e.g. an Altinity-operator-managed
 [`ClickHouseInstallation`](../clickhouse/)).
 
-## Secrets Caveat
+## Credential modes
 
-`clickhouse.password`, `clickhouse.appPassword`, and `apiKey` travel as **plaintext** runtime spec
-values all the way into the generated HelmRelease's `spec.values.hyperdx.secrets.*` — a Kubernetes
-object stored in etcd, readable by anyone with read access to the HelmRelease/RGD instance
-(`kubectl get helmrelease -o yaml`). This is unlike `clickstackK8sTelemetry`'s `apiKeySecret` (a
-`secretKeyRef` env var — the value never appears in any CR spec). There is currently **no
-existing-Secret alternative** for these three fields. Do not treat this family as production-ready
-for credentials that need stronger-than-etcd-RBAC protection until that gap is closed.
+The backwards-compatible default accepts `clickhouse.password`, `clickhouse.appPassword`, and
+`apiKey` inline. Those values enter the HelmRelease and RGD instance, so use that mode only when
+etcd/RBAC protection is sufficient.
+
+For production, construct the Secret-backed variant:
+
+```typescript
+const clickstack = makeClickstackBootstrap({
+  credentials: { source: 'secretValues' },
+});
+
+await clickstack.factory('kro', { namespace: 'typekro-system' }).deploy({
+  name: 'clickstack',
+  namespace: 'observability',
+  clickhouse: {
+    host: 'clickhouse-observability.observability.svc.cluster.local',
+    username: 'otelcollector',
+  },
+  credentialsSecret: {
+    name: 'clickstack-credentials',
+    valuesKey: 'values.yaml',
+  },
+});
+```
+
+The Secret key is a Helm values fragment containing `hyperdx.secrets` and, when a preconfigured UI
+connection is desired, `hyperdx.deployment.defaultConnections`. Flux merges it before TypeKro's
+non-sensitive inline values. TypeKro deliberately omits those credential-bearing paths from the
+HelmRelease and rejects inline password/API-key fields in this variant. The Secret must be in the
+ClickStack workload namespace because Flux values references are namespace-local.
 
 ## Import
 
@@ -34,15 +57,16 @@ import {
 // 1. The stack (internal dev-first Mongo, external ClickHouse). The bootstrap
 // owns its Namespace, so TypeKro hoists that namespace out of the RGD graph
 // (retained) and the instance CR stays in the `clickstack` namespace:
-const factory = clickstackBootstrap.factory('kro', { namespace: 'clickstack' });
+const bootstrap = makeClickstackBootstrap({ credentials: { source: 'secretValues' } });
+const factory = bootstrap.factory('kro', { namespace: 'typekro-system' });
 const stack = await factory.deploy({
   name: 'clickstack',
+  namespace: 'clickstack',
   clickhouse: {
     host: 'clickhouse-observability.clickhouse.svc.cluster.local',
     username: 'otelcollector',
-    password: '…',
   },
-  apiKey: '…',
+  credentialsSecret: { name: 'clickstack-credentials', valuesKey: 'values.yaml' },
 });
 
 // 2. Cluster telemetry into it (wired from the status contract):
@@ -79,8 +103,9 @@ HyperDX requires MongoDB for app state (dashboards, alerts, users — metadata o
 ## Build-Time Options vs Runtime Spec
 
 Build-time (constructor — must be concrete; schema refs are rejected loudly): the Mongo mode + storage,
-static raw chart `values`, RGD `name`/`kind`. Runtime spec (proxy-safe): release name, namespace, chart
-version, the ClickHouse connection, API key, HyperDX conveniences.
+credential source, static raw chart `values`, RGD `name`/`kind`. Runtime spec (proxy-safe): release name,
+namespace, chart version, the ClickHouse connection, credential Secret coordinates or inline API key,
+and HyperDX conveniences.
 
 Note `customValues` is **not part of the runtime schema** — it's absent from `bootstrapBaseShape`, so
 KRO-mode callers (whose spec is validated against that schema, and whose values come out as CEL) cannot

--- a/docs/api/clickstack/index.md
+++ b/docs/api/clickstack/index.md
@@ -17,8 +17,6 @@ For production, construct the Secret-backed variant:
 
 ```typescript
 const clickstack = makeClickstackBootstrap({
-  // Select external when a parent platform owns the workload Namespace.
-  namespaceOwnership: 'external',
   credentials: { source: 'secretValues' },
 });
 
@@ -42,9 +40,10 @@ non-sensitive inline values. TypeKro deliberately omits those credential-bearing
 HelmRelease and rejects inline password/API-key fields in this variant. The Secret must be in the
 ClickStack workload namespace because Flux values references are namespace-local.
 
-`namespaceOwnership` defaults to `owned` for standalone use. Set it to `external` when a parent
-platform owns the workload Namespace; ClickStack will still target that namespace but will not create
-or delete it.
+Omit `namespace` to let TypeKro create and own the documented `clickstack` default Namespace. Pass
+`namespace` when a parent platform owns the workload Namespace; ClickStack targets that Namespace
+without creating or deleting it. The same rule is preserved when the factory is nested in another
+composition, so one Kubernetes Namespace never gains competing lifecycle owners.
 
 ## Import
 
@@ -60,9 +59,8 @@ import {
 ## Quick Example
 
 ```typescript
-// 1. The stack (internal dev-first Mongo, external ClickHouse). The bootstrap
-// owns its Namespace, so TypeKro hoists that namespace out of the RGD graph
-// (retained) and the instance CR stays in the `clickstack` namespace:
+// 1. The stack (internal dev-first Mongo, external ClickHouse). Omitting the
+// runtime namespace asks TypeKro to hoist and own its `clickstack` default.
 const bootstrap = makeClickstackBootstrap({ credentials: { source: 'secretValues' } });
 const factory = bootstrap.factory('kro', { namespace: 'typekro-system' });
 const stack = await factory.deploy({

--- a/docs/api/clickstack/index.md
+++ b/docs/api/clickstack/index.md
@@ -2,16 +2,16 @@
 
 Deploy [ClickStack](https://clickhouse.com/docs/use-cases/observability/clickstack) — ClickHouse Inc.'s
 observability stack (the HyperDX UI/API, an OTel gateway collector, and schema migrations) — via the
-OFFICIAL `clickstack` Helm chart (3.0.x, MIT) from
+OFFICIAL `clickstack` Helm chart (3.2.x, MIT) from
 [`ClickHouse/ClickStack-helm-charts`](https://github.com/ClickHouse/ClickStack-helm-charts), wired to an
 **external ClickHouse** you already run (e.g. an Altinity-operator-managed
 [`ClickHouseInstallation`](../clickhouse/)).
 
 ## Credential modes
 
-The backwards-compatible default accepts `clickhouse.password`, `clickhouse.appPassword`, and
-`apiKey` inline. Those values enter the HelmRelease and RGD instance, so use that mode only when
-etcd/RBAC protection is sufficient.
+The default accepts `clickhouse.password`, `clickhouse.appPassword`, and a required, non-empty
+`apiKey` inline. The published chart placeholder is rejected. Those values enter the HelmRelease
+and RGD instance, so use that mode only when etcd/RBAC protection is sufficient.
 
 For production, construct the Secret-backed variant:
 
@@ -38,7 +38,11 @@ The Secret key is a Helm values fragment containing `hyperdx.secrets` and, when 
 connection is desired, `hyperdx.deployment.defaultConnections`. Flux merges it before TypeKro's
 non-sensitive inline values. TypeKro deliberately omits those credential-bearing paths from the
 HelmRelease and rejects inline password/API-key fields in this variant. The Secret must be in the
-ClickStack workload namespace because Flux values references are namespace-local.
+ClickStack workload namespace because Flux values references are namespace-local. The fragment must
+override `hyperdx.secrets.HYPERDX_API_KEY`: an idempotent reconciliation CronJob refuses the chart's
+published placeholder and keeps the installation non-ready until an authoritative Team is updated.
+It reruns every minute so API-key and external-Mongo URI rotations converge without replacing an
+immutable completed Job.
 
 Omit `namespace` to let TypeKro create and own the documented `clickstack` default Namespace. Pass
 `namespace` when a parent platform owns the workload Namespace; ClickStack targets that Namespace
@@ -65,7 +69,6 @@ const bootstrap = makeClickstackBootstrap({ credentials: { source: 'secretValues
 const factory = bootstrap.factory('kro', { namespace: 'typekro-system' });
 const stack = await factory.deploy({
   name: 'clickstack',
-  namespace: 'clickstack',
   clickhouse: {
     host: 'clickhouse-observability.clickhouse.svc.cluster.local',
     username: 'otelcollector',

--- a/docs/api/clickstack/index.md
+++ b/docs/api/clickstack/index.md
@@ -133,8 +133,8 @@ JSON-typed schema via `HYPERDX_OTEL_EXPORTER_CLICKHOUSE_JSON_ENABLE` wants CH 25
 
 ## Status Contract
 
-Beyond `ready`/`phase` (KRO CEL from the owned HelmRelease), the status exposes typed connection
-details so downstream compositions never reconstruct chart naming rules:
+Beyond `ready`/`phase` (KRO CEL from the owned HelmRelease and Team-bootstrap CronJob), the status
+exposes typed connection details so downstream compositions never reconstruct chart naming rules:
 
 ```typescript
 status: {
@@ -150,7 +150,11 @@ status: {
 HelmRelease resource**, so it serializes as KRO status CEL and is visible on the live KRO CR's
 status (GitOps/KRO consumers can read it):
 
-- `ready`, `phase` — CEL over `clickstackHelmRelease.status.conditions`.
+- `ready`, `phase` — generation-aware CEL over `clickstackHelmRelease.status.conditions`, combined
+  with the authoritative Team-bootstrap CronJob's current schedule and last successful execution.
+  `ready` becomes true only after Flux has observed the current HelmRelease generation **and** the
+  current credential bootstrap has completed successfully; `phase` remains `Installing` until both
+  gates pass and becomes `Failed` on a current-generation Helm failure.
 - `ui.url`, `gateway.otlpHttpEndpoint`, `gateway.otlpGrpcEndpoint`, `app.host` — CEL string concat
   over `clickstackHelmRelease.metadata.name` / `.namespace` (the mapper pins `fullnameOverride` to
   the release name, so the HyperDX Service is `<name>` and the gateway Service is

--- a/docs/api/clickstack/index.md
+++ b/docs/api/clickstack/index.md
@@ -17,6 +17,8 @@ For production, construct the Secret-backed variant:
 
 ```typescript
 const clickstack = makeClickstackBootstrap({
+  // Select external when a parent platform owns the workload Namespace.
+  namespaceOwnership: 'external',
   credentials: { source: 'secretValues' },
 });
 
@@ -39,6 +41,10 @@ connection is desired, `hyperdx.deployment.defaultConnections`. Flux merges it b
 non-sensitive inline values. TypeKro deliberately omits those credential-bearing paths from the
 HelmRelease and rejects inline password/API-key fields in this variant. The Secret must be in the
 ClickStack workload namespace because Flux values references are namespace-local.
+
+`namespaceOwnership` defaults to `owned` for standalone use. Set it to `external` when a parent
+platform owns the workload Namespace; ClickStack will still target that namespace but will not create
+or delete it.
 
 ## Import
 

--- a/src/core/dependencies/resolver.ts
+++ b/src/core/dependencies/resolver.ts
@@ -593,6 +593,16 @@ export class DependencyResolver {
         continue;
       }
 
+      // A three-segment window can begin in the middle of a longer member or
+      // DNS chain. For example, a resource-derived template ending in
+      // `.svc.cluster.local` previously invented a dependency on a resource
+      // named `svc`. Real resource references begin at a CEL token boundary;
+      // a preceding dot proves that this match is only a suffix.
+      if (match.index > 0 && searchableExpression[match.index - 1] === '.') {
+        match = refPattern.exec(searchableExpression);
+        continue;
+      }
+
       refs.push({
         [KUBERNETES_REF_BRAND]: true,
         resourceId: resourceId === 'schema' ? '__schema__' : resourceId,

--- a/src/core/deployment/kro-factory.ts
+++ b/src/core/deployment/kro-factory.ts
@@ -1520,11 +1520,39 @@ export class KroResourceFactoryImpl<
     if (opts?.operationSignal) {
       return this.deployWithinOperation(spec, opts, opts.operationSignal);
     }
-    return runStandaloneOperation(
-      (abortSignal) =>
-        this.deployWithinOperation(spec, { ...opts, operationSignal: abortSignal }, abortSignal),
-      { abortSignals: [this.factoryOptions.abortSignal, opts?.abortSignal] }
-    );
+    const timeout = this.factoryOptions.timeout;
+    const deadlineController = timeout === undefined ? undefined : new AbortController();
+    const timeoutId =
+      timeout === undefined
+        ? undefined
+        : setTimeout(() => {
+            deadlineController?.abort(
+              new DeploymentTimeoutError(
+                `KRO deployment ${this.name} timed out after ${timeout}ms. Singleton owners, definitions, instances, and readiness checks share this operation deadline.`,
+                'ResourceGraphDefinition',
+                this.rgdName,
+                timeout,
+                'deployment'
+              )
+            );
+          }, timeout);
+    timeoutId?.unref?.();
+
+    try {
+      return await runStandaloneOperation(
+        (abortSignal) =>
+          this.deployWithinOperation(spec, { ...opts, operationSignal: abortSignal }, abortSignal),
+        {
+          abortSignals: [
+            this.factoryOptions.abortSignal,
+            opts?.abortSignal,
+            deadlineController?.signal,
+          ],
+        }
+      );
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
   }
 
   private async deployWithinOperation(

--- a/src/core/planning/planner.ts
+++ b/src/core/planning/planner.ts
@@ -23,6 +23,7 @@ import {
   getPortableReadinessStrategy,
   getRuntimeReadinessClassification,
 } from '../readiness/portable-strategies.js';
+import { inlineNestedStatusRefs } from '../serialization/cel-references.js';
 import {
   type FactoryRegistration,
   type FactoryRepresentationRequirement,
@@ -45,6 +46,7 @@ import type {
   CompositionInspection,
   DeclaredInputManifestEntry,
   DesiredStatePlan,
+  ExpressionIR,
   KubernetesIdentity,
   LifecyclePolicy,
   PlanDiagnostic,
@@ -167,6 +169,53 @@ function inlineNestedStatusPlanValue(
   nestedStatusMappings: Readonly<Record<string, string>>,
   resourceIds: ReadonlySet<string> | undefined
 ): PlanValue {
+  const planValueAsExpression = (candidate: PlanValue): string | undefined => {
+    if (candidate.kind === 'literal') return JSON.stringify(candidate.value);
+    if (candidate.kind === 'reference') {
+      const path =
+        candidate.source === 'spec'
+          ? `schema.spec.${candidate.fieldPath}`
+          : `${candidate.resourceId}.${candidate.fieldPath}`;
+      return path;
+    }
+    if (candidate.kind === 'expression') return candidate.expression.expression;
+    if (candidate.kind === 'template') {
+      return candidate.segments
+        .map((segment) => {
+          if (segment.kind === 'literal') return JSON.stringify(segment.value);
+          if (segment.kind === 'expression') {
+            return `string(${segment.expression.expression})`;
+          }
+          const path =
+            segment.source === 'spec'
+              ? `schema.spec.${segment.fieldPath}`
+              : `${segment.resourceId}.${segment.fieldPath}`;
+          return `string(${path})`;
+        })
+        .join(' + ');
+    }
+    return undefined;
+  };
+
+  const inlineExpression = (expression: ExpressionIR): ExpressionIR => {
+    const expressionMappings = Object.fromEntries(
+      Object.entries(nestedStatusMappings).map(([key, mapped]) => {
+        const lowered = lowerPlanValue(mapped, { resourceIds }).value;
+        return [key, planValueAsExpression(lowered) ?? mapped];
+      })
+    );
+    const inlined = inlineNestedStatusRefs(expression.expression, expressionMappings, resourceIds);
+    if (inlined === expression.expression) return expression;
+    const rebuilt = expressionIR(inlined, {
+      language: expression.language,
+      sensitivity: expression.sensitivity,
+      resourceIds,
+    });
+    return expression.sourceLocation === undefined
+      ? rebuilt
+      : { ...rebuilt, sourceLocation: expression.sourceLocation };
+  };
+
   if (value.kind === 'sensitive-value') {
     return {
       ...value,
@@ -198,12 +247,17 @@ function inlineNestedStatusPlanValue(
       ? value
       : { kind: 'expression', expression: expressionIR(mapped, { resourceIds }) };
   }
+  if (value.kind === 'expression') {
+    return { ...value, expression: inlineExpression(value.expression) };
+  }
   if (value.kind === 'template') {
     return {
       ...value,
       segments: value.segments.flatMap((segment) => {
         if (segment.kind === 'literal') return segment;
-        if (segment.kind === 'expression') return segment;
+        if (segment.kind === 'expression') {
+          return { ...segment, expression: inlineExpression(segment.expression) };
+        }
         if (
           segment.source !== 'resource' ||
           !segment.resourceId ||
@@ -681,7 +735,11 @@ function statusProjections(
     .sort()) {
     const lowered = lowerPlanValue(statusMappings[key], { specSchema, resourceIds });
     const canonicalValue = canonicalizeStatusResourceReferences(
-      inlineNestedStatusPlanValue(lowered.value, nestedStatusMappings, resourceIds),
+      inlineNestedStatusPlanValue(
+        markNestedStatusReferences(lowered.value, nestedStatusMappings),
+        nestedStatusMappings,
+        resourceIds
+      ),
       resourceAliases
     );
     const value = markSensitiveResourceReferences(

--- a/src/core/planning/planner.ts
+++ b/src/core/planning/planner.ts
@@ -155,6 +155,96 @@ function markNestedStatusReferences(
   return value;
 }
 
+/**
+ * Replace virtual nested-composition status handles with the flattened CEL
+ * expressions captured for their concrete child resources. Semantic plans
+ * are consumed independently of the imperative factory runtime, so leaving a
+ * virtual handle such as `stack1.status.endpoint` in an output makes direct
+ * artifact hydration request a resource that can never exist.
+ */
+function inlineNestedStatusPlanValue(
+  value: PlanValue,
+  nestedStatusMappings: Readonly<Record<string, string>>,
+  resourceIds: ReadonlySet<string> | undefined
+): PlanValue {
+  if (value.kind === 'sensitive-value') {
+    return {
+      ...value,
+      value: inlineNestedStatusPlanValue(value.value, nestedStatusMappings, resourceIds),
+    };
+  }
+  if (value.kind === 'reference') {
+    if (value.source !== 'resource' || !value.resourceId || value.nestedComposition !== true) {
+      return value;
+    }
+    const authored = `${value.resourceId}.${value.fieldPath}`;
+    const fieldPath = value.fieldPath.replace(/^status\./, '');
+    const mapped = nestedStatusMappings[`__nestedStatus:${value.resourceId}:${fieldPath}`];
+    if (mapped === authored) {
+      if (resourceIds?.has(value.resourceId)) {
+        const { nestedComposition: _nestedComposition, ...resourceReference } = value;
+        return resourceReference;
+      }
+      return value;
+    }
+    if (mapped?.includes('__KUBERNETES_REF_')) {
+      return inlineNestedStatusPlanValue(
+        lowerPlanValue(mapped, { resourceIds }).value,
+        nestedStatusMappings,
+        resourceIds
+      );
+    }
+    return mapped === undefined
+      ? value
+      : { kind: 'expression', expression: expressionIR(mapped, { resourceIds }) };
+  }
+  if (value.kind === 'template') {
+    return {
+      ...value,
+      segments: value.segments.flatMap((segment) => {
+        if (segment.kind === 'literal') return segment;
+        if (segment.kind === 'expression') return segment;
+        if (
+          segment.source !== 'resource' ||
+          !segment.resourceId ||
+          segment.nestedComposition !== true
+        ) {
+          return segment;
+        }
+        const resolved = inlineNestedStatusPlanValue(segment, nestedStatusMappings, resourceIds);
+        if (resolved.kind === 'template') return [...resolved.segments];
+        if (resolved.kind === 'reference') return resolved;
+        if (resolved.kind === 'expression') {
+          return { kind: 'expression' as const, expression: resolved.expression };
+        }
+        if (resolved.kind === 'literal') {
+          return { kind: 'literal' as const, value: String(resolved.value) };
+        }
+        if (resolved.kind === 'omitted') return [];
+        return segment;
+      }),
+    };
+  }
+  if (value.kind === 'array') {
+    return {
+      ...value,
+      items: value.items.map((item) =>
+        inlineNestedStatusPlanValue(item, nestedStatusMappings, resourceIds)
+      ),
+    };
+  }
+  if (value.kind === 'object') {
+    return {
+      ...value,
+      entries: value.entries.map((entry) => ({
+        ...entry,
+        value: inlineNestedStatusPlanValue(entry.value, nestedStatusMappings, resourceIds),
+      })),
+    };
+  }
+  return value;
+}
+
 function summarizeValue(value: PlanValue): ValueReferenceSummary {
   switch (value.kind) {
     case 'sensitive-binding':
@@ -568,6 +658,7 @@ function preserveCapturedDynamicValue(
 
 function statusProjections(
   statusMappings: Readonly<Record<string, unknown>>,
+  nestedStatusMappings: Readonly<Record<string, string>>,
   diagnostics: PlanDiagnostic[],
   specSchema: SchemaIR,
   sensitiveSpecPaths: ReadonlySet<string> = new Set(),
@@ -589,7 +680,10 @@ function statusProjections(
     .filter((key) => !key.startsWith('__'))
     .sort()) {
     const lowered = lowerPlanValue(statusMappings[key], { specSchema, resourceIds });
-    const canonicalValue = canonicalizeStatusResourceReferences(lowered.value, resourceAliases);
+    const canonicalValue = canonicalizeStatusResourceReferences(
+      inlineNestedStatusPlanValue(lowered.value, nestedStatusMappings, resourceIds),
+      resourceAliases
+    );
     const value = markSensitiveResourceReferences(
       markSensitiveSpecReferences(canonicalValue, sensitiveSpecPaths),
       resourceNodes,
@@ -663,6 +757,7 @@ function buildStatusContract<TSpec extends KroCompatibleType>(
   }
   const projected = statusProjections(
     capture.ir.statusMappings,
+    capture.ir.nestedStatusMappings,
     diagnostics,
     specSchema,
     sensitiveSpecPaths,

--- a/src/factories/clickhouse/compositions/clickhouse-cluster.ts
+++ b/src/factories/clickhouse/compositions/clickhouse-cluster.ts
@@ -59,7 +59,11 @@ interface ResolvedTopology {
   replicas: number;
   shards: number;
   keeper: boolean;
-  users: readonly { name: string; networksIp: readonly string[] }[];
+  users: readonly {
+    name: string;
+    networksIp: readonly string[];
+    credentialSource: 'sha256' | 'secret';
+  }[];
 }
 
 function resolveTopology(topology: ClickHouseClusterTopology): ResolvedTopology {
@@ -80,6 +84,7 @@ function resolveTopology(topology: ClickHouseClusterTopology): ResolvedTopology 
     users: (topology.users ?? []).map((user) => ({
       name: user.name,
       networksIp: user.networksIp ?? DEFAULT_USER_NETWORKS_IP,
+      credentialSource: user.credentialSource ?? 'sha256',
     })),
   };
 }
@@ -113,7 +118,12 @@ function buildSpecSchema(topology: ResolvedTopology) {
 
   if (topology.users.length > 0) {
     definition.users = Object.fromEntries(
-      topology.users.map((user) => [user.name, { passwordSha256Hex: 'string' }])
+      topology.users.map((user) => [
+        user.name,
+        user.credentialSource === 'secret'
+          ? { passwordSecretRef: { name: 'string > 0', key: 'string > 0' } }
+          : { passwordSha256Hex: 'string' },
+      ])
     );
   }
 
@@ -177,12 +187,25 @@ export function makeClickHouseCluster(
       // Runtime credentials pair with build-time user names by LITERAL key:
       // `spec.users.<name>.passwordSha256Hex` is a plain schema path, so it
       // serializes to clean CEL. Names/networks come from the topology.
-      const users: ClickHouseUser[] = resolved.users.map((user) => ({
-        name: user.name,
-        // biome-ignore lint/style/noNonNullAssertion: the generated schema requires one users.<name> entry per declared user
-        passwordSha256Hex: spec.users![user.name]!.passwordSha256Hex,
-        networksIp: [...user.networksIp],
-      }));
+      const users: ClickHouseUser[] = resolved.users.map((user) => {
+        const credential = spec.users?.[user.name] as
+          | { passwordSha256Hex: string }
+          | { passwordSecretRef: { name: string; key: string } };
+        return {
+          name: user.name,
+          ...(user.credentialSource === 'secret'
+            ? {
+                passwordSecretRef: (
+                  credential as { passwordSecretRef: { name: string; key: string } }
+                ).passwordSecretRef,
+              }
+            : {
+                passwordSha256Hex: (credential as { passwordSha256Hex: string })
+                  .passwordSha256Hex,
+              }),
+          networksIp: [...user.networksIp],
+        };
+      });
 
       const clickhouse = clickHouseInstallation({
         name: spec.name,

--- a/src/factories/clickhouse/resources/installation.ts
+++ b/src/factories/clickhouse/resources/installation.ts
@@ -183,8 +183,23 @@ function compileUsers(
 ): Record<string, unknown> {
   const compiled: Record<string, unknown> = {};
   for (const user of users) {
+    if (user.passwordSha256Hex !== undefined && user.passwordSecretRef !== undefined) {
+      throw new Error(
+        `ClickHouse user ${user.name} cannot define both passwordSha256Hex and passwordSecretRef.`
+      );
+    }
     if (user.passwordSha256Hex !== undefined) {
       compiled[`${user.name}/password_sha256_hex`] = user.passwordSha256Hex;
+    }
+    if (user.passwordSecretRef !== undefined) {
+      compiled[`${user.name}/password`] = {
+        valueFrom: {
+          secretKeyRef: {
+            name: user.passwordSecretRef.name,
+            key: user.passwordSecretRef.key,
+          },
+        },
+      };
     }
     if (user.networksIp !== undefined) {
       compiled[`${user.name}/networks/ip`] = user.networksIp;

--- a/src/factories/clickhouse/types.ts
+++ b/src/factories/clickhouse/types.ts
@@ -200,6 +200,15 @@ export const ClickHouseUserSchema = type({
   name: 'string',
   /** SHA256 hex digest of the user password (value position — refs OK). */
   'passwordSha256Hex?': 'string',
+  /**
+   * Secret-backed plaintext password. The Altinity operator resolves this
+   * reference without copying credential material into the CHI spec.
+   * Mutually exclusive with `passwordSha256Hex`.
+   */
+  'passwordSecretRef?': {
+    name: 'string > 0',
+    key: 'string > 0',
+  },
   /** Allowed source networks, e.g. ['::/0'] (value position — refs OK). */
   'networksIp?': 'string[]',
 });
@@ -417,6 +426,8 @@ export interface ClickHouseClusterUserTopology {
   readonly name: string;
   /** Allowed source networks (default: ['::/0']). */
   readonly networksIp?: readonly string[];
+  /** Runtime credential representation. Defaults to the legacy SHA256 form. */
+  readonly credentialSource?: 'sha256' | 'secret';
 }
 
 /**
@@ -499,7 +510,11 @@ export type ClickHouseClusterSpec = ClickHouseClusterSpecBase & {
   /** Keeper connection (required iff the topology enables keeper). */
   keeper?: ClickHouseClusterKeeperSpec;
   /** Per-declared-user runtime credentials, keyed by build-time user name. */
-  users?: Record<string, { passwordSha256Hex: string }>;
+  users?: Record<
+    string,
+    | { passwordSha256Hex: string }
+    | { passwordSecretRef: { name: string; key: string } }
+  >;
 };
 
 /**

--- a/src/factories/clickstack/compositions/clickstack-bootstrap.ts
+++ b/src/factories/clickstack/compositions/clickstack-bootstrap.ts
@@ -59,6 +59,7 @@
  *     username: 'otelcollector',
  *     password: '…',
  *   },
+ *   apiKey: '…',
  * });
  * ```
  *
@@ -69,18 +70,22 @@
  * await bootstrap.factory('kro').deploy({
  *   name: 'clickstack',
  *   clickhouse: { host: '…' },
+ *   apiKey: '…',
  *   mongoUri: 'mongodb://user:pass@mongo.example.com:27017/hyperdx',
  * });
  * ```
  */
 
+import type { V1CronJob } from '@kubernetes/client-node';
 import { kubernetesComposition } from '../../../core/composition/imperative.js';
 import { DEFAULT_FLUX_NAMESPACE } from '../../../core/config/defaults.js';
+import { registerPortableReadinessEvaluator } from '../../../core/readiness/portable-strategies.js';
 import { Cel } from '../../../core/references/cel.js';
 import { singleton } from '../../../core/singleton/singleton.js';
 import { containsKubernetesRefs, isKubernetesRef } from '../../../utils/type-guards.js';
+import { helmReleaseConditionSummary } from '../../helm/status.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
-import { job } from '../../kubernetes/workloads/job.js';
+import { cronJob } from '../../kubernetes/workloads/cron-job.js';
 import {
   CLICKSTACK_API_PORT,
   CLICKSTACK_APP_PORT,
@@ -102,12 +107,16 @@ import {
   type ClickStackExternalMongoBootstrapConfig,
   ClickStackExternalMongoBootstrapConfigSchema,
   type ClickStackExternalMongoBuildOptions,
+  type ClickStackInlineExternalMongoBuildOptions,
+  type ClickStackInlineInternalMongoBuildOptions,
   type ClickStackInternalMongoBuildOptions,
   type ClickStackMongoStorageOptions,
   type ClickStackSecretValuesBootstrapConfig,
   ClickStackSecretValuesBootstrapConfigSchema,
+  type ClickStackSecretValuesExternalMongoBuildOptions,
   type ClickStackSecretValuesExternalMongoBootstrapConfig,
   ClickStackSecretValuesExternalMongoBootstrapConfigSchema,
+  type ClickStackSecretValuesInternalMongoBuildOptions,
 } from '../types.js';
 import {
   DEFAULT_CLICKSTACK_NAMESPACE,
@@ -123,16 +132,43 @@ interface ResolvedBuildConfig {
   values?: Record<string, unknown>;
 }
 
-const secretValuesSchemaFieldValidations = {
-  'clickhouse.password': 'self == null',
-  'clickhouse.appPassword': 'self == null',
-  apiKey: 'self == null',
+const CLICKSTACK_CHART_PLACEHOLDER_API_KEY = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+const clickstackTeamBootstrapReadiness = registerPortableReadinessEvaluator<V1CronJob>(
+  'typekro.readiness.clickstack.team-bootstrap',
+  '1',
+  (liveResource) => {
+    const status = liveResource.status;
+    const scheduledAt = status?.lastScheduleTime
+      ? new Date(status.lastScheduleTime).getTime()
+      : Number.NaN;
+    const succeededAt = status?.lastSuccessfulTime
+      ? new Date(status.lastSuccessfulTime).getTime()
+      : Number.NaN;
+    if (Number.isFinite(scheduledAt) && Number.isFinite(succeededAt) && succeededAt >= scheduledAt) {
+      return {
+        ready: true,
+        reason: 'BootstrapCurrent',
+        message: 'The latest ClickStack Team credential convergence succeeded',
+      };
+    }
+    return {
+      ready: false,
+      reason: status?.active?.length ? 'BootstrapActive' : 'BootstrapPending',
+      message: status?.lastScheduleTime
+        ? 'The latest ClickStack Team credential convergence has not succeeded'
+        : 'The ClickStack Team credential convergence has not run yet',
+    };
+  }
+);
+const inlineSchemaFieldValidations = {
+  apiKey: `self != "${CLICKSTACK_CHART_PLACEHOLDER_API_KEY}"`,
 } as const;
 
 const CLICKSTACK_TEAM_BOOTSTRAP_SCRIPT = [
   "const database = db.getSiblingDB('hyperdx');",
   'const apiKey = process.env.HYPERDX_API_KEY;',
-  "if (!apiKey) throw new Error('HYPERDX_API_KEY is required.');",
+  "if (typeof apiKey !== 'string' || apiKey.trim().length === 0) throw new Error('HYPERDX_API_KEY is required.');",
+  `if (apiKey === '${CLICKSTACK_CHART_PLACEHOLDER_API_KEY}') throw new Error('HYPERDX_API_KEY must override the published ClickStack chart placeholder.');`,
   "const hookId = 'typekro-managed-ingestion';",
   'const teams = database.teams.find({ hookId }).toArray();',
   "if (teams.length > 1) throw new Error('Multiple TypeKro-managed ClickStack Teams exist.');",
@@ -181,6 +217,20 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
       ? Cel.default(spec.version, DEFAULT_CLICKSTACK_VERSION)
       : (spec.version ?? DEFAULT_CLICKSTACK_VERSION);
 
+    if (build.credentialSource === 'inline') {
+      const inlineApiKey = (
+        spec as ClickStackBootstrapConfig | ClickStackExternalMongoBootstrapConfig
+      ).apiKey;
+      if (
+        !isKubernetesRef(inlineApiKey) &&
+        (inlineApiKey.trim().length === 0 || inlineApiKey === CLICKSTACK_CHART_PLACEHOLDER_API_KEY)
+      ) {
+        throw new Error(
+          'ClickStack inline credential mode requires a non-empty apiKey that is not the published chart placeholder.'
+        );
+      }
+    }
+
     const helmValues = mapClickStackConfigToHelmValues(spec, {
       mongoMode: build.mongoMode,
       credentialSource: build.credentialSource,
@@ -192,16 +242,14 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
       !isKubernetesRef(credentialsSecret) &&
       credentialsSecret === undefined
     ) {
-      throw new Error(
-        'ClickStack secretValues credential mode requires credentialsSecret.'
-      );
+      throw new Error('ClickStack secretValues credential mode requires credentialsSecret.');
     }
     if (
       build.credentialSource === 'secretValues' &&
       !isKubernetesRef(spec.clickhouse) &&
-      (spec.clickhouse.password !== undefined ||
-        spec.clickhouse.appPassword !== undefined ||
-        spec.apiKey !== undefined ||
+      ((spec.clickhouse as { password?: unknown }).password !== undefined ||
+        (spec.clickhouse as { appPassword?: unknown }).appPassword !== undefined ||
+        (spec as { apiKey?: unknown }).apiKey !== undefined ||
         spec.customValues !== undefined)
     ) {
       throw new Error(
@@ -222,9 +270,7 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
       },
       id: 'clickstackNamespace',
     }).withIncludeWhen(
-      isKubernetesRef(spec.namespace)
-        ? Cel.not(spec.namespace)
-        : spec.namespace === undefined
+      isKubernetesRef(spec.namespace) ? Cel.not(spec.namespace) : spec.namespace === undefined
     );
 
     // One cluster-level Flux source shared by every ClickStack instance —
@@ -294,7 +340,11 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
     // chart-owned Secret, after the release (and therefore Mongo) is ready.
     // This keeps the credential out of the Job manifest, coexists with
     // application-created Teams, and converges the framework-owned key when a
-    // replacement credentials Secret is selected.
+    // referenced Secret or Mongo URI rotates. A one-shot Job cannot observe
+    // either update after it completes, so this deliberately uses an
+    // idempotent minute-level CronJob. Readiness requires a successful run;
+    // the script rejects the chart's public placeholder key, making an absent
+    // Secret values override fail closed.
     const mongoUri =
       build.mongoMode === 'external'
         ? (spec as ClickStackExternalMongoBootstrapConfig).mongoUri
@@ -303,10 +353,10 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
             spec.name,
             resolvedNamespace
           );
-    const _teamBootstrap = job({
+    const _teamBootstrap = cronJob({
       id: 'clickstackTeamBootstrap',
       metadata: {
-        name: spec.name,
+        name: `${spec.name}-team-bootstrap`,
         namespace: resolvedNamespace as string,
         labels: {
           'app.kubernetes.io/name': 'clickstack-team-bootstrap',
@@ -315,40 +365,62 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
         },
       },
       spec: {
-        backoffLimit: 6,
-        template: {
-          metadata: {
-            labels: {
-              'app.kubernetes.io/name': 'clickstack-team-bootstrap',
-              'app.kubernetes.io/instance': spec.name,
-            },
-          },
+        schedule: '* * * * *',
+        concurrencyPolicy: 'Forbid',
+        startingDeadlineSeconds: 60,
+        successfulJobsHistoryLimit: 1,
+        failedJobsHistoryLimit: 3,
+        jobTemplate: {
           spec: {
-            restartPolicy: 'Never',
-            containers: [{
-              name: 'team-bootstrap',
-              image: 'mongo:7',
-              command: ['mongosh', '--quiet', mongoUri as string, '--eval', CLICKSTACK_TEAM_BOOTSTRAP_SCRIPT],
-              env: [{
-                name: 'HYPERDX_API_KEY',
-                valueFrom: {
-                  secretKeyRef: {
-                    name: 'clickstack-secret',
-                    key: 'HYPERDX_API_KEY',
-                    optional: false,
-                  },
+            backoffLimit: 6,
+            template: {
+              metadata: {
+                labels: {
+                  'app.kubernetes.io/name': 'clickstack-team-bootstrap',
+                  'app.kubernetes.io/instance': spec.name,
                 },
-              }],
-            }],
+              },
+              spec: {
+                restartPolicy: 'Never',
+                containers: [
+                  {
+                    name: 'team-bootstrap',
+                    image: 'mongo:7',
+                    command: [
+                      'mongosh',
+                      '--quiet',
+                      mongoUri as string,
+                      '--eval',
+                      CLICKSTACK_TEAM_BOOTSTRAP_SCRIPT,
+                    ],
+                    env: [
+                      {
+                        name: 'HYPERDX_API_KEY',
+                        valueFrom: {
+                          secretKeyRef: {
+                            name: 'clickstack-secret',
+                            key: 'HYPERDX_API_KEY',
+                            optional: false,
+                          },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
           },
         },
       },
-    });
+    }).withReadinessEvaluator(clickstackTeamBootstrapReadiness);
     _teamBootstrap.dependsOn(_clickstackHelmRelease);
 
-    const helmReleaseReady = Cel.expr<boolean>(
-      _clickstackHelmRelease.status.conditions,
-      '.exists(c, c.type == "Ready" && c.status == "True")'
+    const helmReleaseStatus = helmReleaseConditionSummary(_clickstackHelmRelease);
+    const teamBootstrapReady = Cel.expr<boolean>(
+      'has(clickstackTeamBootstrap.status.lastScheduleTime) && ',
+      'has(clickstackTeamBootstrap.status.lastSuccessfulTime) && ',
+      'string(clickstackTeamBootstrap.status.lastSuccessfulTime) >= ',
+      'string(clickstackTeamBootstrap.status.lastScheduleTime)'
     );
 
     // Status endpoints derive from the owned HelmRelease resource so they
@@ -376,15 +448,14 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
     // final-pipeline test). Unchanged by this migration: raw Cel.expr before
     // and after; only the metadata endpoint fields switched to template literals.
     return {
-      ready: Cel.expr<boolean>(
-        `${helmReleaseReady.expression} && has(clickstackTeamBootstrap.status.succeeded) && clickstackTeamBootstrap.status.succeeded > 0`
-      ),
+      ready: Cel.expr<boolean>(helmReleaseStatus.ready, ' && ', teamBootstrapReady),
       phase: Cel.expr<'Ready' | 'Installing' | 'Failed'>(
-        'clickstackHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "False") || ' +
-          '(has(clickstackTeamBootstrap.status.failed) && clickstackTeamBootstrap.status.failed > 0) ? "Failed" : ' +
-          '(clickstackHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "True") && ' +
-          'has(clickstackTeamBootstrap.status.succeeded) && clickstackTeamBootstrap.status.succeeded > 0) ' +
-          '? "Ready" : "Installing"'
+        helmReleaseStatus.failed,
+        ' ? "Failed" : (',
+        helmReleaseStatus.ready,
+        ' && ',
+        teamBootstrapReady,
+        ' ? "Ready" : "Installing")'
       ),
       version: resolvedVersion,
       ui: {
@@ -405,65 +476,122 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
   }
 }
 
-function buildInternalComposition(options: ClickStackInternalMongoBuildOptions) {
-  const build: ResolvedBuildConfig = {
+function resolveInternalBuild(options: ClickStackInternalMongoBuildOptions): ResolvedBuildConfig {
+  return {
     mongoMode: 'internal',
     credentialSource: options.credentials?.source ?? 'inline',
     ...(options.mongo?.storage !== undefined && { storage: options.mongo.storage }),
     ...(options.values !== undefined && { values: options.values }),
   };
-  const secretValues = build.credentialSource === 'secretValues';
-  return kubernetesComposition(
-    {
-      name: options.name ?? 'clickstack-bootstrap',
-      kind: options.kind ?? 'ClickStackBootstrap',
-      spec: secretValues
-        ? ClickStackSecretValuesBootstrapConfigSchema
-        : ClickStackBootstrapConfigSchema,
-      status: ClickStackBootstrapStatusSchema,
-    },
-    (spec: ClickStackBootstrapConfig | ClickStackSecretValuesBootstrapConfig) =>
-      bootstrapBody(spec, build),
-    secretValues
-      ? { schemaFieldValidations: secretValuesSchemaFieldValidations }
-      : undefined
-  );
 }
 
-function buildExternalComposition(options: ClickStackExternalMongoBuildOptions) {
-  const build: ResolvedBuildConfig = {
+function resolveExternalBuild(options: ClickStackExternalMongoBuildOptions): ResolvedBuildConfig {
+  return {
     mongoMode: 'external',
     credentialSource: options.credentials?.source ?? 'inline',
     ...(options.values !== undefined && { values: options.values }),
   };
-  const secretValues = build.credentialSource === 'secretValues';
+}
+
+function buildInternalInlineComposition(options: ClickStackInlineInternalMongoBuildOptions) {
+  const build = resolveInternalBuild(options);
+  return kubernetesComposition(
+    {
+      name: options.name ?? 'clickstack-bootstrap',
+      kind: options.kind ?? 'ClickStackBootstrap',
+      spec: ClickStackBootstrapConfigSchema,
+      status: ClickStackBootstrapStatusSchema,
+    },
+    (spec: ClickStackBootstrapConfig) => bootstrapBody(spec, build),
+    { schemaFieldValidations: inlineSchemaFieldValidations }
+  );
+}
+
+function buildInternalSecretValuesComposition(
+  options: ClickStackSecretValuesInternalMongoBuildOptions
+) {
+  const build: ResolvedBuildConfig = {
+    ...resolveInternalBuild(options),
+    credentialSource: 'secretValues',
+  };
+  return kubernetesComposition(
+    {
+      name: options.name ?? 'clickstack-bootstrap',
+      kind: options.kind ?? 'ClickStackBootstrap',
+      spec: ClickStackSecretValuesBootstrapConfigSchema,
+      status: ClickStackBootstrapStatusSchema,
+    },
+    (spec: ClickStackSecretValuesBootstrapConfig) => bootstrapBody(spec, build)
+  );
+}
+
+function buildExternalInlineComposition(options: ClickStackInlineExternalMongoBuildOptions) {
+  const build = resolveExternalBuild(options);
   return kubernetesComposition(
     {
       name: options.name ?? 'clickstack-bootstrap-external-mongo',
       kind: options.kind ?? 'ClickStackExternalMongoBootstrap',
-      spec: secretValues
-        ? ClickStackSecretValuesExternalMongoBootstrapConfigSchema
-        : ClickStackExternalMongoBootstrapConfigSchema,
+      spec: ClickStackExternalMongoBootstrapConfigSchema,
       status: ClickStackBootstrapStatusSchema,
     },
-    (
-      spec:
-        | ClickStackExternalMongoBootstrapConfig
-        | ClickStackSecretValuesExternalMongoBootstrapConfig
-    ) => bootstrapBody(spec, build),
-    secretValues
-      ? { schemaFieldValidations: secretValuesSchemaFieldValidations }
-      : undefined
+    (spec: ClickStackExternalMongoBootstrapConfig) => bootstrapBody(spec, build),
+    { schemaFieldValidations: inlineSchemaFieldValidations }
+  );
+}
+
+function buildExternalSecretValuesComposition(
+  options: ClickStackSecretValuesExternalMongoBuildOptions
+) {
+  const build: ResolvedBuildConfig = {
+    ...resolveExternalBuild(options),
+    credentialSource: 'secretValues',
+  };
+  return kubernetesComposition(
+    {
+      name: options.name ?? 'clickstack-bootstrap-external-mongo',
+      kind: options.kind ?? 'ClickStackExternalMongoBootstrap',
+      spec: ClickStackSecretValuesExternalMongoBootstrapConfigSchema,
+      status: ClickStackBootstrapStatusSchema,
+    },
+    (spec: ClickStackSecretValuesExternalMongoBootstrapConfig) => bootstrapBody(spec, build)
   );
 }
 
 /** Composition type for the internal-Mongo variant. */
-export type ClickStackBootstrapComposition = ReturnType<typeof buildInternalComposition>;
+export type ClickStackBootstrapComposition = ReturnType<typeof buildInternalInlineComposition>;
+
+/** Composition type for the Secret-backed internal-Mongo variant. */
+export type ClickStackSecretValuesBootstrapComposition = ReturnType<
+  typeof buildInternalSecretValuesComposition
+>;
 
 /** Composition type for the external-Mongo variant. */
 export type ClickStackExternalMongoBootstrapComposition = ReturnType<
-  typeof buildExternalComposition
+  typeof buildExternalInlineComposition
 >;
+
+/** Composition type for the Secret-backed external-Mongo variant. */
+export type ClickStackSecretValuesExternalMongoBootstrapComposition = ReturnType<
+  typeof buildExternalSecretValuesComposition
+>;
+
+function isSecretValuesExternalBuild(
+  options: ClickStackBuildOptions
+): options is ClickStackSecretValuesExternalMongoBuildOptions {
+  return options.mongo?.mode === 'external' && options.credentials?.source === 'secretValues';
+}
+
+function isInlineExternalBuild(
+  options: ClickStackBuildOptions
+): options is ClickStackInlineExternalMongoBuildOptions {
+  return options.mongo?.mode === 'external' && options.credentials?.source !== 'secretValues';
+}
+
+function isSecretValuesInternalBuild(
+  options: ClickStackBuildOptions
+): options is ClickStackSecretValuesInternalMongoBuildOptions {
+  return options.mongo?.mode !== 'external' && options.credentials?.source === 'secretValues';
+}
 
 /**
  * Construct a ClickStack bootstrap composition variant. Build-time options
@@ -471,14 +599,24 @@ export type ClickStackExternalMongoBootstrapComposition = ReturnType<
  * values; everything per-instance stays in the runtime spec.
  */
 export function makeClickstackBootstrap(
-  options?: ClickStackInternalMongoBuildOptions
+  options?: ClickStackInlineInternalMongoBuildOptions
 ): ClickStackBootstrapComposition;
 export function makeClickstackBootstrap(
-  options: ClickStackExternalMongoBuildOptions
+  options: ClickStackSecretValuesInternalMongoBuildOptions
+): ClickStackSecretValuesBootstrapComposition;
+export function makeClickstackBootstrap(
+  options: ClickStackInlineExternalMongoBuildOptions
 ): ClickStackExternalMongoBootstrapComposition;
 export function makeClickstackBootstrap(
+  options: ClickStackSecretValuesExternalMongoBuildOptions
+): ClickStackSecretValuesExternalMongoBootstrapComposition;
+export function makeClickstackBootstrap(
   options: ClickStackBuildOptions = {}
-): ClickStackBootstrapComposition | ClickStackExternalMongoBootstrapComposition {
+):
+  | ClickStackBootstrapComposition
+  | ClickStackSecretValuesBootstrapComposition
+  | ClickStackExternalMongoBootstrapComposition
+  | ClickStackSecretValuesExternalMongoBootstrapComposition {
   // Build-time options must be CONCRETE: they select which resources exist and bake static chart
   // values at construction — a schema ref here can never serialize (loud > silent mis-serialization).
   if (containsKubernetesRefs(options)) {
@@ -509,10 +647,16 @@ export function makeClickstackBootstrap(
       );
     }
   }
-  if (options.mongo?.mode === 'external') {
-    return buildExternalComposition(options as ClickStackExternalMongoBuildOptions);
+  if (isSecretValuesExternalBuild(options)) {
+    return buildExternalSecretValuesComposition(options);
   }
-  return buildInternalComposition(options as ClickStackInternalMongoBuildOptions);
+  if (isInlineExternalBuild(options)) {
+    return buildExternalInlineComposition(options);
+  }
+  if (isSecretValuesInternalBuild(options)) {
+    return buildInternalSecretValuesComposition(options);
+  }
+  return buildInternalInlineComposition(options);
 }
 
 /**

--- a/src/factories/clickstack/compositions/clickstack-bootstrap.ts
+++ b/src/factories/clickstack/compositions/clickstack-bootstrap.ts
@@ -1,7 +1,7 @@
 /**
  * ClickStack (HyperDX) Bootstrap Composition — EXTERNAL ClickHouse only.
  *
- * Deploys the OFFICIAL `clickstack` chart (3.0.x, MIT) from
+ * Deploys the OFFICIAL `clickstack` chart (3.2.x, MIT) from
  * https://clickhouse.github.io/ClickStack-helm-charts via HelmRepository and
  * HelmRelease resources. Build-around: we wrap the official chart — never
  * hand-rolled manifests. NOT the archived hyperdxio/helm-charts repo, NOT the
@@ -80,6 +80,7 @@ import { Cel } from '../../../core/references/cel.js';
 import { singleton } from '../../../core/singleton/singleton.js';
 import { containsKubernetesRefs, isKubernetesRef } from '../../../utils/type-guards.js';
 import { namespace } from '../../kubernetes/core/namespace.js';
+import { job } from '../../kubernetes/workloads/job.js';
 import {
   CLICKSTACK_API_PORT,
   CLICKSTACK_APP_PORT,
@@ -128,6 +129,32 @@ const secretValuesSchemaFieldValidations = {
   'clickhouse.appPassword': 'self == null',
   apiKey: 'self == null',
 } as const;
+
+const CLICKSTACK_TEAM_BOOTSTRAP_SCRIPT = [
+  "const database = db.getSiblingDB('hyperdx');",
+  'const apiKey = process.env.HYPERDX_API_KEY;',
+  "if (!apiKey) throw new Error('HYPERDX_API_KEY is required.');",
+  "const hookId = 'typekro-managed-ingestion';",
+  'const teams = database.teams.find({ hookId }).toArray();',
+  "if (teams.length > 1) throw new Error('Multiple TypeKro-managed ClickStack Teams exist.');",
+  'if (teams.length === 0) {',
+  '  const now = new Date();',
+  '  database.teams.insertOne({',
+  "    name: 'Applik8s Observability',",
+  '    allowedAuthMethods: [],',
+  '    hookId,',
+  '    apiKey,',
+  '    collectorAuthenticationEnforced: true,',
+  '    isMetricsSeriesTableEnabled: false,',
+  '    createdAt: now,',
+  '    updatedAt: now,',
+  '  });',
+  '} else if (teams[0].apiKey !== apiKey || teams[0].collectorAuthenticationEnforced !== true) {',
+  '  database.teams.updateOne({ _id: teams[0]._id }, {',
+  '    $set: { apiKey, collectorAuthenticationEnforced: true, updatedAt: new Date() },',
+  '  });',
+  '}',
+].join('\n');
 
 /**
  * Shared composition body. `build` is CONCRETE (construction-time), so every
@@ -257,6 +284,65 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
       id: 'clickstackHelmRelease',
     });
 
+    // HyperDX's production OpAMP controller activates OTLP only after its
+    // authoritative Team collection contains an ingestion key. The chart's
+    // HYPERDX_API_KEY environment value configures application telemetry but
+    // does not create that Team. Bootstrap one framework-owned Team from the
+    // chart-owned Secret, after the release (and therefore Mongo) is ready.
+    // This keeps the credential out of the Job manifest, coexists with
+    // application-created Teams, and converges the framework-owned key when a
+    // replacement credentials Secret is selected.
+    const mongoUri =
+      build.mongoMode === 'external'
+        ? (spec as ClickStackExternalMongoBootstrapConfig).mongoUri
+        : Cel.template(
+            'mongodb://%s-mongodb.%s.svc.cluster.local:27017/hyperdx',
+            spec.name,
+            resolvedNamespace
+          );
+    const _teamBootstrap = job({
+      id: 'clickstackTeamBootstrap',
+      metadata: {
+        name: spec.name,
+        namespace: resolvedNamespace as string,
+        labels: {
+          'app.kubernetes.io/name': 'clickstack-team-bootstrap',
+          'app.kubernetes.io/instance': spec.name,
+          'app.kubernetes.io/managed-by': 'typekro',
+        },
+      },
+      spec: {
+        backoffLimit: 6,
+        template: {
+          metadata: {
+            labels: {
+              'app.kubernetes.io/name': 'clickstack-team-bootstrap',
+              'app.kubernetes.io/instance': spec.name,
+            },
+          },
+          spec: {
+            restartPolicy: 'Never',
+            containers: [{
+              name: 'team-bootstrap',
+              image: 'mongo:7',
+              command: ['mongosh', '--quiet', mongoUri as string, '--eval', CLICKSTACK_TEAM_BOOTSTRAP_SCRIPT],
+              env: [{
+                name: 'HYPERDX_API_KEY',
+                valueFrom: {
+                  secretKeyRef: {
+                    name: 'clickstack-secret',
+                    key: 'HYPERDX_API_KEY',
+                    optional: false,
+                  },
+                },
+              }],
+            }],
+          },
+        },
+      },
+    });
+    _teamBootstrap.dependsOn(_clickstackHelmRelease);
+
     const helmReleaseReady = Cel.expr<boolean>(
       _clickstackHelmRelease.status.conditions,
       '.exists(c, c.type == "Ready" && c.status == "True")'
@@ -287,11 +373,15 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
     // final-pipeline test). Unchanged by this migration: raw Cel.expr before
     // and after; only the metadata endpoint fields switched to template literals.
     return {
-      ready: helmReleaseReady,
+      ready: Cel.expr<boolean>(
+        `${helmReleaseReady.expression} && has(clickstackTeamBootstrap.status.succeeded) && clickstackTeamBootstrap.status.succeeded > 0`
+      ),
       phase: Cel.expr<'Ready' | 'Installing' | 'Failed'>(
-        'clickstackHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "False") ' +
-          '? "Failed" : clickstackHelmRelease.status.conditions.exists(c, c.type == "Ready" && ' +
-          'c.status == "True") ? "Ready" : "Installing"'
+        'clickstackHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "False") || ' +
+          '(has(clickstackTeamBootstrap.status.failed) && clickstackTeamBootstrap.status.failed > 0) ? "Failed" : ' +
+          '(clickstackHelmRelease.status.conditions.exists(c, c.type == "Ready" && c.status == "True") && ' +
+          'has(clickstackTeamBootstrap.status.succeeded) && clickstackTeamBootstrap.status.succeeded > 0) ' +
+          '? "Ready" : "Installing"'
       ),
       version: resolvedVersion,
       ui: {

--- a/src/factories/clickstack/compositions/clickstack-bootstrap.ts
+++ b/src/factories/clickstack/compositions/clickstack-bootstrap.ts
@@ -118,6 +118,7 @@ import { clickstackHelmRepositoryBootstrap } from './clickstack-helm-repository.
 interface ResolvedBuildConfig {
   mongoMode: 'internal' | 'external';
   credentialSource: 'inline' | 'secretValues';
+  namespaceOwnership: 'owned' | 'external';
   storage?: ClickStackMongoStorageOptions;
   values?: Record<string, unknown>;
 }
@@ -182,17 +183,19 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
       );
     }
 
-    const _clickstackNamespace = namespace({
-      metadata: {
-        name: resolvedNamespace,
-        labels: {
-          'app.kubernetes.io/name': 'clickstack',
-          'app.kubernetes.io/instance': spec.name,
-          'app.kubernetes.io/managed-by': 'typekro',
+    if (build.namespaceOwnership === 'owned') {
+      const _clickstackNamespace = namespace({
+        metadata: {
+          name: resolvedNamespace,
+          labels: {
+            'app.kubernetes.io/name': 'clickstack',
+            'app.kubernetes.io/instance': spec.name,
+            'app.kubernetes.io/managed-by': 'typekro',
+          },
         },
-      },
-      id: 'clickstackNamespace',
-    });
+        id: 'clickstackNamespace',
+      });
+    }
 
     // One cluster-level Flux source shared by every ClickStack instance —
     // singleton(...) keeps it out of any single instance's KRO ApplySet
@@ -313,6 +316,7 @@ function buildInternalComposition(options: ClickStackInternalMongoBuildOptions) 
   const build: ResolvedBuildConfig = {
     mongoMode: 'internal',
     credentialSource: options.credentials?.source ?? 'inline',
+    namespaceOwnership: options.namespaceOwnership ?? 'owned',
     ...(options.mongo?.storage !== undefined && { storage: options.mongo.storage }),
     ...(options.values !== undefined && { values: options.values }),
   };
@@ -338,6 +342,7 @@ function buildExternalComposition(options: ClickStackExternalMongoBuildOptions) 
   const build: ResolvedBuildConfig = {
     mongoMode: 'external',
     credentialSource: options.credentials?.source ?? 'inline',
+    namespaceOwnership: options.namespaceOwnership ?? 'owned',
     ...(options.values !== undefined && { values: options.values }),
   };
   const secretValues = build.credentialSource === 'secretValues';

--- a/src/factories/clickstack/compositions/clickstack-bootstrap.ts
+++ b/src/factories/clickstack/compositions/clickstack-bootstrap.ts
@@ -119,7 +119,6 @@ import { clickstackHelmRepositoryBootstrap } from './clickstack-helm-repository.
 interface ResolvedBuildConfig {
   mongoMode: 'internal' | 'external';
   credentialSource: 'inline' | 'secretValues';
-  namespaceOwnership: 'owned' | 'external';
   storage?: ClickStackMongoStorageOptions;
   values?: Record<string, unknown>;
 }
@@ -210,19 +209,23 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
       );
     }
 
-    if (build.namespaceOwnership === 'owned') {
-      const _clickstackNamespace = namespace({
-        metadata: {
-          name: resolvedNamespace,
-          labels: {
-            'app.kubernetes.io/name': 'clickstack',
-            'app.kubernetes.io/instance': spec.name,
-            'app.kubernetes.io/managed-by': 'typekro',
-          },
+    const _clickstackNamespace = namespace({
+      metadata: {
+        // This resource is active only when namespace is omitted, so its
+        // identity is always TypeKro's documented standalone default.
+        name: DEFAULT_CLICKSTACK_NAMESPACE,
+        labels: {
+          'app.kubernetes.io/name': 'clickstack',
+          'app.kubernetes.io/instance': spec.name,
+          'app.kubernetes.io/managed-by': 'typekro',
         },
-        id: 'clickstackNamespace',
-      });
-    }
+      },
+      id: 'clickstackNamespace',
+    }).withIncludeWhen(
+      isKubernetesRef(spec.namespace)
+        ? Cel.not(spec.namespace)
+        : spec.namespace === undefined
+    );
 
     // One cluster-level Flux source shared by every ClickStack instance —
     // singleton(...) keeps it out of any single instance's KRO ApplySet
@@ -406,7 +409,6 @@ function buildInternalComposition(options: ClickStackInternalMongoBuildOptions) 
   const build: ResolvedBuildConfig = {
     mongoMode: 'internal',
     credentialSource: options.credentials?.source ?? 'inline',
-    namespaceOwnership: options.namespaceOwnership ?? 'owned',
     ...(options.mongo?.storage !== undefined && { storage: options.mongo.storage }),
     ...(options.values !== undefined && { values: options.values }),
   };
@@ -432,7 +434,6 @@ function buildExternalComposition(options: ClickStackExternalMongoBuildOptions) 
   const build: ResolvedBuildConfig = {
     mongoMode: 'external',
     credentialSource: options.credentials?.source ?? 'inline',
-    namespaceOwnership: options.namespaceOwnership ?? 'owned',
     ...(options.values !== undefined && { values: options.values }),
   };
   const secretValues = build.credentialSource === 'secretValues';

--- a/src/factories/clickstack/compositions/clickstack-bootstrap.ts
+++ b/src/factories/clickstack/compositions/clickstack-bootstrap.ts
@@ -103,6 +103,10 @@ import {
   type ClickStackExternalMongoBuildOptions,
   type ClickStackInternalMongoBuildOptions,
   type ClickStackMongoStorageOptions,
+  type ClickStackSecretValuesBootstrapConfig,
+  ClickStackSecretValuesBootstrapConfigSchema,
+  type ClickStackSecretValuesExternalMongoBootstrapConfig,
+  ClickStackSecretValuesExternalMongoBootstrapConfigSchema,
 } from '../types.js';
 import {
   DEFAULT_CLICKSTACK_NAMESPACE,
@@ -113,9 +117,16 @@ import { clickstackHelmRepositoryBootstrap } from './clickstack-helm-repository.
 /** Concrete, resolved build choices the composition body branches on. */
 interface ResolvedBuildConfig {
   mongoMode: 'internal' | 'external';
+  credentialSource: 'inline' | 'secretValues';
   storage?: ClickStackMongoStorageOptions;
   values?: Record<string, unknown>;
 }
+
+const secretValuesSchemaFieldValidations = {
+  'clickhouse.password': 'self == null',
+  'clickhouse.appPassword': 'self == null',
+  apiKey: 'self == null',
+} as const;
 
 /**
  * Shared composition body. `build` is CONCRETE (construction-time), so every
@@ -131,6 +142,11 @@ interface ResolvedBuildConfig {
  */
 function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBuildConfig) {
   {
+    const credentialsSecret = (
+      spec as
+        | ClickStackSecretValuesBootstrapConfig
+        | ClickStackSecretValuesExternalMongoBootstrapConfig
+    ).credentialsSecret;
     const resolvedNamespace = isKubernetesRef(spec.namespace)
       ? Cel.default(spec.namespace, DEFAULT_CLICKSTACK_NAMESPACE)
       : (spec.namespace ?? DEFAULT_CLICKSTACK_NAMESPACE);
@@ -140,8 +156,31 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
 
     const helmValues = mapClickStackConfigToHelmValues(spec, {
       mongoMode: build.mongoMode,
+      credentialSource: build.credentialSource,
       ...(build.values !== undefined && { values: build.values }),
     });
+
+    if (
+      build.credentialSource === 'secretValues' &&
+      !isKubernetesRef(credentialsSecret) &&
+      credentialsSecret === undefined
+    ) {
+      throw new Error(
+        'ClickStack secretValues credential mode requires credentialsSecret.'
+      );
+    }
+    if (
+      build.credentialSource === 'secretValues' &&
+      !isKubernetesRef(spec.clickhouse) &&
+      (spec.clickhouse.password !== undefined ||
+        spec.clickhouse.appPassword !== undefined ||
+        spec.apiKey !== undefined ||
+        spec.customValues !== undefined)
+    ) {
+      throw new Error(
+        'ClickStack secretValues credential mode rejects inline clickhouse.password, clickhouse.appPassword, apiKey, and runtime customValues.'
+      );
+    }
 
     const _clickstackNamespace = namespace({
       metadata: {
@@ -198,6 +237,20 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
       namespace: resolvedNamespace,
       version: resolvedVersion,
       values: helmValues,
+      ...(build.credentialSource === 'secretValues'
+        ? {
+            valuesFrom: [
+              {
+                kind: 'Secret' as const,
+                // biome-ignore lint/style/noNonNullAssertion: the secretValues schema requires credentialsSecret
+                name: credentialsSecret!.name,
+                valuesKey: isKubernetesRef(credentialsSecret?.valuesKey)
+                  ? Cel.default(credentialsSecret.valuesKey, 'values.yaml')
+                  : (credentialsSecret?.valuesKey ?? 'values.yaml'),
+              },
+            ],
+          }
+        : {}),
       id: 'clickstackHelmRelease',
     });
 
@@ -259,33 +312,52 @@ function bootstrapBody(spec: ClickStackBootstrapRuntimeConfig, build: ResolvedBu
 function buildInternalComposition(options: ClickStackInternalMongoBuildOptions) {
   const build: ResolvedBuildConfig = {
     mongoMode: 'internal',
+    credentialSource: options.credentials?.source ?? 'inline',
     ...(options.mongo?.storage !== undefined && { storage: options.mongo.storage }),
     ...(options.values !== undefined && { values: options.values }),
   };
+  const secretValues = build.credentialSource === 'secretValues';
   return kubernetesComposition(
     {
       name: options.name ?? 'clickstack-bootstrap',
       kind: options.kind ?? 'ClickStackBootstrap',
-      spec: ClickStackBootstrapConfigSchema,
+      spec: secretValues
+        ? ClickStackSecretValuesBootstrapConfigSchema
+        : ClickStackBootstrapConfigSchema,
       status: ClickStackBootstrapStatusSchema,
     },
-    (spec: ClickStackBootstrapConfig) => bootstrapBody(spec, build)
+    (spec: ClickStackBootstrapConfig | ClickStackSecretValuesBootstrapConfig) =>
+      bootstrapBody(spec, build),
+    secretValues
+      ? { schemaFieldValidations: secretValuesSchemaFieldValidations }
+      : undefined
   );
 }
 
 function buildExternalComposition(options: ClickStackExternalMongoBuildOptions) {
   const build: ResolvedBuildConfig = {
     mongoMode: 'external',
+    credentialSource: options.credentials?.source ?? 'inline',
     ...(options.values !== undefined && { values: options.values }),
   };
+  const secretValues = build.credentialSource === 'secretValues';
   return kubernetesComposition(
     {
       name: options.name ?? 'clickstack-bootstrap-external-mongo',
       kind: options.kind ?? 'ClickStackExternalMongoBootstrap',
-      spec: ClickStackExternalMongoBootstrapConfigSchema,
+      spec: secretValues
+        ? ClickStackSecretValuesExternalMongoBootstrapConfigSchema
+        : ClickStackExternalMongoBootstrapConfigSchema,
       status: ClickStackBootstrapStatusSchema,
     },
-    (spec: ClickStackExternalMongoBootstrapConfig) => bootstrapBody(spec, build)
+    (
+      spec:
+        | ClickStackExternalMongoBootstrapConfig
+        | ClickStackSecretValuesExternalMongoBootstrapConfig
+    ) => bootstrapBody(spec, build),
+    secretValues
+      ? { schemaFieldValidations: secretValuesSchemaFieldValidations }
+      : undefined
   );
 }
 
@@ -319,6 +391,27 @@ export function makeClickstackBootstrap(
         'Build-time options (mongo mode/storage, static chart values, name/kind) are fixed at ' +
         'construction — move per-instance values into the runtime spec instead.'
     );
+  }
+  if (options.credentials?.source === 'secretValues') {
+    const hyperdx = options.values?.hyperdx;
+    const deployment =
+      hyperdx && typeof hyperdx === 'object' && !Array.isArray(hyperdx)
+        ? hyperdx.deployment
+        : undefined;
+    if (
+      hyperdx &&
+      typeof hyperdx === 'object' &&
+      !Array.isArray(hyperdx) &&
+      (hyperdx.secrets !== undefined ||
+        (deployment &&
+          typeof deployment === 'object' &&
+          !Array.isArray(deployment) &&
+          deployment.defaultConnections !== undefined))
+    ) {
+      throw new Error(
+        'makeClickstackBootstrap: secretValues credential mode rejects build-time hyperdx.secrets and hyperdx.deployment.defaultConnections. Put those values in the referenced Secret.'
+      );
+    }
   }
   if (options.mongo?.mode === 'external') {
     return buildExternalComposition(options as ClickStackExternalMongoBuildOptions);

--- a/src/factories/clickstack/resources/helm.ts
+++ b/src/factories/clickstack/resources/helm.ts
@@ -50,9 +50,9 @@ export const CLICKSTACK_CHART_NAME = 'clickstack';
 
 /**
  * Default clickstack chart version (verified against the live repo index on
- * 2026-07-06: 3.0.1, appVersion 2.29.0).
+ * 2026-08-26: 3.2.0, appVersion 2.35.0).
  */
-export const DEFAULT_CLICKSTACK_VERSION = '3.0.1';
+export const DEFAULT_CLICKSTACK_VERSION = '3.2.0';
 
 /** Official OpenTelemetry Helm chart repository URL. */
 export const DEFAULT_OTEL_REPO_URL = 'https://open-telemetry.github.io/opentelemetry-helm-charts';
@@ -72,7 +72,7 @@ export const OTEL_COLLECTOR_CHART_NAME = 'opentelemetry-collector';
 export const DEFAULT_OTEL_COLLECTOR_VERSION = '0.146.1';
 
 // Chart port facts (values.yaml `hyperdx.ports` and `otel-collector.ports`,
-// chart 3.0.1) — the bootstrap status contract is built on these defaults.
+// chart 3.2.0) — the bootstrap status contract is built on these defaults.
 
 /** HyperDX UI port (`hyperdx.ports.app`). */
 export const CLICKSTACK_APP_PORT = 3000;

--- a/src/factories/clickstack/resources/helm.ts
+++ b/src/factories/clickstack/resources/helm.ts
@@ -154,6 +154,7 @@ export function clickstackHelmRelease(
     },
     driftDetection: { mode: 'enabled' },
     values: config.values || {},
+    ...(config.valuesFrom && { valuesFrom: config.valuesFrom }),
     ...(config.id && { id: config.id }),
   }).withReadinessEvaluator(
     createLabeledHelmReleaseEvaluator('ClickStack')

--- a/src/factories/clickstack/types.ts
+++ b/src/factories/clickstack/types.ts
@@ -5,7 +5,7 @@
  * inferred via `typeof Schema.infer` (mirrors the clickhouse/dagster families).
  *
  * Wraps the OFFICIAL ClickStack Helm chart (MIT):
- * - Chart: `clickstack` 3.0.x from https://clickhouse.github.io/ClickStack-helm-charts
+ * - Chart: `clickstack` 3.2.x from https://clickhouse.github.io/ClickStack-helm-charts
  *   (classic Helm repo, NOT OCI). The old hyperdxio/helm-charts repo is archived
  *   and its `hdx-oss-v2` chart is deprecated — do not use them.
  * - Components: the HyperDX app (UI + API + OpAMP server on 4320 that remotely
@@ -198,13 +198,6 @@ export type ClickStackMongoBuildOptions =
 /** Shared build-time options for both bootstrap variants. */
 interface ClickStackBuildOptionsBase {
   /**
-   * Credential transport selected at composition construction time.
-   * `inline` preserves the historical runtime fields. `secretValues` loads a
-   * complete Helm values fragment from a Kubernetes Secret through Flux and
-   * keeps credentials out of the RGD, instance, and HelmRelease values.
-   */
-  credentials?: { source: 'inline' } | { source: 'secretValues' };
-  /**
    * Static raw official-chart values merged at construction time (they win
    * over the typed mapping), EXCEPT the hard pins — `clickhouse.enabled: false`,
    * `mongodb.enabled: false`, and `fullnameOverride` (the status contract's
@@ -223,15 +216,39 @@ interface ClickStackBuildOptionsBase {
   kind?: string;
 }
 
-/** Build-time options for the internal-Mongo bootstrap variant. */
-export interface ClickStackInternalMongoBuildOptions extends ClickStackBuildOptionsBase {
+/** Build-time options for inline credentials with internal Mongo. */
+export type ClickStackInlineInternalMongoBuildOptions = ClickStackBuildOptionsBase & {
   mongo?: { mode: 'internal'; storage?: ClickStackMongoStorageOptions };
-}
+  credentials?: { source: 'inline' };
+};
 
-/** Build-time options for the external-Mongo bootstrap variant. */
-export interface ClickStackExternalMongoBuildOptions extends ClickStackBuildOptionsBase {
+/** Build-time options for Secret-backed credentials with internal Mongo. */
+export type ClickStackSecretValuesInternalMongoBuildOptions = ClickStackBuildOptionsBase & {
+  mongo?: { mode: 'internal'; storage?: ClickStackMongoStorageOptions };
+  credentials: { source: 'secretValues' };
+};
+
+/** Every supported internal-Mongo construction-time configuration. */
+export type ClickStackInternalMongoBuildOptions =
+  | ClickStackInlineInternalMongoBuildOptions
+  | ClickStackSecretValuesInternalMongoBuildOptions;
+
+/** Build-time options for inline credentials with external Mongo. */
+export type ClickStackInlineExternalMongoBuildOptions = ClickStackBuildOptionsBase & {
   mongo: { mode: 'external' };
-}
+  credentials?: { source: 'inline' };
+};
+
+/** Build-time options for Secret-backed credentials with external Mongo. */
+export type ClickStackSecretValuesExternalMongoBuildOptions = ClickStackBuildOptionsBase & {
+  mongo: { mode: 'external' };
+  credentials: { source: 'secretValues' };
+};
+
+/** Every supported external-Mongo construction-time configuration. */
+export type ClickStackExternalMongoBuildOptions =
+  | ClickStackInlineExternalMongoBuildOptions
+  | ClickStackSecretValuesExternalMongoBuildOptions;
 
 /** Union accepted by `makeClickstackBootstrap`. */
 export type ClickStackBuildOptions =
@@ -242,6 +259,21 @@ export type ClickStackBuildOptions =
 // Bootstrap runtime spec (external ClickHouse)
 // ============================================================================
 
+const clickhouseConnectionBaseShape = {
+  /** DNS host of the external ClickHouse service (no scheme, no port). */
+  host: 'string',
+  /** Native TCP port (default: 9000) → `CLICKHOUSE_ENDPOINT`/`CLICKHOUSE_SERVER_ENDPOINT`. */
+  'nativePort?': 'number.integer',
+  /** HTTP port (default: 8123) → HyperDX UI `defaultConnections` host. */
+  'httpPort?': 'number.integer',
+  /** OTel export target database (default: 'default') → `HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE`. */
+  'database?': 'string',
+  /** Ingest/collector user (default: 'default') → `hyperdx.config.CLICKHOUSE_USER`. Needs SELECT,INSERT,CREATE,SHOW on the database. */
+  'username?': 'string',
+  /** Read-mostly UI user for HyperDX connections (default: `username`). Needs SHOW + SELECT. */
+  'appUsername?': 'string',
+} as const;
+
 const bootstrapBaseShape = {
   /** Release name for the Helm installation. */
   name: 'string',
@@ -249,38 +281,25 @@ const bootstrapBaseShape = {
   'namespace?': 'string',
   /** Chart version (default: '3.2.0'). */
   'version?': 'string',
-  // SECRETS CAVEAT: `password`/`appPassword` below (and `apiKey` further
-  // down) travel as PLAINTEXT runtime spec values all the way into the
+  // SECRETS CAVEAT: `password`/`appPassword` below (and the required inline
+  // `apiKey` on the inline-mode schemas) travel as PLAINTEXT runtime spec values all the way into the
   // generated HelmRelease's `spec.values.hyperdx.secrets.*` — a Kubernetes
   // object stored in etcd, readable by anyone with read access to the
   // HelmRelease/RGD instance (`kubectl get helmrelease -o yaml`), unlike
   // `k8s-telemetry.ts`'s `apiKeySecret` (a `secretKeyRef` env var — the
-  // value never appears in any CR spec). There is currently NO
-  // existing-Secret / secretKeyRef alternative for these three fields.
+  // value never appears in any CR spec). Use the secretValues constructor
+  // mode when these three fields need to stay out of the CR spec.
   // Treat them as no more protected than any other spec field; do not
   // consider this family production-ready for credentials that need
   // stronger-than-etcd-RBAC protection until that gap is closed.
   /** External ClickHouse connection (REQUIRED — external-only build-around). */
   clickhouse: {
-    /** DNS host of the external ClickHouse service (no scheme, no port). */
-    host: 'string',
-    /** Native TCP port (default: 9000) → `CLICKHOUSE_ENDPOINT`/`CLICKHOUSE_SERVER_ENDPOINT`. */
-    'nativePort?': 'number.integer',
-    /** HTTP port (default: 8123) → HyperDX UI `defaultConnections` host. */
-    'httpPort?': 'number.integer',
-    /** OTel export target database (default: 'default') → `HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE`. */
-    'database?': 'string',
-    /** Ingest/collector user (default: 'default') → `hyperdx.config.CLICKHOUSE_USER`. Needs SELECT,INSERT,CREATE,SHOW on the database. */
-    'username?': 'string',
+    ...clickhouseConnectionBaseShape,
     /** Ingest/collector password → `hyperdx.secrets.CLICKHOUSE_PASSWORD` (default: ''). PLAINTEXT in the HelmRelease spec — see the secrets caveat above. */
     'password?': 'string',
-    /** Read-mostly UI user for HyperDX connections (default: `username`). Needs SHOW + SELECT. */
-    'appUsername?': 'string',
     /** UI user password → `hyperdx.secrets.CLICKHOUSE_APP_PASSWORD` (default: `password`). PLAINTEXT in the HelmRelease spec — see the secrets caveat above. */
     'appPassword?': 'string',
   },
-  /** HyperDX ingestion API key → `hyperdx.secrets.HYPERDX_API_KEY`. PLAINTEXT in the HelmRelease spec — see the secrets caveat above `clickhouse`. */
-  'apiKey?': 'string',
   /** HyperDX app (UI/API) conveniences. */
   'hyperdx?': {
     'replicas?': 'number.integer',
@@ -303,19 +322,28 @@ const bootstrapBaseShape = {
   // concrete objects before serialization.
 } as const;
 
+const secretValuesBootstrapBaseShape = {
+  ...bootstrapBaseShape,
+  clickhouse: clickhouseConnectionBaseShape,
+} as const;
+
 /**
  * Runtime spec for the internal-Mongo variant (the default
  * `clickstackBootstrap`). Mongo needs no runtime config — mode and storage
  * are build-time (`makeClickstackBootstrap`).
  */
-export const ClickStackBootstrapConfigSchema = type(bootstrapBaseShape);
+export const ClickStackBootstrapConfigSchema = type({
+  ...bootstrapBaseShape,
+  /** HyperDX ingestion API key → `hyperdx.secrets.HYPERDX_API_KEY`. Required and non-empty in inline mode. */
+  apiKey: 'string > 0',
+});
 
 /** Runtime configuration for the internal-Mongo bootstrap variant. */
 export type ClickStackBootstrapConfig = typeof ClickStackBootstrapConfigSchema.infer;
 
 /** Runtime schema used by the Secret-backed internal-Mongo variant. */
 export const ClickStackSecretValuesBootstrapConfigSchema = type({
-  ...bootstrapBaseShape,
+  ...secretValuesBootstrapBaseShape,
   credentialsSecret: {
     name: 'string > 0',
     'valuesKey?': 'string > 0',
@@ -331,6 +359,8 @@ export type ClickStackSecretValuesBootstrapConfig =
  */
 export const ClickStackExternalMongoBootstrapConfigSchema = type({
   ...bootstrapBaseShape,
+  /** HyperDX ingestion API key → `hyperdx.secrets.HYPERDX_API_KEY`. Required and non-empty in inline mode. */
+  apiKey: 'string > 0',
   /** Full MongoDB connection URI → `hyperdx.config.MONGO_URI` (verbatim). */
   mongoUri: 'string',
 });
@@ -341,7 +371,7 @@ export type ClickStackExternalMongoBootstrapConfig =
 
 /** Runtime schema used by the Secret-backed external-Mongo variant. */
 export const ClickStackSecretValuesExternalMongoBootstrapConfigSchema = type({
-  ...bootstrapBaseShape,
+  ...secretValuesBootstrapBaseShape,
   credentialsSecret: {
     name: 'string > 0',
     'valuesKey?': 'string > 0',

--- a/src/factories/clickstack/types.ts
+++ b/src/factories/clickstack/types.ts
@@ -198,13 +198,6 @@ export type ClickStackMongoBuildOptions =
 /** Shared build-time options for both bootstrap variants. */
 interface ClickStackBuildOptionsBase {
   /**
-   * Namespace lifecycle boundary. `owned` preserves the standalone default;
-   * `external` requires the namespace to be managed by a parent platform and
-   * prevents duplicate ownership when ClickStack is embedded in a larger
-   * deployment graph.
-   */
-  namespaceOwnership?: 'owned' | 'external';
-  /**
    * Credential transport selected at composition construction time.
    * `inline` preserves the historical runtime fields. `secretValues` loads a
    * complete Helm values fragment from a Kubernetes Secret through Flux and

--- a/src/factories/clickstack/types.ts
+++ b/src/factories/clickstack/types.ts
@@ -100,10 +100,15 @@ const imageShape = {
 /**
  * Typed subset of the official `clickstack` chart values we map or pin
  * (verified 2026-07-06 against ClickHouse/ClickStack-helm-charts
- * charts/clickstack/values.yaml, chart 3.0.1). The index signature keeps the
+ * charts/clickstack/values.yaml, chart 3.2.0). The index signature keeps the
  * rest of the chart's surface reachable through the values passthrough.
  */
 export interface ClickStackHelmValues {
+  /** Cross-subchart settings, including the supported collector config overlay. */
+  global?: {
+    otelCollector?: { customConfig?: string; [key: string]: unknown };
+    [key: string]: unknown;
+  };
   /** HyperDX app (UI + API + OpAMP). */
   hyperdx?: {
     /** Shared non-sensitive env (rendered into the `clickstack-config` ConfigMap). */
@@ -249,7 +254,7 @@ const bootstrapBaseShape = {
   name: 'string',
   /** Namespace for the stack (default: 'clickstack'). */
   'namespace?': 'string',
-  /** Chart version (default: '3.0.1'). */
+  /** Chart version (default: '3.2.0'). */
   'version?': 'string',
   // SECRETS CAVEAT: `password`/`appPassword` below (and `apiKey` further
   // down) travel as PLAINTEXT runtime spec values all the way into the

--- a/src/factories/clickstack/types.ts
+++ b/src/factories/clickstack/types.ts
@@ -42,7 +42,8 @@
 
 import { type } from 'arktype';
 import type { ValuesMergeExpression } from '../../core/aspects/values-merge.js';
-import type { TypeKroChartValues } from '../../core/types/common.js';
+import type { TypeKroChartValues, TypeKroValue } from '../../core/types/common.js';
+import type { HelmReleaseValuesFromSource } from '../helm/types.js';
 
 // ============================================================================
 // ClickHouse version-coupling guidance
@@ -192,6 +193,13 @@ export type ClickStackMongoBuildOptions =
 /** Shared build-time options for both bootstrap variants. */
 interface ClickStackBuildOptionsBase {
   /**
+   * Credential transport selected at composition construction time.
+   * `inline` preserves the historical runtime fields. `secretValues` loads a
+   * complete Helm values fragment from a Kubernetes Secret through Flux and
+   * keeps credentials out of the RGD, instance, and HelmRelease values.
+   */
+  credentials?: { source: 'inline' } | { source: 'secretValues' };
+  /**
    * Static raw official-chart values merged at construction time (they win
    * over the typed mapping), EXCEPT the hard pins — `clickhouse.enabled: false`,
    * `mongodb.enabled: false`, and `fullnameOverride` (the status contract's
@@ -300,6 +308,19 @@ export const ClickStackBootstrapConfigSchema = type(bootstrapBaseShape);
 /** Runtime configuration for the internal-Mongo bootstrap variant. */
 export type ClickStackBootstrapConfig = typeof ClickStackBootstrapConfigSchema.infer;
 
+/** Runtime schema used by the Secret-backed internal-Mongo variant. */
+export const ClickStackSecretValuesBootstrapConfigSchema = type({
+  ...bootstrapBaseShape,
+  credentialsSecret: {
+    name: 'string > 0',
+    'valuesKey?': 'string > 0',
+  },
+});
+
+/** Runtime configuration for the Secret-backed internal-Mongo variant. */
+export type ClickStackSecretValuesBootstrapConfig =
+  typeof ClickStackSecretValuesBootstrapConfigSchema.infer;
+
 /**
  * Runtime spec for the external-Mongo variant: base + a required `mongoUri`.
  */
@@ -313,8 +334,27 @@ export const ClickStackExternalMongoBootstrapConfigSchema = type({
 export type ClickStackExternalMongoBootstrapConfig =
   typeof ClickStackExternalMongoBootstrapConfigSchema.infer;
 
+/** Runtime schema used by the Secret-backed external-Mongo variant. */
+export const ClickStackSecretValuesExternalMongoBootstrapConfigSchema = type({
+  ...bootstrapBaseShape,
+  credentialsSecret: {
+    name: 'string > 0',
+    'valuesKey?': 'string > 0',
+  },
+  mongoUri: 'string',
+});
+
+/** Runtime configuration for the Secret-backed external-Mongo variant. */
+export type ClickStackSecretValuesExternalMongoBootstrapConfig =
+  typeof ClickStackSecretValuesExternalMongoBootstrapConfigSchema.infer;
+
 /** Widest runtime config the values mapper accepts (either variant). */
-export type ClickStackBootstrapRuntimeConfig = ClickStackBootstrapConfig & {
+export type ClickStackBootstrapRuntimeConfig = (
+  | ClickStackBootstrapConfig
+  | ClickStackSecretValuesBootstrapConfig
+  | ClickStackExternalMongoBootstrapConfig
+  | ClickStackSecretValuesExternalMongoBootstrapConfig
+) & {
   mongoUri?: string;
   /**
    * INTERNAL, DIRECT-MODE-ONLY escape hatch — not part of the runtime
@@ -516,6 +556,8 @@ export interface ClickStackHelmReleaseConfig {
   repositoryNamespace?: string;
   /** Official clickstack chart values (graph-aware trees / runtime merges allowed). */
   values?: ClickStackMappedHelmValues;
+  /** Secret/ConfigMap values overlays resolved by Flux before inline values. */
+  valuesFrom?: TypeKroValue<HelmReleaseValuesFromSource>[];
   id?: string;
 }
 

--- a/src/factories/clickstack/types.ts
+++ b/src/factories/clickstack/types.ts
@@ -193,6 +193,13 @@ export type ClickStackMongoBuildOptions =
 /** Shared build-time options for both bootstrap variants. */
 interface ClickStackBuildOptionsBase {
   /**
+   * Namespace lifecycle boundary. `owned` preserves the standalone default;
+   * `external` requires the namespace to be managed by a parent platform and
+   * prevents duplicate ownership when ClickStack is embedded in a larger
+   * deployment graph.
+   */
+  namespaceOwnership?: 'owned' | 'external';
+  /**
    * Credential transport selected at composition construction time.
    * `inline` preserves the historical runtime fields. `secretValues` loads a
    * complete Helm values fragment from a Kubernetes Secret through Flux and

--- a/src/factories/clickstack/utils/helm-values-mapper.ts
+++ b/src/factories/clickstack/utils/helm-values-mapper.ts
@@ -57,7 +57,9 @@ import type { TypeKroChartValues } from '../../../core/types/common.js';
 import { isCelExpression, isKubernetesRef } from '../../../utils/type-guards.js';
 import { CLICKSTACK_MONGO_NAME_SUFFIX, CLICKSTACK_MONGO_PORT } from '../resources/mongo.js';
 import type {
+  ClickStackBootstrapConfig,
   ClickStackBootstrapRuntimeConfig,
+  ClickStackExternalMongoBootstrapConfig,
   ClickStackHelmValues,
   ClickStackK8sTelemetryConfig,
   ClickStackMappedHelmValues,
@@ -282,8 +284,7 @@ const DEFAULT_SOURCES_FORMAT = JSON.stringify([
     bodyExpression: 'SpanName',
     eventAttributesExpression: 'SpanAttributes',
     resourceAttributesExpression: 'ResourceAttributes',
-    defaultTableSelectExpression:
-      'Timestamp,ServiceName,StatusCode,round(Duration/1e6),SpanName',
+    defaultTableSelectExpression: 'Timestamp,ServiceName,StatusCode,round(Duration/1e6),SpanName',
     traceIdExpression: 'TraceId',
     spanIdExpression: 'SpanId',
     durationExpression: 'Duration',
@@ -377,15 +378,6 @@ export function mapClickStackConfigToHelmValues(
     const httpPortStr = Cel.expr<string>(
       `string(${hasSchemaPath('schema.spec.clickhouse.httpPort')} ? schema.spec.clickhouse.httpPort : 8123)`
     );
-    const appUsername = Cel.expr<string>(
-      `${hasSchemaPath('schema.spec.clickhouse.appUsername')} ? schema.spec.clickhouse.appUsername : ` +
-        `(${hasSchemaPath('schema.spec.clickhouse.username')} ? schema.spec.clickhouse.username : "default")`
-    );
-    const appPassword = Cel.expr<string>(
-      `${hasSchemaPath('schema.spec.clickhouse.appPassword')} ? schema.spec.clickhouse.appPassword : ` +
-        `(${hasSchemaPath('schema.spec.clickhouse.password')} ? schema.spec.clickhouse.password : "")`
-    );
-
     hyperdxConfig.CLICKHOUSE_ENDPOINT = Cel.template(
       'tcp://%s:%s?dial_timeout=10s',
       ch.host,
@@ -405,15 +397,21 @@ export function mapClickStackConfigToHelmValues(
     hyperdxConfig.FRONTEND_URL = graphOptional('schema.spec.hyperdx.frontendUrl');
 
     if (credentialSource === 'inline') {
-      hyperdxSecrets.CLICKHOUSE_PASSWORD = resolve(ch.password, '');
+      const inlineConfig = config as
+        | ClickStackBootstrapConfig
+        | ClickStackExternalMongoBootstrapConfig;
+      const inlineClickhouse = inlineConfig.clickhouse;
+      const appUsername = Cel.expr<string>(
+        `${hasSchemaPath('schema.spec.clickhouse.appUsername')} ? schema.spec.clickhouse.appUsername : ` +
+          `(${hasSchemaPath('schema.spec.clickhouse.username')} ? schema.spec.clickhouse.username : "default")`
+      );
+      const appPassword = Cel.expr<string>(
+        `${hasSchemaPath('schema.spec.clickhouse.appPassword')} ? schema.spec.clickhouse.appPassword : ` +
+          `(${hasSchemaPath('schema.spec.clickhouse.password')} ? schema.spec.clickhouse.password : "")`
+      );
+      hyperdxSecrets.CLICKHOUSE_PASSWORD = resolve(inlineClickhouse.password, '');
       hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
-      hyperdxSecrets.HYPERDX_API_KEY = graphOptional('schema.spec.apiKey');
-    }
-
-    hyperdxDeployment.replicas = graphOptional('schema.spec.hyperdx.replicas');
-    hyperdxDeployment.resources = graphOptional('schema.spec.hyperdx.resources');
-    hyperdxDeployment.image = graphOptional('schema.spec.hyperdx.image');
-    if (credentialSource === 'inline') {
+      hyperdxSecrets.HYPERDX_API_KEY = inlineConfig.apiKey;
       hyperdxDeployment.defaultConnections = Cel.template(
         DEFAULT_CONNECTIONS_FORMAT,
         ch.host,
@@ -423,6 +421,10 @@ export function mapClickStackConfigToHelmValues(
         appPassword
       );
     }
+
+    hyperdxDeployment.replicas = graphOptional('schema.spec.hyperdx.replicas');
+    hyperdxDeployment.resources = graphOptional('schema.spec.hyperdx.resources');
+    hyperdxDeployment.image = graphOptional('schema.spec.hyperdx.image');
     const database = resolve(ch.database, 'default');
     hyperdxDeployment.defaultSources = Cel.template(
       DEFAULT_SOURCES_FORMAT,
@@ -436,10 +438,6 @@ export function mapClickStackConfigToHelmValues(
     const httpPort = ch.httpPort ?? 8123;
     const database = ch.database ?? 'default';
     const username = ch.username ?? 'default';
-    const password = ch.password ?? '';
-    const appUsername = ch.appUsername ?? username;
-    const appPassword = ch.appPassword ?? password;
-
     hyperdxConfig.CLICKHOUSE_ENDPOINT = `tcp://${ch.host}:${nativePort}?dial_timeout=10s`;
     hyperdxConfig.CLICKHOUSE_SERVER_ENDPOINT = `${ch.host}:${nativePort}`;
     hyperdxConfig.CLICKHOUSE_USER = username;
@@ -451,15 +449,16 @@ export function mapClickStackConfigToHelmValues(
     setIfDefined(hyperdxConfig, 'FRONTEND_URL', config.hyperdx?.frontendUrl);
 
     if (credentialSource === 'inline') {
+      const inlineConfig = config as
+        | ClickStackBootstrapConfig
+        | ClickStackExternalMongoBootstrapConfig;
+      const inlineClickhouse = inlineConfig.clickhouse;
+      const password = inlineClickhouse.password ?? '';
+      const appUsername = inlineClickhouse.appUsername ?? username;
+      const appPassword = inlineClickhouse.appPassword ?? password;
       hyperdxSecrets.CLICKHOUSE_PASSWORD = password;
       hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
-      setIfDefined(hyperdxSecrets, 'HYPERDX_API_KEY', config.apiKey);
-    }
-
-    setIfDefined(hyperdxDeployment, 'replicas', config.hyperdx?.replicas);
-    setIfDefined(hyperdxDeployment, 'resources', config.hyperdx?.resources);
-    setIfDefined(hyperdxDeployment, 'image', config.hyperdx?.image);
-    if (credentialSource === 'inline') {
+      hyperdxSecrets.HYPERDX_API_KEY = inlineConfig.apiKey;
       hyperdxDeployment.defaultConnections = JSON.stringify([
         {
           name: CLICKSTACK_CONNECTION_NAME,
@@ -470,6 +469,10 @@ export function mapClickStackConfigToHelmValues(
         },
       ]);
     }
+
+    setIfDefined(hyperdxDeployment, 'replicas', config.hyperdx?.replicas);
+    setIfDefined(hyperdxDeployment, 'resources', config.hyperdx?.resources);
+    setIfDefined(hyperdxDeployment, 'image', config.hyperdx?.image);
     hyperdxDeployment.defaultSources = DEFAULT_SOURCES_FORMAT.replace(/%s/g, () => database);
   }
 

--- a/src/factories/clickstack/utils/helm-values-mapper.ts
+++ b/src/factories/clickstack/utils/helm-values-mapper.ts
@@ -13,7 +13,7 @@
  *
  * Values keys verified 2026-07-06 against
  * https://github.com/ClickHouse/ClickStack-helm-charts
- * charts/clickstack/values.yaml (chart 3.0.1, appVersion 2.29.0):
+ * charts/clickstack/values.yaml (chart 3.2.0, appVersion 2.35.0):
  * - `hyperdx.config.*` env map: `CLICKHOUSE_ENDPOINT` (native, tcp://…),
  *   `CLICKHOUSE_SERVER_ENDPOINT` (host:port), `CLICKHOUSE_USER`,
  *   `HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE`, `MONGO_URI`, `FRONTEND_URL`.
@@ -92,6 +92,26 @@ export const DEFAULT_K8S_TELEMETRY_COLLECTOR_IMAGE = 'otel/opentelemetry-collect
 
 /** Name of the HyperDX connection emitted into `defaultConnections`/`defaultSources`. */
 export const CLICKSTACK_CONNECTION_NAME = 'External ClickHouse';
+
+/**
+ * The ClickStack image runs under the OpAMP supervisor. Its built-in remote
+ * configuration declares the OTLP receiver but, without an overlay, does not
+ * attach it to any pipeline. The Service and health endpoint can therefore be
+ * Ready while 4317/4318 refuse connections. Chart 3.1+ provides the supported
+ * `global.otelCollector.customConfig` merge seam; keep every built-in receiver
+ * while attaching OTLP to all three signal pipelines.
+ */
+export const CLICKSTACK_INGEST_PIPELINES_CONFIG = [
+  'service:',
+  '  pipelines:',
+  '    logs/in:',
+  '      receivers: [fluentforward, otlp/hyperdx]',
+  '    metrics:',
+  '      receivers: [prometheus, otlp/hyperdx]',
+  '    traces:',
+  '      receivers: [nop, otlp/hyperdx]',
+  '',
+].join('\n');
 
 /** Concrete build-time options consumed by the bootstrap values mapper. */
 export interface ClickStackValuesMapperOptions {
@@ -227,7 +247,7 @@ function mergeOverridesWithPinsLast(
  * `defaultConnections`/`defaultSources` pointing at the (nonexistent) bundled
  * ClickHouse Service, so both must be overridden for external mode. The
  * sources below mirror the chart defaults (values.yaml `defaultSources`,
- * chart 3.0.1) with the connection renamed and the database parameterized
+ * chart 3.2.0) with the connection renamed and the database parameterized
  * (`%s` slots filled per mode).
  */
 const DEFAULT_SOURCES_FORMAT = JSON.stringify([
@@ -465,6 +485,11 @@ export function mapClickStackConfigToHelmValues(
   // contract's naming anchor. Merged AFTER every passthrough so they always
   // win — including over a graph-aware per-instance `customValues` override.
   const pins: Record<string, unknown> = {
+    global: {
+      otelCollector: {
+        customConfig: CLICKSTACK_INGEST_PIPELINES_CONFIG,
+      },
+    },
     clickhouse: { enabled: false },
     mongodb: { enabled: false },
     fullnameOverride: config.name,

--- a/src/factories/clickstack/utils/helm-values-mapper.ts
+++ b/src/factories/clickstack/utils/helm-values-mapper.ts
@@ -99,6 +99,8 @@ export interface ClickStackValuesMapperOptions {
   mongoMode?: 'internal' | 'external';
   /** Static raw chart values merged after the typed mapping (pins re-applied after). */
   values?: TypeKroChartValues<ClickStackHelmValues>;
+  /** Runtime credential transport selected by the composition constructor. */
+  credentialSource?: 'inline' | 'secretValues';
 }
 
 /** Values pair for the two stock collector instances. */
@@ -339,6 +341,7 @@ export function mapClickStackConfigToHelmValues(
 ): ClickStackMappedHelmValues {
   const isGraph = isKubernetesRef(config.name) || isKubernetesRef(config.clickhouse);
   const mongoMode = options.mongoMode ?? 'internal';
+  const credentialSource = options.credentialSource ?? 'inline';
 
   const ch = config.clickhouse;
   const hyperdxConfig: Record<string, unknown> = {};
@@ -381,21 +384,25 @@ export function mapClickStackConfigToHelmValues(
           );
     hyperdxConfig.FRONTEND_URL = graphOptional('schema.spec.hyperdx.frontendUrl');
 
-    hyperdxSecrets.CLICKHOUSE_PASSWORD = resolve(ch.password, '');
-    hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
-    hyperdxSecrets.HYPERDX_API_KEY = graphOptional('schema.spec.apiKey');
+    if (credentialSource === 'inline') {
+      hyperdxSecrets.CLICKHOUSE_PASSWORD = resolve(ch.password, '');
+      hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
+      hyperdxSecrets.HYPERDX_API_KEY = graphOptional('schema.spec.apiKey');
+    }
 
     hyperdxDeployment.replicas = graphOptional('schema.spec.hyperdx.replicas');
     hyperdxDeployment.resources = graphOptional('schema.spec.hyperdx.resources');
     hyperdxDeployment.image = graphOptional('schema.spec.hyperdx.image');
-    hyperdxDeployment.defaultConnections = Cel.template(
-      DEFAULT_CONNECTIONS_FORMAT,
-      ch.host,
-      httpPortStr,
-      httpPortStr,
-      appUsername,
-      appPassword
-    );
+    if (credentialSource === 'inline') {
+      hyperdxDeployment.defaultConnections = Cel.template(
+        DEFAULT_CONNECTIONS_FORMAT,
+        ch.host,
+        httpPortStr,
+        httpPortStr,
+        appUsername,
+        appPassword
+      );
+    }
     const database = resolve(ch.database, 'default');
     hyperdxDeployment.defaultSources = Cel.template(
       DEFAULT_SOURCES_FORMAT,
@@ -423,29 +430,33 @@ export function mapClickStackConfigToHelmValues(
         : `mongodb://${config.name}${CLICKSTACK_MONGO_NAME_SUFFIX}.${config.namespace ?? DEFAULT_CLICKSTACK_NAMESPACE}.svc.cluster.local:${CLICKSTACK_MONGO_PORT}/hyperdx`;
     setIfDefined(hyperdxConfig, 'FRONTEND_URL', config.hyperdx?.frontendUrl);
 
-    hyperdxSecrets.CLICKHOUSE_PASSWORD = password;
-    hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
-    setIfDefined(hyperdxSecrets, 'HYPERDX_API_KEY', config.apiKey);
+    if (credentialSource === 'inline') {
+      hyperdxSecrets.CLICKHOUSE_PASSWORD = password;
+      hyperdxSecrets.CLICKHOUSE_APP_PASSWORD = appPassword;
+      setIfDefined(hyperdxSecrets, 'HYPERDX_API_KEY', config.apiKey);
+    }
 
     setIfDefined(hyperdxDeployment, 'replicas', config.hyperdx?.replicas);
     setIfDefined(hyperdxDeployment, 'resources', config.hyperdx?.resources);
     setIfDefined(hyperdxDeployment, 'image', config.hyperdx?.image);
-    hyperdxDeployment.defaultConnections = JSON.stringify([
-      {
-        name: CLICKSTACK_CONNECTION_NAME,
-        host: `http://${ch.host}:${httpPort}`,
-        port: httpPort,
-        username: appUsername,
-        password: appPassword,
-      },
-    ]);
+    if (credentialSource === 'inline') {
+      hyperdxDeployment.defaultConnections = JSON.stringify([
+        {
+          name: CLICKSTACK_CONNECTION_NAME,
+          host: `http://${ch.host}:${httpPort}`,
+          port: httpPort,
+          username: appUsername,
+          password: appPassword,
+        },
+      ]);
+    }
     hyperdxDeployment.defaultSources = DEFAULT_SOURCES_FORMAT.replace(/%s/g, () => database);
   }
 
   const values: ClickStackHelmValues = {
     hyperdx: {
       config: hyperdxConfig,
-      secrets: hyperdxSecrets,
+      ...(credentialSource === 'inline' ? { secrets: hyperdxSecrets } : {}),
       deployment: hyperdxDeployment,
     },
   };

--- a/test/core/dependency-resolver.test.ts
+++ b/test/core/dependency-resolver.test.ts
@@ -410,6 +410,35 @@ describe('DependencyResolver', () => {
       expect(warnings).toEqual([]);
     });
 
+    it('does not treat a Kubernetes DNS suffix as a resource reference', () => {
+      const warnings: Array<{ message: string; context?: unknown }> = [];
+      (
+        resolver as unknown as { logger: { warn: (message: string, context?: unknown) => void } }
+      ).logger = {
+        warn: (message, context) => warnings.push({ message, context }),
+      };
+      const app = createMockResource({
+        id: 'app',
+        metadata: { name: 'app' },
+        spec: {
+          value: {
+            [CEL_EXPRESSION_BRAND]: true,
+            expression:
+              'string(service.metadata.name) + "." + string(service.metadata.namespace) + .svc.cluster.local',
+          },
+        },
+      });
+      const service = createMockResource({
+        id: 'service',
+        metadata: { name: 'service' },
+      });
+
+      const graph = resolver.buildDependencyGraph([app, service]);
+
+      expect(graph.getDependencies('app')).toEqual(['service']);
+      expect(warnings).toEqual([]);
+    });
+
     it('does not turn CEL macro variables into graph resources', () => {
       const warnings: Array<{ message: string; context?: unknown }> = [];
       (

--- a/test/core/kro-artifact-bundle-standalone.test.ts
+++ b/test/core/kro-artifact-bundle-standalone.test.ts
@@ -30,6 +30,8 @@ afterEach(() => {
 describe('standalone KRO artifact-bundle execution', () => {
   it('applies one operation-wide timeout across singleton and root bundle phases', async () => {
     let receivedSignal: AbortSignal | undefined;
+    const operationSignals: AbortSignal[] = [];
+    const applied: Array<{ kind: string; name: string }> = [];
     let started!: () => void;
     const operationStarted = new Promise<void>((resolve) => {
       started = resolve;
@@ -40,15 +42,37 @@ describe('standalone KRO artifact-bundle execution', () => {
     }));
     replace(factoryPrototype, 'ensureTargetNamespace', async () => {});
     replace(factoryPrototype, 'assertNoPreHoistNamespaceConflict', async () => {});
+    replace(factoryPrototype, 'getSingletonOwnerInstancesForDriftCheck', async () => []);
     replace(factoryPrototype, 'executeClosuresBeforeRGD', async () => []);
     replace(factoryPrototype, 'addRgdSchemaStatusPruneMarkers', async () => {});
     replace(factoryPrototype, 'migrateLegacyArtifactBindings', async () => {});
     replace(factoryPrototype, 'repairRetainedCrdOwnership', async () => {});
+    replace(factoryPrototype, 'waitForCRDReadyWithEngine', async () => {});
+    replace(factoryPrototype, 'waitForKroInstanceReady', async () => {});
+    replace(factoryPrototype, 'createEnhancedProxy', async (spec: unknown, name: string) => ({
+      metadata: { name },
+      spec,
+      status: { ready: true },
+    }));
     replace(factoryPrototype, 'dispose', async () => {});
     replace(
       enginePrototype,
       'deployResource',
-      async (_resource: KubernetesResource, options: { abortSignal?: AbortSignal }) => {
+      async (resource: KubernetesResource, options: { abortSignal?: AbortSignal }) => {
+        applied.push({ kind: resource.kind, name: String(resource.metadata.name) });
+        if (options.abortSignal) operationSignals.push(options.abortSignal);
+        if (resource.metadata.name !== 'standalone-timeout-kro') {
+          return {
+            id: String(Reflect.get(resource, 'id') ?? resource.metadata.name),
+            kind: resource.kind,
+            name: String(resource.metadata.name),
+            namespace: resource.metadata.namespace ?? 'default',
+            manifest: resource,
+            status: 'deployed',
+            applied: true,
+            deployedAt: new Date(0),
+          };
+        }
         receivedSignal = options.abortSignal;
         started();
         return new Promise<never>((_, reject) => {
@@ -62,6 +86,19 @@ describe('standalone KRO artifact-bundle execution', () => {
     );
     replace(enginePrototype, 'dispose', async () => {});
 
+    const owner = kubernetesComposition(
+      {
+        name: 'standalone-timeout-owner',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'StandaloneTimeoutOwner',
+        spec: type({ name: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        simple.ConfigMap({ id: 'ownerConfig', name: spec.name, data: { ready: 'true' } });
+        return { ready: true };
+      }
+    );
     const composition = kubernetesComposition(
       {
         name: 'standalone-timeout-kro',
@@ -71,6 +108,7 @@ describe('standalone KRO artifact-bundle execution', () => {
         status: type({ ready: 'boolean' }),
       },
       (spec) => {
+        singleton(owner, { id: 'owner', spec: { name: 'shared-owner' } });
         simple.ConfigMap({ id: 'config', name: spec.name, data: { ready: 'true' } });
         return { ready: true };
       }
@@ -85,6 +123,13 @@ describe('standalone KRO artifact-bundle execution', () => {
     expect((error as DeploymentTimeoutError).timeoutMs).toBe(500);
     expect((error as DeploymentTimeoutError).operation).toBe('deployment');
     expect(receivedSignal?.aborted).toBe(true);
+    expect(operationSignals).toHaveLength(3);
+    expect(operationSignals.every((signal) => signal === receivedSignal)).toBe(true);
+    expect(applied).toEqual([
+      { kind: 'ResourceGraphDefinition', name: 'standalone-timeout-owner' },
+      { kind: 'StandaloneTimeoutOwner', name: 'owner' },
+      { kind: 'ResourceGraphDefinition', name: 'standalone-timeout-kro' },
+    ]);
   });
 
   it('forwards Effect interruption through the decoded bundle executor', async () => {

--- a/test/core/kro-artifact-bundle-standalone.test.ts
+++ b/test/core/kro-artifact-bundle-standalone.test.ts
@@ -3,6 +3,7 @@ import { type } from 'arktype';
 
 import { DirectDeploymentEngine } from '../../src/core/deployment/engine.js';
 import { KroResourceFactoryImpl } from '../../src/core/deployment/kro-factory.js';
+import { DeploymentTimeoutError } from '../../src/core/errors.js';
 import type { KubernetesResource } from '../../src/core/types/kubernetes.js';
 import {
   createResource,
@@ -27,6 +28,65 @@ afterEach(() => {
 });
 
 describe('standalone KRO artifact-bundle execution', () => {
+  it('applies one operation-wide timeout across singleton and root bundle phases', async () => {
+    let receivedSignal: AbortSignal | undefined;
+    let started!: () => void;
+    const operationStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+
+    replace(factoryPrototype, 'getKubeConfig', () => ({
+      getCurrentCluster: () => ({ server: 'https://example.invalid' }),
+    }));
+    replace(factoryPrototype, 'ensureTargetNamespace', async () => {});
+    replace(factoryPrototype, 'assertNoPreHoistNamespaceConflict', async () => {});
+    replace(factoryPrototype, 'executeClosuresBeforeRGD', async () => []);
+    replace(factoryPrototype, 'addRgdSchemaStatusPruneMarkers', async () => {});
+    replace(factoryPrototype, 'migrateLegacyArtifactBindings', async () => {});
+    replace(factoryPrototype, 'repairRetainedCrdOwnership', async () => {});
+    replace(factoryPrototype, 'dispose', async () => {});
+    replace(
+      enginePrototype,
+      'deployResource',
+      async (_resource: KubernetesResource, options: { abortSignal?: AbortSignal }) => {
+        receivedSignal = options.abortSignal;
+        started();
+        return new Promise<never>((_, reject) => {
+          options.abortSignal?.addEventListener(
+            'abort',
+            () => reject(options.abortSignal?.reason),
+            { once: true }
+          );
+        });
+      }
+    );
+    replace(enginePrototype, 'dispose', async () => {});
+
+    const composition = kubernetesComposition(
+      {
+        name: 'standalone-timeout-kro',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'StandaloneTimeoutKro',
+        spec: type({ name: 'string' }),
+        status: type({ ready: 'boolean' }),
+      },
+      (spec) => {
+        simple.ConfigMap({ id: 'config', name: spec.name, data: { ready: 'true' } });
+        return { ready: true };
+      }
+    );
+    const factory = await composition.factory('kro', { namespace: 'apps', timeout: 500 });
+    const deployment = factory.deploy({ name: 'demo' }).catch((error: unknown) => error);
+
+    await operationStarted;
+    const error = await deployment;
+
+    expect(error).toBeInstanceOf(DeploymentTimeoutError);
+    expect((error as DeploymentTimeoutError).timeoutMs).toBe(500);
+    expect((error as DeploymentTimeoutError).operation).toBe('deployment');
+    expect(receivedSignal?.aborted).toBe(true);
+  });
+
   it('forwards Effect interruption through the decoded bundle executor', async () => {
     const controller = new AbortController();
     const reason = new DOMException('stop KRO deployment', 'AbortError');

--- a/test/core/planning/composition.test.ts
+++ b/test/core/planning/composition.test.ts
@@ -19,10 +19,12 @@ import {
   encodeDesiredStatePlan,
   expressionIR,
   kroArtifactPlanToGraphResources,
+  materializePlanOutputs,
   planExpression,
   type SchemaNodeIR,
   SEMANTIC_PLAN_VERSION,
 } from '../../../src/experimental-planning.js';
+import { clickstackBootstrap } from '../../../src/factories/clickstack/compositions/clickstack-bootstrap.js';
 import {
   Cel,
   createResource,
@@ -302,6 +304,133 @@ describe('captured composition planning prototype', () => {
     ).toEqual(['deployment']);
   });
 
+  it('materializes nested-composition outputs from flattened child resources', () => {
+    const child = kubernetesComposition(
+      {
+        name: 'planning-nested-child',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'PlanningNestedChild',
+        revision: '1',
+        spec: type({ name: 'string' }),
+        status: type({ readyReplicas: 'number' }),
+      },
+      (spec) => {
+        const deployment = simple.Deployment({
+          id: 'deployment',
+          name: spec.name,
+          image: 'nginx:1.27',
+          replicas: 1,
+        });
+        simple.ConfigMap({
+          id: 'config',
+          name: `${spec.name}-config`,
+          data: { role: 'forces-multi-resource-flattening' },
+        });
+        return { readyReplicas: deployment.status.readyReplicas };
+      }
+    );
+    const parent = kubernetesComposition(
+      {
+        name: 'planning-nested-parent',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'PlanningNestedParent',
+        revision: '1',
+        spec: type({ name: 'string' }),
+        status: type({ readyReplicas: 'number' }),
+      },
+      (spec) => {
+        const installation = child({ name: spec.name });
+        return { readyReplicas: installation.status.readyReplicas };
+      }
+    );
+
+    const plan = parent.plan!({ name: 'demo' }, { strict: true });
+    const output = plan.outputs.readyReplicas;
+    if (!output) throw new Error('Expected readyReplicas output.');
+    expect(output).toEqual(
+      expect.objectContaining({
+        kind: 'expression',
+        expression: expect.objectContaining({
+          references: [
+            {
+              source: 'resource',
+              resourceId: 'planningNestedChild1Deployment',
+              fieldPath: 'status.readyReplicas',
+            },
+          ],
+        }),
+      })
+    );
+    expect(JSON.stringify(output)).not.toContain('planningNestedChild1.status');
+    expect(
+      materializePlanOutputs(
+        { readyReplicas: output },
+        {
+          resources: {
+            planningNestedChild1Deployment: { status: { readyReplicas: 1 } },
+          },
+        }
+      )
+    ).toEqual({ readyReplicas: 1 });
+  });
+
+  it('materializes nested ClickStack endpoints from its flattened HelmRelease', () => {
+    const parent = kubernetesComposition(
+      {
+        name: 'planning-nested-clickstack',
+        apiVersion: 'testing.typekro.dev/v1alpha1',
+        kind: 'PlanningNestedClickStack',
+        revision: '1',
+        spec: type({ name: 'string', namespace: 'string' }),
+        status: type({ endpoint: 'string' }),
+      },
+      (spec) => {
+        const stack = clickstackBootstrap({
+          name: spec.name,
+          namespace: spec.namespace,
+          clickhouse: {
+            host: 'clickhouse.observability.svc.cluster.local',
+            username: 'otelcollector',
+            password: 'test-only',
+          },
+          apiKey: 'test-only',
+        });
+        return { endpoint: stack.status.gateway.otlpHttpEndpoint };
+      }
+    );
+
+    const plan = parent.plan!({ name: 'clickstack', namespace: 'observability' });
+    const endpoint = plan.outputs.endpoint;
+    if (!endpoint) throw new Error('Expected endpoint output.');
+    expect(JSON.stringify(endpoint)).not.toContain('clickstackBootstrap1.status');
+    expect(endpoint).toEqual(
+      expect.objectContaining({
+        kind: 'template',
+        segments: expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'reference',
+            source: 'resource',
+            fieldPath: 'metadata.name',
+          }),
+          expect.objectContaining({
+            kind: 'reference',
+            source: 'resource',
+            fieldPath: 'metadata.namespace',
+          }),
+        ]),
+      })
+    );
+    const resources = Object.fromEntries(
+      plan.nodes.map((node) => [
+        node.id,
+        { metadata: { name: 'clickstack', namespace: 'observability' } },
+      ])
+    );
+    expect(materializePlanOutputs({ endpoint }, { resources })).toEqual({
+      endpoint: 'http://clickstack-otel-collector.observability.svc.cluster.local:4318',
+    });
+  });
+
   it('marks source-only composition identity as preview-unstable and changes semantic digests with inputs', () => {
     const { revision: _revision, ...previewDefinition } = definition;
     const composition = toResourceGraph(
@@ -416,10 +545,7 @@ describe('captured composition planning prototype', () => {
                 containers: [
                   {
                     name: 'application',
-                    image: artifactOutput(
-                      'application-image',
-                      'immutableReference'
-                    ),
+                    image: artifactOutput('application-image', 'immutableReference'),
                   },
                 ],
               },

--- a/test/core/planning/composition.test.ts
+++ b/test/core/planning/composition.test.ts
@@ -382,7 +382,11 @@ describe('captured composition planning prototype', () => {
         kind: 'PlanningNestedClickStack',
         revision: '1',
         spec: type({ name: 'string', namespace: 'string' }),
-        status: type({ endpoint: 'string' }),
+        status: type({
+          endpoint: 'string',
+          templateEndpoint: 'string',
+          expressionEndpoint: 'string',
+        }),
       },
       (spec) => {
         const stack = clickstackBootstrap({
@@ -395,7 +399,11 @@ describe('captured composition planning prototype', () => {
           },
           apiKey: 'test-only',
         });
-        return { endpoint: stack.status.gateway.otlpHttpEndpoint };
+        return {
+          endpoint: stack.status.gateway.otlpHttpEndpoint,
+          templateEndpoint: `${stack.status.gateway.otlpHttpEndpoint}/v1`,
+          expressionEndpoint: Cel.expr<string>(stack.status.gateway.otlpHttpEndpoint, ' + "/v2"'),
+        };
       }
     );
 
@@ -429,6 +437,20 @@ describe('captured composition planning prototype', () => {
     expect(materializePlanOutputs({ endpoint }, { resources })).toEqual({
       endpoint: 'http://clickstack-otel-collector.observability.svc.cluster.local:4318',
     });
+    expect(
+      materializePlanOutputs(
+        {
+          templateEndpoint: plan.outputs.templateEndpoint!,
+          expressionEndpoint: plan.outputs.expressionEndpoint!,
+        },
+        { resources }
+      )
+    ).toEqual({
+      templateEndpoint: 'http://clickstack-otel-collector.observability.svc.cluster.local:4318/v1',
+      expressionEndpoint:
+        'http://clickstack-otel-collector.observability.svc.cluster.local:4318/v2',
+    });
+    expect(JSON.stringify(plan.outputs)).not.toContain('clickstackBootstrap1.status');
   });
 
   it('marks source-only composition identity as preview-unstable and changes semantic digests with inputs', () => {

--- a/test/factories/bootstrap-instance-namespace.test.ts
+++ b/test/factories/bootstrap-instance-namespace.test.ts
@@ -204,7 +204,7 @@ describe('bootstrap factories: self-owned namespace is hoisted + retained, not r
     expect(bNamespace?.props.namespaceEmptyGate).toBe(true);
   });
 
-  it('clickstackBootstrap serializes without throwing (instance in workload ns)', () => {
+  it('clickstackBootstrap treats an explicit workload namespace as externally owned', () => {
     const factory = clickstackBootstrap.factory('kro', { namespace: 'clickstack' });
     let yaml = '';
     expect(() => {
@@ -221,6 +221,7 @@ describe('bootstrap factories: self-owned namespace is hoisted + retained, not r
       } as never);
     }).not.toThrow();
     expect(yaml).toMatch(/namespace: clickstack$/m);
-    expect(yaml).toContain('typekro.io/kro-instance-namespace');
+    expect(yaml).toContain("typekro.io/hoisted-namespaces: '[]'");
+    expect(yaml).not.toContain('typekro.io/kro-instance-namespace');
   });
 });

--- a/test/factories/clickhouse/cluster-composition.test.ts
+++ b/test/factories/clickhouse/cluster-composition.test.ts
@@ -95,6 +95,48 @@ describe('makeClickHouseCluster (build-time topology, runtime spec)', () => {
       expect(yaml).not.toContain('__typekroSchemaKey');
     });
 
+    it('compiles Secret-backed runtime user credentials in direct and KRO modes', () => {
+      const clickhouse = makeClickHouseCluster({
+        replicas: 1,
+        users: [
+          {
+            name: 'otelcollector',
+            credentialSource: 'secret',
+            networksIp: ['::/0'],
+          },
+        ],
+      });
+      const spec = {
+        name: 'observability',
+        namespace: 'observability',
+        version: '25.7',
+        storage: { size: '10Gi' },
+        users: {
+          otelcollector: {
+            passwordSecretRef: {
+              name: 'observability-credentials',
+              key: 'clickhouse-password',
+            },
+          },
+        },
+      };
+
+      const direct = clickhouse.factory('direct').toYaml(spec as never);
+      expect(direct).toContain('otelcollector/password:');
+      expect(direct).toContain('name: observability-credentials');
+      expect(direct).toContain('key: clickhouse-password');
+      expect(direct).not.toContain('password_sha256_hex');
+
+      const kro = clickhouse.toYaml();
+      expect(kro).toContain(
+        'name: ${schema.spec.users.otelcollector.passwordSecretRef.name}'
+      );
+      expect(kro).toContain(
+        'key: ${schema.spec.users.otelcollector.passwordSecretRef.key}'
+      );
+      expect(kro).not.toContain('otelcollector/password_sha256_hex');
+    });
+
     it('enables keeper by default for multi-replica topologies and requires the runtime host', () => {
       const yaml = makeClickHouseCluster({ replicas: 2 }).toYaml();
       expect(yaml).toContain('zookeeper');

--- a/test/factories/clickhouse/installation.test.ts
+++ b/test/factories/clickhouse/installation.test.ts
@@ -274,6 +274,56 @@ describe('ClickHouseInstallation Factory', () => {
       });
     });
 
+    it('should preserve Secret-backed user credentials without copying their value', () => {
+      const chi = clickHouseInstallation({
+        name: 'test-ch',
+        version: '25.12.5',
+        storage: { size: '10Gi' },
+        users: [
+          {
+            name: 'otelcollector',
+            passwordSecretRef: {
+              name: 'clickstack-credentials',
+              key: 'clickhouse-password',
+            },
+            networksIp: ['::/0'],
+          },
+        ],
+      });
+
+      expect(chi.spec.configuration?.users).toEqual({
+        'otelcollector/password': {
+          valueFrom: {
+            secretKeyRef: {
+              name: 'clickstack-credentials',
+              key: 'clickhouse-password',
+            },
+          },
+        },
+        'otelcollector/networks/ip': ['::/0'],
+      });
+    });
+
+    it('rejects ambiguous inline and Secret-backed user credentials', () => {
+      expect(() =>
+        clickHouseInstallation({
+          name: 'test-ch',
+          version: '25.12.5',
+          storage: { size: '10Gi' },
+          users: [
+            {
+              name: 'otelcollector',
+              passwordSha256Hex: 'abc123',
+              passwordSecretRef: {
+                name: 'clickstack-credentials',
+                key: 'clickhouse-password',
+              },
+            },
+          ],
+        })
+      ).toThrow('cannot define both passwordSha256Hex and passwordSecretRef');
+    });
+
     it('should omit user fields that are not provided', () => {
       const chi = clickHouseInstallation({
         name: 'test-ch',

--- a/test/factories/clickstack/bootstrap-composition.test.ts
+++ b/test/factories/clickstack/bootstrap-composition.test.ts
@@ -113,7 +113,9 @@ describe('clickstackBootstrap (internal-Mongo default)', () => {
       app: { host: string };
     };
     // Resource-derived fields serialize as KRO CEL off the owned HelmRelease...
-    expect(yaml).toMatch(/ready: \$\{clickstackHelmRelease\.status\.conditions\.exists/);
+    expect(yaml).toContain('clickstackHelmRelease.status.observedGeneration');
+    expect(yaml).toContain('clickstackTeamBootstrap.status.lastScheduleTime');
+    expect(yaml).toContain('clickstackTeamBootstrap.status.lastSuccessfulTime');
     expect(yaml).toContain('phase:');
     // ...and so does the CONNECTION CONTRACT (ui/gateway/app): it is anchored
     // on the HelmRelease resource (raw CEL over clickstackHelmRelease.metadata,
@@ -168,7 +170,7 @@ describe('makeClickstackBootstrap (build-time variants)', () => {
     });
     const yaml = external.toYaml();
     expect(yaml).not.toContain('kind: StatefulSet');
-    expect(yaml).toContain('kind: Job');
+    expect(yaml).toContain('kind: CronJob');
     expect(yaml).toContain('${schema.spec.mongoUri}');
     // The variant's spec schema requires the URI (topology shapes the schema).
     expect(yaml).toContain('mongoUri');

--- a/test/factories/clickstack/bootstrap-composition.test.ts
+++ b/test/factories/clickstack/bootstrap-composition.test.ts
@@ -39,6 +39,26 @@ function fakeRef(path: string): unknown {
 }
 
 describe('clickstackBootstrap (internal-Mongo default)', () => {
+  it('preserves the internal Mongo URI as a canonical plan template', () => {
+    const plan = clickstackBootstrap.plan!(
+      {
+        name: 'clickstack',
+        namespace: 'observability',
+        clickhouse: {
+          host: 'clickhouse.observability.svc.cluster.local',
+          username: 'otelcollector',
+          password: 'test-only',
+        },
+        apiKey: 'test-only',
+      },
+      { strict: true }
+    );
+    const serialized = JSON.stringify(plan);
+
+    expect(serialized).not.toContain('[object Object]');
+    expect(serialized).toContain('.svc.cluster.local:27017/hyperdx');
+  });
+
   it('serializes an RGD wrapping the official clickstack chart under strict CEL', () => {
     const yaml = clickstackBootstrap.toYaml();
 
@@ -148,7 +168,8 @@ describe('makeClickstackBootstrap (build-time variants)', () => {
     });
     const yaml = external.toYaml();
     expect(yaml).not.toContain('kind: StatefulSet');
-    expect(yaml).not.toContain('mongo:7');
+    expect(yaml).toContain('kind: Job');
+    expect(yaml).toContain('${schema.spec.mongoUri}');
     // The variant's spec schema requires the URI (topology shapes the schema).
     expect(yaml).toContain('mongoUri');
   });

--- a/test/factories/clickstack/factory-modes.test.ts
+++ b/test/factories/clickstack/factory-modes.test.ts
@@ -30,7 +30,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadAll } from 'js-yaml';
 
-import { clickstackBootstrap } from '../../../src/factories/clickstack/compositions/clickstack-bootstrap.js';
+import {
+  clickstackBootstrap,
+  makeClickstackBootstrap,
+} from '../../../src/factories/clickstack/compositions/clickstack-bootstrap.js';
 import { clickstackK8sTelemetry } from '../../../src/factories/clickstack/compositions/k8s-telemetry.js';
 import {
   DEFAULT_CLICKSTACK_REPO_NAME,
@@ -138,6 +141,69 @@ const TELEMETRY_SPEC = {
 
 describe('clickstackBootstrap factory modes', () => {
   describe("direct: factory('direct').toYaml(spec) — concrete manifests", () => {
+    it('loads credential values from a Secret without serializing inline credential fields', () => {
+      const bootstrap = makeClickstackBootstrap({
+        credentials: { source: 'secretValues' },
+      });
+      const yaml = bootstrap.factory('direct').toYaml({
+        name: 'clickstack',
+        namespace: 'clickstack',
+        clickhouse: {
+          host: 'clickhouse-observability.clickhouse.svc.cluster.local',
+          username: 'otelcollector',
+        },
+        credentialsSecret: {
+          name: 'clickstack-credentials',
+          valuesKey: 'values.yaml',
+        },
+      } as never);
+      const release = splitDocs(yaml).find((doc) => docKind(doc) === 'HelmRelease');
+
+      expect(release).toContain('valuesFrom:');
+      expect(release).toContain('kind: Secret');
+      expect(release).toContain('name: clickstack-credentials');
+      expect(release).toContain('valuesKey: values.yaml');
+      expect(release).not.toContain('CLICKHOUSE_PASSWORD');
+      expect(release).not.toContain('CLICKHOUSE_APP_PASSWORD');
+      expect(release).not.toContain('HYPERDX_API_KEY');
+      expect(release).not.toContain('defaultConnections');
+    });
+
+    it('rejects inline credential fields in Secret-backed mode', () => {
+      const bootstrap = makeClickstackBootstrap({
+        credentials: { source: 'secretValues' },
+      });
+      expect(() =>
+        bootstrap.factory('direct').toYaml({
+          ...BOOTSTRAP_SPEC,
+          credentialsSecret: { name: 'clickstack-credentials' },
+        } as never)
+      ).toThrow('rejects inline');
+    });
+
+    it('rejects build-time credential-bearing values in Secret-backed mode', () => {
+      expect(() =>
+        makeClickstackBootstrap({
+          credentials: { source: 'secretValues' },
+          values: {
+            hyperdx: {
+              secrets: { CLICKHOUSE_PASSWORD: 'must-not-enter-the-rgd' },
+            },
+          },
+        })
+      ).toThrow('Put those values in the referenced Secret');
+
+      expect(() =>
+        makeClickstackBootstrap({
+          credentials: { source: 'secretValues' },
+          values: {
+            hyperdx: {
+              deployment: { defaultConnections: 'must-not-enter-the-rgd' },
+            },
+          },
+        })
+      ).toThrow('Put those values in the referenced Secret');
+    });
     it('emits the internal-Mongo resource set with correct namespace wiring and NO singleton document', () => {
       const factory = clickstackBootstrap.factory('direct', { namespace: 'clickstack' });
       const yaml = factory.toYaml(BOOTSTRAP_SPEC as never);
@@ -228,6 +294,28 @@ describe('clickstackBootstrap factory modes', () => {
   });
 
   describe("kro: factory('kro').toYaml(...) — instance bundle + RGD contract", () => {
+    it('preserves Secret-backed valuesFrom wiring without exposing inline credential paths', () => {
+      const bootstrap = makeClickstackBootstrap({
+        credentials: { source: 'secretValues' },
+        name: 'clickstack-secret-values',
+        kind: 'ClickStackSecretValues',
+      });
+      const yaml = bootstrap.factory('kro', { namespace: 'typekro-system' }).toYaml();
+      const serialized = JSON.stringify(loadAll(yaml));
+
+      expect(yaml).toContain('credentialsSecret:');
+      expect(yaml).toContain('valuesFrom:');
+      expect(yaml).toContain('kind: Secret');
+      expect(serialized).toContain('${schema.spec.credentialsSecret.name}');
+      expect(serialized).toContain(
+        'has(schema.spec.credentialsSecret) && has(schema.spec.credentialsSecret.valuesKey)'
+      );
+      expect(serialized).not.toContain('CLICKHOUSE_PASSWORD');
+      expect(serialized).not.toContain('CLICKHOUSE_APP_PASSWORD');
+      expect(serialized).not.toContain('HYPERDX_API_KEY');
+      expect(yaml).toContain('validation="self == null"');
+    });
+
     it('toYaml(instance) bundles the singleton owner instance BEFORE the ClickStackBootstrap CR', () => {
       // `clickstackBootstrap` owns its workload namespace, so pin the instance CR
       // to an explicit control-plane namespace (decoupled from the `clickstack`

--- a/test/factories/clickstack/factory-modes.test.ts
+++ b/test/factories/clickstack/factory-modes.test.ts
@@ -144,6 +144,29 @@ const TELEMETRY_SPEC = {
   apiKeySecret: { name: 'hyperdx-api-key' },
 } as const;
 
+function credentialModeCompileTimeContract(): void {
+  const secretBacked = makeClickstackBootstrap({
+    credentials: { source: 'secretValues' },
+  }).factory('direct');
+  secretBacked.toYaml({
+    name: 'clickstack',
+    // @ts-expect-error Secret-backed specs do not expose plaintext credential fields.
+    clickhouse: { host: 'clickhouse', password: 'plaintext' },
+    credentialsSecret: { name: 'credentials' },
+  });
+
+  const inline = makeClickstackBootstrap().factory('direct');
+  inline.toYaml({
+    name: 'clickstack',
+    clickhouse: { host: 'clickhouse' },
+    // @ts-expect-error Inline specs require apiKey and do not accept a values Secret coordinate.
+    credentialsSecret: { name: 'credentials' },
+  });
+}
+
+// Preserve the contract in the TypeScript test graph without executing it.
+void credentialModeCompileTimeContract;
+
 describe('clickstackBootstrap factory modes', () => {
   describe("direct: factory('direct').toYaml(spec) — concrete manifests", () => {
     it('can consume an externally managed namespace without owning it', () => {
@@ -195,7 +218,7 @@ describe('clickstackBootstrap factory modes', () => {
           name: 'clickstack-credentials',
           valuesKey: 'values.yaml',
         },
-      } as never);
+      });
       const release = splitDocs(yaml).find((doc) => docKind(doc) === 'HelmRelease');
 
       expect(release).toContain('valuesFrom:');
@@ -218,6 +241,39 @@ describe('clickstackBootstrap factory modes', () => {
           credentialsSecret: { name: 'clickstack-credentials' },
         } as never)
       ).toThrow('rejects inline');
+    });
+
+    it('rejects the chart placeholder API key in inline mode', () => {
+      expect(() =>
+        clickstackBootstrap.factory('direct').toYaml({
+          ...BOOTSTRAP_SPEC,
+          apiKey: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+        })
+      ).toThrow('published chart placeholder');
+
+      const rgd = clickstackBootstrap.factory('kro').toYaml();
+      expect(rgd).toContain('apiKey: string | minLength=1');
+      expect(rgd).toContain('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+    });
+
+    it('types Secret-backed external Mongo independently from inline credentials', () => {
+      const bootstrap = makeClickstackBootstrap({
+        mongo: { mode: 'external' },
+        credentials: { source: 'secretValues' },
+      });
+      const yaml = bootstrap.factory('direct').toYaml({
+        name: 'clickstack',
+        namespace: 'clickstack',
+        clickhouse: {
+          host: 'clickhouse-observability.clickhouse.svc.cluster.local',
+          username: 'otelcollector',
+        },
+        mongoUri: 'mongodb://mongo.example.test:27017/hyperdx',
+        credentialsSecret: { name: 'clickstack-credentials' },
+      });
+
+      expect(yaml).toContain('mongodb://mongo.example.test:27017/hyperdx');
+      expect(yaml).toContain('kind: CronJob');
     });
 
     it('rejects build-time credential-bearing values in Secret-backed mode', () => {
@@ -250,20 +306,22 @@ describe('clickstackBootstrap factory modes', () => {
       const kinds = docs.map(docKind);
 
       // The supplied namespace is external; ClickStack owns only Mongo,
-      // HelmRelease, and the idempotent authoritative-Team bootstrap Job.
+      // HelmRelease, and the idempotent authoritative-Team bootstrap CronJob.
       expect(kinds).not.toContain('Namespace');
       expect(kinds).toContain('StatefulSet');
       expect(kinds).toContain('Service');
       expect(kinds).toContain('HelmRelease');
-      expect(kinds).toContain('Job');
+      expect(kinds).toContain('CronJob');
       expect(yaml).toContain('image: mongo:7');
       expect(yaml).toContain('name: clickstack-mongodb');
       expect(yaml).toContain('name: clickstack-team-bootstrap');
       expect(yaml).toContain('key: HYPERDX_API_KEY');
       expect(yaml).toContain('name: clickstack-secret');
       expect(yaml).toContain("hookId = 'typekro-managed-ingestion'");
+      expect(yaml).toContain("schedule: '* * * * *'");
+      expect(yaml).toContain('must override the published ClickStack chart placeholder');
       expect(yaml).not.toContain('ttlSecondsAfterFinished');
-      expect(kinds.indexOf('HelmRelease')).toBeLessThan(kinds.indexOf('Job'));
+      expect(kinds.indexOf('HelmRelease')).toBeLessThan(kinds.indexOf('CronJob'));
 
       // DOCUMENTED WART: direct-mode toYaml() omits singleton-owned resources.
       // The shared HelmRepository is NOT a document here — only the HelmRelease
@@ -393,7 +451,6 @@ describe('clickstackBootstrap factory modes', () => {
       expect(serialized).not.toContain('schema.spec.apiKey');
       expect(yaml).toContain('key: HYPERDX_API_KEY');
       expect(yaml).toContain('name: clickstack-secret');
-      expect(yaml).toContain('validation="self == null"');
       expect(yaml).toContain('receivers: [fluentforward, otlp/hyperdx]');
     });
 
@@ -441,7 +498,9 @@ describe('clickstackBootstrap factory modes', () => {
 
       // The status/endpoint contract survives factory serialization: KRO CEL
       // anchored on the owned HelmRelease (never schema.spec.*).
-      expect(yaml).toMatch(/ready: \$\{clickstackHelmRelease\.status\.conditions\.exists/);
+      expect(yaml).toContain('clickstackHelmRelease.status.observedGeneration');
+      expect(yaml).toContain('clickstackTeamBootstrap.status.lastScheduleTime');
+      expect(yaml).toContain('clickstackTeamBootstrap.status.lastSuccessfulTime');
       expect(yaml).toContain(
         'url: http://${string(clickstackHelmRelease.metadata.name)}.${string(clickstackHelmRelease.metadata.namespace)}.svc.cluster.local:3000'
       );
@@ -453,9 +512,7 @@ describe('clickstackBootstrap factory modes', () => {
       );
 
       // Secret wiring reaches the RGD values as guarded schema CEL.
-      expect(JSON.stringify(loadAll(yaml))).toContain(
-        '${has(schema.spec.apiKey) ? dyn(schema.spec.apiKey) : omit()}'
-      );
+      expect(JSON.stringify(loadAll(yaml))).toContain('${schema.spec.apiKey}');
     });
   });
 });

--- a/test/factories/clickstack/factory-modes.test.ts
+++ b/test/factories/clickstack/factory-modes.test.ts
@@ -30,6 +30,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadAll } from 'js-yaml';
 
+import { kubernetesComposition } from '../../../src/core/composition/imperative.js';
 import {
   clickstackBootstrap,
   makeClickstackBootstrap,
@@ -43,6 +44,10 @@ import {
   DEFAULT_OTEL_REPO_NAME,
   DEFAULT_OTEL_REPO_URL,
 } from '../../../src/factories/clickstack/resources/helm.js';
+import {
+  ClickStackBootstrapConfigSchema,
+  ClickStackBootstrapStatusSchema,
+} from '../../../src/factories/clickstack/types.js';
 
 const ORIGINAL_STRICT_ENV = process.env.TYPEKRO_STRICT_CEL;
 const ORIGINAL_KUBECONFIG = process.env.KUBECONFIG;
@@ -142,13 +147,37 @@ const TELEMETRY_SPEC = {
 describe('clickstackBootstrap factory modes', () => {
   describe("direct: factory('direct').toYaml(spec) — concrete manifests", () => {
     it('can consume an externally managed namespace without owning it', () => {
-      const bootstrap = makeClickstackBootstrap({
-        namespaceOwnership: 'external',
-      });
+      const bootstrap = makeClickstackBootstrap();
       const yaml = bootstrap.factory('direct').toYaml(BOOTSTRAP_SPEC);
 
       expect(splitDocs(yaml).some((doc) => docKind(doc) === 'Namespace')).toBe(false);
       expect(yaml).toContain('namespace: clickstack');
+    });
+
+    it('preserves the external namespace boundary when nested in another composition', () => {
+      const bootstrap = makeClickstackBootstrap();
+      const parent = kubernetesComposition(
+        {
+          name: 'nested-clickstack',
+          kind: 'NestedClickStack',
+          spec: ClickStackBootstrapConfigSchema,
+          status: ClickStackBootstrapStatusSchema,
+        },
+        (spec) => bootstrap(spec).status
+      );
+
+      const yaml = parent.factory('direct').toYaml(BOOTSTRAP_SPEC as never);
+
+      expect(splitDocs(yaml).some((doc) => docKind(doc) === 'Namespace')).toBe(false);
+      expect(yaml).toContain('namespace: clickstack');
+    });
+
+    it('owns the default namespace only when namespace is omitted', () => {
+      const { namespace: _externalNamespace, ...standaloneSpec } = BOOTSTRAP_SPEC;
+      const yaml = clickstackBootstrap.factory('direct').toYaml(standaloneSpec as never);
+      const namespaceDocument = splitDocs(yaml).find((doc) => docKind(doc) === 'Namespace');
+
+      expect(namespaceDocument).toContain('name: clickstack');
     });
 
     it('loads credential values from a Secret without serializing inline credential fields', () => {
@@ -220,9 +249,9 @@ describe('clickstackBootstrap factory modes', () => {
       const docs = splitDocs(yaml);
       const kinds = docs.map(docKind);
 
-      // Internal-Mongo default: Namespace + Mongo StatefulSet/Service +
-      // HelmRelease + the idempotent authoritative-Team bootstrap Job.
-      expect(kinds).toContain('Namespace');
+      // The supplied namespace is external; ClickStack owns only Mongo,
+      // HelmRelease, and the idempotent authoritative-Team bootstrap Job.
+      expect(kinds).not.toContain('Namespace');
       expect(kinds).toContain('StatefulSet');
       expect(kinds).toContain('Service');
       expect(kinds).toContain('HelmRelease');
@@ -325,14 +354,22 @@ describe('clickstackBootstrap factory modes', () => {
   });
 
   describe("kro: factory('kro').toYaml(...) — instance bundle + RGD contract", () => {
-    it('keeps an externally managed namespace out of the generated resource graph', () => {
-      const bootstrap = makeClickstackBootstrap({
-        namespaceOwnership: 'external',
+    it('hoists namespace ownership only when the runtime namespace is absent', async () => {
+      const bootstrap = makeClickstackBootstrap();
+      const factory = bootstrap.factory('kro', {
+        namespace: 'typekro-system',
+        waitForReady: false,
       });
-      const yaml = bootstrap.factory('kro').toYaml();
+      const { namespace: _externalNamespace, ...standaloneSpec } = BOOTSTRAP_SPEC;
+      const owned = await factory.toAlchemyResources(standaloneSpec as never);
+      const external = await factory.toAlchemyResources(BOOTSTRAP_SPEC as never);
 
-      expect(yaml).not.toContain('kind: Namespace');
-      expect(yaml).toContain('kind: HelmRelease');
+      expect(owned.some((declaration) => declaration.props.resource.kind === 'Namespace')).toBe(
+        true
+      );
+      expect(external.some((declaration) => declaration.props.resource.kind === 'Namespace')).toBe(
+        false
+      );
     });
 
     it('preserves Secret-backed valuesFrom wiring without exposing inline credential paths', () => {

--- a/test/factories/clickstack/factory-modes.test.ts
+++ b/test/factories/clickstack/factory-modes.test.ts
@@ -141,6 +141,16 @@ const TELEMETRY_SPEC = {
 
 describe('clickstackBootstrap factory modes', () => {
   describe("direct: factory('direct').toYaml(spec) — concrete manifests", () => {
+    it('can consume an externally managed namespace without owning it', () => {
+      const bootstrap = makeClickstackBootstrap({
+        namespaceOwnership: 'external',
+      });
+      const yaml = bootstrap.factory('direct').toYaml(BOOTSTRAP_SPEC);
+
+      expect(splitDocs(yaml).some((doc) => docKind(doc) === 'Namespace')).toBe(false);
+      expect(yaml).toContain('namespace: clickstack');
+    });
+
     it('loads credential values from a Secret without serializing inline credential fields', () => {
       const bootstrap = makeClickstackBootstrap({
         credentials: { source: 'secretValues' },
@@ -294,6 +304,16 @@ describe('clickstackBootstrap factory modes', () => {
   });
 
   describe("kro: factory('kro').toYaml(...) — instance bundle + RGD contract", () => {
+    it('keeps an externally managed namespace out of the generated resource graph', () => {
+      const bootstrap = makeClickstackBootstrap({
+        namespaceOwnership: 'external',
+      });
+      const yaml = bootstrap.factory('kro').toYaml();
+
+      expect(yaml).not.toContain('kind: Namespace');
+      expect(yaml).toContain('kind: HelmRelease');
+    });
+
     it('preserves Secret-backed valuesFrom wiring without exposing inline credential paths', () => {
       const bootstrap = makeClickstackBootstrap({
         credentials: { source: 'secretValues' },

--- a/test/factories/clickstack/factory-modes.test.ts
+++ b/test/factories/clickstack/factory-modes.test.ts
@@ -220,13 +220,21 @@ describe('clickstackBootstrap factory modes', () => {
       const docs = splitDocs(yaml);
       const kinds = docs.map(docKind);
 
-      // Internal-Mongo default: Namespace + Mongo StatefulSet/Service + HelmRelease.
+      // Internal-Mongo default: Namespace + Mongo StatefulSet/Service +
+      // HelmRelease + the idempotent authoritative-Team bootstrap Job.
       expect(kinds).toContain('Namespace');
       expect(kinds).toContain('StatefulSet');
       expect(kinds).toContain('Service');
       expect(kinds).toContain('HelmRelease');
+      expect(kinds).toContain('Job');
       expect(yaml).toContain('image: mongo:7');
       expect(yaml).toContain('name: clickstack-mongodb');
+      expect(yaml).toContain('name: clickstack-team-bootstrap');
+      expect(yaml).toContain('key: HYPERDX_API_KEY');
+      expect(yaml).toContain('name: clickstack-secret');
+      expect(yaml).toContain("hookId = 'typekro-managed-ingestion'");
+      expect(yaml).not.toContain('ttlSecondsAfterFinished');
+      expect(kinds.indexOf('HelmRelease')).toBeLessThan(kinds.indexOf('Job'));
 
       // DOCUMENTED WART: direct-mode toYaml() omits singleton-owned resources.
       // The shared HelmRepository is NOT a document here — only the HelmRelease
@@ -264,6 +272,10 @@ describe('clickstackBootstrap factory modes', () => {
       expect(release).toMatch(/mongodb:\s*\n\s+enabled: false/);
       // The status contract's naming anchor.
       expect(release).toContain('fullnameOverride: clickstack');
+      expect(release).toContain('customConfig: |');
+      expect(release).toContain('receivers: [fluentforward, otlp/hyperdx]');
+      expect(release).toContain('receivers: [prometheus, otlp/hyperdx]');
+      expect(release).toContain('receivers: [nop, otlp/hyperdx]');
 
       // External-ClickHouse wiring is fully concrete.
       expect(release).toContain(
@@ -288,6 +300,15 @@ describe('clickstackBootstrap factory modes', () => {
       );
       expect(release).toContain('"username":"otelcollector"');
       expect(release).toContain('"tableName":"otel_logs"');
+    });
+
+    it('protects the OTLP pipeline attachment from chart-value passthrough overrides', () => {
+      const bootstrap = makeClickstackBootstrap({
+        values: { global: { otelCollector: { customConfig: '' } } },
+      });
+      const yaml = bootstrap.factory('direct').toYaml(BOOTSTRAP_SPEC);
+
+      expect(yaml).toContain('receivers: [fluentforward, otlp/hyperdx]');
     });
 
     it('resolves every schema ref — no unresolved CEL/schema markers anywhere', () => {
@@ -332,8 +353,11 @@ describe('clickstackBootstrap factory modes', () => {
       );
       expect(serialized).not.toContain('CLICKHOUSE_PASSWORD');
       expect(serialized).not.toContain('CLICKHOUSE_APP_PASSWORD');
-      expect(serialized).not.toContain('HYPERDX_API_KEY');
+      expect(serialized).not.toContain('schema.spec.apiKey');
+      expect(yaml).toContain('key: HYPERDX_API_KEY');
+      expect(yaml).toContain('name: clickstack-secret');
       expect(yaml).toContain('validation="self == null"');
+      expect(yaml).toContain('receivers: [fluentforward, otlp/hyperdx]');
     });
 
     it('toYaml(instance) bundles the singleton owner instance BEFORE the ClickStackBootstrap CR', () => {

--- a/test/factories/final-cel-resolution.test.ts
+++ b/test/factories/final-cel-resolution.test.ts
@@ -96,14 +96,28 @@ describe('final-pipeline CEL resolution for raw-Cel.expr status fields (hermetic
     );
     expect(status).not.toBeNull();
 
-    // A reconciled HelmRelease (Ready=True) — what the graph looks like post-waitForReady.
-    const ready = { clickstackHelmRelease: { status: { conditions: [{ type: 'Ready', status: 'True' }] } } };
+    // Both the chart and the authoritative ingestion-Team bootstrap have
+    // reconciled — what the graph looks like post-waitForReady.
+    const ready = {
+      clickstackHelmRelease: { status: { conditions: [{ type: 'Ready', status: 'True' }] } },
+      clickstackTeamBootstrap: { status: { succeeded: 1 } },
+    };
     expect(await evalCel(status!.ready, ready)).toBe(true);
     expect(await evalCel(status!.phase, ready)).toBe('Ready');
 
     // A failed HelmRelease drives phase to Failed — proves the macro chain, not a constant.
-    const failed = { clickstackHelmRelease: { status: { conditions: [{ type: 'Ready', status: 'False' }] } } };
+    const failed = {
+      clickstackHelmRelease: { status: { conditions: [{ type: 'Ready', status: 'False' }] } },
+      clickstackTeamBootstrap: { status: {} },
+    };
     expect(await evalCel(status!.ready, failed)).toBe(false);
     expect(await evalCel(status!.phase, failed)).toBe('Failed');
+
+    const bootstrapFailed = {
+      clickstackHelmRelease: { status: { conditions: [{ type: 'Ready', status: 'True' }] } },
+      clickstackTeamBootstrap: { status: { succeeded: 0, failed: 1 } },
+    };
+    expect(await evalCel(status!.ready, bootstrapFailed)).toBe(false);
+    expect(await evalCel(status!.phase, bootstrapFailed)).toBe('Failed');
   });
 });

--- a/test/factories/final-cel-resolution.test.ts
+++ b/test/factories/final-cel-resolution.test.ts
@@ -99,25 +99,53 @@ describe('final-pipeline CEL resolution for raw-Cel.expr status fields (hermetic
     // Both the chart and the authoritative ingestion-Team bootstrap have
     // reconciled — what the graph looks like post-waitForReady.
     const ready = {
-      clickstackHelmRelease: { status: { conditions: [{ type: 'Ready', status: 'True' }] } },
-      clickstackTeamBootstrap: { status: { succeeded: 1 } },
+      clickstackHelmRelease: {
+        metadata: { generation: 2 },
+        status: {
+          observedGeneration: 2,
+          conditions: [{ type: 'Ready', status: 'True', observedGeneration: 2 }],
+        },
+      },
+      clickstackTeamBootstrap: {
+        status: {
+          lastScheduleTime: '2026-08-28T10:00:00Z',
+          lastSuccessfulTime: '2026-08-28T10:00:05Z',
+        },
+      },
     };
     expect(await evalCel(status!.ready, ready)).toBe(true);
     expect(await evalCel(status!.phase, ready)).toBe('Ready');
 
     // A failed HelmRelease drives phase to Failed — proves the macro chain, not a constant.
     const failed = {
-      clickstackHelmRelease: { status: { conditions: [{ type: 'Ready', status: 'False' }] } },
+      clickstackHelmRelease: {
+        metadata: { generation: 2 },
+        status: {
+          observedGeneration: 2,
+          conditions: [{ type: 'Ready', status: 'False', observedGeneration: 2 }],
+        },
+      },
       clickstackTeamBootstrap: { status: {} },
     };
     expect(await evalCel(status!.ready, failed)).toBe(false);
     expect(await evalCel(status!.phase, failed)).toBe('Failed');
 
-    const bootstrapFailed = {
-      clickstackHelmRelease: { status: { conditions: [{ type: 'Ready', status: 'True' }] } },
-      clickstackTeamBootstrap: { status: { succeeded: 0, failed: 1 } },
+    const bootstrapPending = {
+      clickstackHelmRelease: {
+        metadata: { generation: 2 },
+        status: {
+          observedGeneration: 2,
+          conditions: [{ type: 'Ready', status: 'True', observedGeneration: 2 }],
+        },
+      },
+      clickstackTeamBootstrap: {
+        status: {
+          lastScheduleTime: '2026-08-28T10:01:00Z',
+          lastSuccessfulTime: '2026-08-28T10:00:05Z',
+        },
+      },
     };
-    expect(await evalCel(status!.ready, bootstrapFailed)).toBe(false);
-    expect(await evalCel(status!.phase, bootstrapFailed)).toBe('Failed');
+    expect(await evalCel(status!.ready, bootstrapPending)).toBe(false);
+    expect(await evalCel(status!.phase, bootstrapPending)).toBe('Installing');
   });
 });

--- a/test/integration/clickstack/bootstrap-composition.test.ts
+++ b/test/integration/clickstack/bootstrap-composition.test.ts
@@ -34,6 +34,7 @@
  */
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from 'bun:test';
 import { getKubeConfig } from '../../../src/core/kubernetes/client-provider.js';
+import { getErrorStatusCode } from '../../../src/core/kubernetes/errors.js';
 import {
   createTestNamespace,
   deleteGeneratedCrdAndWait,
@@ -49,6 +50,48 @@ import {
 const clusterAvailable = await isClusterAvailable();
 const describeOrSkip =
   clusterAvailable || process.env.REQUIRE_CLUSTER_TESTS === 'true' ? describe : describe.skip;
+
+async function resetClickstackKroDefinition(kubeConfig: any): Promise<void> {
+  const { createBunCompatibleCustomObjectsApi } = await import(
+    '../../../src/core/kubernetes/index.js'
+  );
+  const customApi = createBunCompatibleCustomObjectsApi(kubeConfig);
+  let instances: any[] = [];
+  try {
+    const raw: any = await customApi.listClusterCustomObject({
+      group: 'kro.run',
+      version: 'v1alpha1',
+      plural: 'clickstackbootstraps',
+    });
+    instances = (raw?.body ?? raw)?.items ?? [];
+  } catch (error) {
+    if (getErrorStatusCode(error) !== 404) throw error;
+  }
+  if (instances.length > 0) {
+    throw new Error(
+      `Refusing to reset ClickStack's live test RGD while ${instances.length} instance(s) remain`
+    );
+  }
+  await deleteTestResourceAndWait(
+    {
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'ResourceGraphDefinition',
+      metadata: { name: 'clickstack-bootstrap' },
+    },
+    kubeConfig,
+    60_000
+  );
+  await deleteGeneratedCrdAndWait(
+    {
+      apiVersion: 'apiextensions.k8s.io/v1',
+      kind: 'CustomResourceDefinition',
+      metadata: { name: 'clickstackbootstraps.kro.run' },
+    },
+    'kro.run/v1alpha1',
+    'ClickStackBootstrap',
+    kubeConfig
+  );
+}
 
 // Live-verified: tearing down the operator + CHI + clickstack (direct +
 // kro) + singleton sweep + 5 namespaces exceeds bun's 5s default hook
@@ -76,9 +119,8 @@ describeOrSkip('ClickStack Bootstrap Composition Integration Tests', () => {
   const chiNs = `clickstack-test-chi-${runId}`;
   const stackNs = `clickstack-test-stack-${runId}`;
   // KRO-mode namespaces: the instance CR lives in kroCrNs (factory
-  // namespace); the app namespace kroStackNs is OWNED by the composition
-  // graph (it declares the Namespace resource), so it is NOT pre-created —
-  // same split as the searxng/dagster KRO-mode suites.
+  // namespace); the explicitly supplied app namespace is externally owned
+  // under ClickStack's namespace-presence contract and is pre-created below.
   const kroStackNs = `clickstack-test-kro-${runId}`;
   const kroCrNs = `clickstack-test-kro-cr-${runId}`;
   let storageClass: string;
@@ -107,6 +149,7 @@ describeOrSkip('ClickStack Bootstrap Composition Integration Tests', () => {
         '../../../src/core/kubernetes/index.js'
       );
       const customApi = createBunCompatibleCustomObjectsApi(kubeConfig);
+      await resetClickstackKroDefinition(kubeConfig);
 
       try {
         await customApi.getNamespacedCustomObject({
@@ -139,7 +182,9 @@ describeOrSkip('ClickStack Bootstrap Composition Integration Tests', () => {
       altinityRepositoryPreexisting = await repositoryExists('altinity');
       clickstackRepositoryPreexisting = await repositoryExists('clickstack');
 
-      const namespaces = reuseExistingOperator ? [chiNs, stackNs] : [operatorNs, chiNs, stackNs];
+      const namespaces = reuseExistingOperator
+        ? [chiNs, stackNs, kroStackNs]
+        : [operatorNs, chiNs, stackNs, kroStackNs];
       namespaceLeases.push(
         ...(await Promise.all(
           namespaces.map((namespace) => createTestNamespace(namespace, kubeConfig))
@@ -468,7 +513,7 @@ describeOrSkip('ClickStack Bootstrap Composition Integration Tests', () => {
     kroStackDeployed = true;
 
     const instance = await runWithExpectedTestNamespaces<any>(
-      [kroStackNs, kroCrNs],
+      [kroCrNs],
       kubeConfig,
       (lease) => namespaceLeases.push(lease),
       () =>
@@ -617,7 +662,8 @@ describeOrSkip('ClickStack Bootstrap Composition Integration Tests', () => {
     expect(yaml).toContain('kind: ResourceGraphDefinition');
     expect(yaml).toContain('name: clickstack-bootstrap');
     expect(yaml).toContain('chart: clickstack');
-    expect(yaml).toMatch(/ready: \$\{clickstackHelmRelease\.status\.conditions\.exists/);
+    expect(yaml).toContain('clickstackHelmRelease.status.observedGeneration');
+    expect(yaml).toContain('clickstackTeamBootstrap.status.lastSuccessfulTime');
     expect(yaml).toContain('otlpHttpEndpoint:');
     expect(yaml).toContain('driftDetection:');
     expect(yaml).toContain('mode: enabled');

--- a/test/integration/clickstack/bootstrap-composition.test.ts
+++ b/test/integration/clickstack/bootstrap-composition.test.ts
@@ -129,8 +129,12 @@ describeOrSkip('ClickStack Bootstrap Composition Integration Tests', () => {
   const chiName = 'clickstack-e2e-ch';
   const stackName = 'clickstack-e2e';
   const kroStackName = 'clickstack-kro-e2e';
-  const kroNamespaceLeases = (): TestNamespaceLease[] =>
-    namespaceLeases.filter((lease) => lease.name === kroStackNs || lease.name === kroCrNs);
+  // Only the workload namespace belongs to the ClickStack instance lifecycle.
+  // The factory's CR/control-plane namespace is a separate harness lease and
+  // must be deleted by afterAll, not misclassified as a remaining child of
+  // factory.deleteInstance().
+  const kroWorkloadNamespaceLeases = (): TestNamespaceLease[] =>
+    namespaceLeases.filter((lease) => lease.name === kroStackNs);
 
   // A named ClickHouse user (not the CHI's network-restricted `default`
   // user — see the deploy test's comment) that clickstack's otel-collector
@@ -206,7 +210,7 @@ describeOrSkip('ClickStack Bootstrap Composition Integration Tests', () => {
       await deleteTestFactoryInstanceAndRecoverNamespaces(
         kroStackFactory,
         kroStackName,
-        kroNamespaceLeases(),
+        kroWorkloadNamespaceLeases(),
         kubeConfig,
         120_000
       ).catch((error) => cleanupErrors.push(error));
@@ -609,11 +613,12 @@ describeOrSkip('ClickStack Bootstrap Composition Integration Tests', () => {
     expect(liveCr.status?.app?.host).toBe(`${kroStackName}.${kroStackNs}.svc.cluster.local`);
   }, 1800000);
 
-  it('tears down the KRO instance cleanly (CR gone, RGD/CRD removed as sole instance)', async () => {
+  it('tears down the KRO instance cleanly (CR and RGD gone; generated CRD safely retained)', async () => {
     // Self-cleaning proof for kro mode: deleteInstance removes the CR (waits
     // for KRO's graph-deletion finalizer), then — as the only instance — the
-    // clickstack-bootstrap RGD and generated CRD. The shared HelmRepository
-    // singleton intentionally survives (swept in afterAll).
+    // clickstack-bootstrap RGD. The generated CRD follows TypeKro's safe
+    // zero-instance retention policy, and the shared HelmRepository singleton
+    // intentionally survives (both are swept/reset by the suite boundary).
     expect(kroStackDeployed).toBe(true);
 
     const { createBunCompatibleCustomObjectsApi } = await import(
@@ -627,7 +632,7 @@ describeOrSkip('ClickStack Bootstrap Composition Integration Tests', () => {
     await deleteTestFactoryInstanceAndRecoverNamespaces(
       kroStackFactory,
       kroStackName,
-      kroNamespaceLeases(),
+      kroWorkloadNamespaceLeases(),
       kubeConfig,
       120_000
     );


### PR DESCRIPTION
## Summary

- support Secret-backed ClickHouse and ClickStack credentials without serializing values into RGDs or inline Helm values
- allow a parent deployment graph to own the ClickStack namespace
- upgrade the official ClickStack chart to 3.2.0, create the framework-owned ingestion Team, and attach the authenticated OTLP receiver to all signal pipelines
- make ClickStack readiness include completion of the ingestion bootstrap

## Root cause

The released 0.33.8 ClickStack graph reports its HelmRelease Ready while chart 3.0.1's OpAMP configuration leaves `otlp/hyperdx` detached from every pipeline. The collector health port is ready, but 4317/4318 never bind, so application telemetry gets `ECONNREFUSED`.

## Verification

- 127 focused ClickHouse, ClickStack, dependency-resolution, and CEL-resolution tests passed
- library, examples, and test typechecks passed
- Biome lint passed across 992 files
- production build passed
- Applik8s' OrbStack receipt independently reproduced the released failure with a Ready collector, valid Service/endpoints, and no 4318 listener; the patched end-to-end rerun is being completed against this branch
