### PR TITLE
fix: plan SearXNG external secrets safely

### DIFF
--- a/docs/api/searxng/index.md
+++ b/docs/api/searxng/index.md
@@ -21,6 +21,10 @@ Deploy [SearXNG](https://docs.searxng.org/) — a privacy-respecting metasearch 
 
 - **`search.formats` is direct-mode only.** In KRO mode the user-supplied `formats` array is currently ignored and the composition falls back to the literal default `['html', 'json']`. This is because KRO's CEL mixed templates don't yet support iterating a schema array into a YAML list. If you need a custom `formats` list, deploy via direct mode. Array-valued CEL templating is tracked in [yehudacohen/typekro#57](https://github.com/yehudacohen/typekro/issues/57) and this limitation will be removed once it lands.
 - **Optional generated settings fields are direct-mode only.** `server.bind_address`, `server.method`, `search.default_lang`, `search.autocomplete`, and `search.safe_search` are emitted into generated `settings.yml` when the spec is concrete. In KRO mode those optional fields are schema proxies, so the composition omits them rather than emitting invalid YAML for absent values.
+- **KRO credentials are reference-only.** KRO instances require `secretKeyRef`; inline
+  `server.secret_key` is supported only in direct mode. This keeps plaintext credentials out of the
+  custom resource. Raw GitOps instances that omit `secretKeyRef` fail closed and create no SearXNG
+  workload resources.
 - **KRO 0.9.2+ required.** See [Requirements](#requirements) above.
 
 ## Quick Start
@@ -48,7 +52,7 @@ await factory.deploy({
 |----------|------|------|
 | Namespace | `searxng` | Namespace |
 | Settings | `{name}-config` | ConfigMap |
-| Secret key | `{name}-secret` | Secret, created when `secretKeyRef` is omitted |
+| Secret key | `{name}-secret` | Secret, created from inline `server.secret_key` in direct mode only |
 | Search engine | `{name}` | Deployment |
 | Service | `{name}` | Service (port 8080) |
 
@@ -68,7 +72,7 @@ await factory.deploy({
 | `server` | object | — | Server configuration |
 | `search` | object | — | Search configuration |
 | `redisUrl` | `string` | — | Redis/Valkey URL for rate limiter |
-| `secretKeyRef` | `{ name: string; key: string }` | — | Existing Secret key to use for `SEARXNG_SECRET`; skips the auto-created Secret workflow |
+| `secretKeyRef` | `{ name: string; key: string }` | — | Existing Secret key to use for `SEARXNG_SECRET`; required in KRO mode and skips the direct-mode auto-created Secret workflow |
 | `settingsYaml` | `string` | — | Complete `settings.yml` content. In direct mode this overrides generated settings and is useful when KRO array templating limits apply |
 | `env` | `Record<string, string>` | — | Extra environment variables |
 | `resources` | object | — | CPU/memory requests and limits |
@@ -77,7 +81,7 @@ await factory.deploy({
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `secret_key` | `string` | required unless `secretKeyRef` is set | Session encryption key used for the auto-created Secret |
+| `secret_key` | `string` | required in direct mode unless `secretKeyRef` is set | Session encryption key used for the direct-mode auto-created Secret; not accepted as the KRO credential source |
 | `limiter` | `boolean` | — | Enable built-in rate limiter |
 | `bind_address` | `string` | `'0.0.0.0:8080'` | Bind address |
 | `method` | `string` | `'GET'` | HTTP method |

--- a/src/factories/searxng/compositions/searxng-bootstrap.ts
+++ b/src/factories/searxng/compositions/searxng-bootstrap.ts
@@ -278,14 +278,12 @@ ${redisSection}`;
       //       Secret from `server.secret_key`. The plaintext stops at the
       //       Secret's stringData and never enters the Deployment env.
       //
-      // The plain `if (!spec.secretKeyRef)` below is transformed into a KRO
-      // `includeWhen: ${!has(schema.spec.secretKeyRef)}` directive by the
-      // composition AST analyzer during serialization. In direct mode the
-      // `if` runs normally; in KRO mode the analyzer attaches the includeWhen
-      // so the Secret is only created when the user didn't provide an
-      // external ref. The Deployment's `secretKeyRef` field is computed by
-      // the JS ternary on the same condition and the analyzer emits the
-      // corresponding CEL ternary there as well.
+      // The generated Secret is explicitly gated by the absence of
+      // `secretKeyRef`, so an external Secret remains externally owned. The
+      // Deployment itself is not gated on either credential branch: admission
+      // already requires one source, and secret-derived resource activation
+      // would turn sensitive data into structural planning control flow. Its
+      // `secretKeyRef` value instead selects the external or generated Secret.
       //
       // Why `simple.Secret` is NOT used here: it eagerly base64-encodes
       // stringData values via `Buffer.from(...)` at composition time, which
@@ -344,11 +342,9 @@ ${redisSection}`;
       // `secretKeyRef` instead, which the factory translates into
       // `valueFrom.secretKeyRef` on the SEARXNG_SECRET env var.
       //
-      // The two nested ternaries on `secretKeyRef.name` and `secretKeyRef.key`
-      // are detected by the composition AST analyzer and emitted as CEL
-      // conditionals in the final RGD — in KRO mode the user's CR value
-      // for `spec.secretKeyRef` selects between the external Secret and
-      // the auto-created one at reconcile time.
+      // In KRO mode the explicit CEL conditionals select the external Secret
+      // or the auto-created one at reconcile time without changing whether
+      // the Deployment exists.
       const deploymentSecretRefName = hasDynamicSecretKeyRef
         ? `${Cel.cond<string>(Cel.has(dynamicSecretKeyRef), dynamicSecretKeyRef.name, secretName)}`
         : spec.secretKeyRef

--- a/src/factories/searxng/compositions/searxng-bootstrap.ts
+++ b/src/factories/searxng/compositions/searxng-bootstrap.ts
@@ -33,8 +33,8 @@ import type {
 } from '../../../core/types/deployment.js';
 import { isKubernetesRef } from '../../../utils/type-guards.js';
 import { configMap } from '../../kubernetes/config/config-map.js';
-import { namespace } from '../../kubernetes/core/namespace.js';
 import { secret } from '../../kubernetes/config/secret.js';
+import { namespace } from '../../kubernetes/core/namespace.js';
 import { simple } from '../../simple/index.js';
 import { searxng } from '../resources/searxng.js';
 import {
@@ -48,10 +48,9 @@ import {
 /**
  * Return a copy of the server config with `secret_key` removed. The field
  * is delivered via a dedicated K8s Secret, not via the Deployment spec —
- * this helper makes sure the plaintext (or the KubernetesRef proxy that
- * carries it in KRO mode) does not leak into the searxng() factory's
- * `spec.server` which would otherwise fall back to injecting it as a
- * plaintext env var.
+ * this helper makes sure direct mode's plaintext does not leak into the
+ * searxng() factory's `spec.server`, which would otherwise inject it as an
+ * env value. KRO rejects the inline field and uses only `secretKeyRef`.
  */
 function stripSecretKey<T extends { secret_key?: unknown }>(server: T): Omit<T, 'secret_key'> {
   const { secret_key: _discarded, ...rest } = server;
@@ -72,6 +71,14 @@ function validateKroBootstrapInstanceSpec(spec: SearxngBootstrapConfig): void {
     );
   }
 
+  if (spec.server?.secret_key !== undefined) {
+    throw new TypeKroError(
+      'searxngBootstrap KRO mode rejects server.secret_key even when secretKeyRef is present. KRO credentials are reference-only so plaintext is never materialized into the instance custom resource.',
+      'UNSUPPORTED_KRO_CONFIG',
+      { field: 'server.secret_key', mode: 'kro' }
+    );
+  }
+
   if (!spec.secretKeyRef) {
     throw new TypeKroError(
       'searxngBootstrap KRO mode requires secretKeyRef for enabled instances. Inline server.secret_key is direct-mode-only so plaintext credentials are not stored in KRO custom resources.',
@@ -89,7 +96,12 @@ function withKroInstanceValidation(
       if (prop === 'deploy') {
         return (
           spec: SearxngBootstrapConfig,
-          opts?: Parameters<KroResourceFactory<SearxngBootstrapConfig, typeof SearxngBootstrapStatusSchema.infer>['deploy']>[1]
+          opts?: Parameters<
+            KroResourceFactory<
+              SearxngBootstrapConfig,
+              typeof SearxngBootstrapStatusSchema.infer
+            >['deploy']
+          >[1]
         ) => {
           validateKroBootstrapInstanceSpec(spec);
           return target.deploy(spec, opts);
@@ -97,10 +109,7 @@ function withKroInstanceValidation(
       }
 
       if (prop === 'toYaml') {
-        return (
-          spec?: SearxngBootstrapConfig,
-          options?: StaticYamlMaterializationOptions
-        ) => {
+        return (spec?: SearxngBootstrapConfig, options?: StaticYamlMaterializationOptions) => {
           if (spec !== undefined) {
             validateKroBootstrapInstanceSpec(spec);
             return target.toYaml(spec, options);
@@ -293,8 +302,8 @@ ${redisSection}`;
       // gated on credential-source PRESENCE so raw GitOps instances that
       // bypass ArkType validation fail
       // closed without creating a broken workload. Secret DATA never controls
-      // resource activation. The Deployment's `secretKeyRef` value selects the
-      // external or generated Secret for valid instances.
+      // resource activation. KRO always selects the external reference; only
+      // direct mode can select the generated Secret.
       //
       // Why `simple.Secret` is NOT used here: it eagerly base64-encodes
       // stringData values via `Buffer.from(...)` at composition time, which
@@ -353,9 +362,8 @@ ${redisSection}`;
       // `secretKeyRef` instead, which the factory translates into
       // `valueFrom.secretKeyRef` on the SEARXNG_SECRET env var.
       //
-      // In KRO mode the explicit CEL conditionals select the external Secret
-      // or the auto-created one at reconcile time without changing whether
-      // the Deployment exists.
+      // In KRO mode the explicit CEL reference selects the required external
+      // Secret. Direct mode may instead select the auto-created Secret.
       const deploymentSecretRefName = hasDynamicSecretKeyRef
         ? `${Cel.cond<string>(Cel.has(dynamicSecretKeyRef), dynamicSecretKeyRef.name, secretName)}`
         : spec.secretKeyRef
@@ -442,6 +450,16 @@ ${redisSection}`;
       ),
       url: `http://${spec.name}.${resolvedNamespace}:${port}`,
     };
+  },
+  {
+    // Direct mode intentionally retains the ergonomic inline-to-Secret path,
+    // but a KRO custom resource is a broadly readable persistence boundary.
+    // This optional-leaf validation runs only when the field is present, so
+    // raw GitOps instances cannot submit plaintext — including alongside an
+    // otherwise valid secretKeyRef.
+    schemaFieldValidations: {
+      'server.secret_key': 'false',
+    },
   }
 );
 
@@ -459,7 +477,10 @@ function searxngBootstrapFactory(mode: 'kro' | 'direct', options?: PublicFactory
   const factory = baseFactory(mode, options);
   return mode === 'kro'
     ? withKroInstanceValidation(
-        factory as KroResourceFactory<SearxngBootstrapConfig, typeof SearxngBootstrapStatusSchema.infer>
+        factory as KroResourceFactory<
+          SearxngBootstrapConfig,
+          typeof SearxngBootstrapStatusSchema.infer
+        >
       )
     : factory;
 }

--- a/src/factories/searxng/compositions/searxng-bootstrap.ts
+++ b/src/factories/searxng/compositions/searxng-bootstrap.ts
@@ -72,11 +72,11 @@ function validateKroBootstrapInstanceSpec(spec: SearxngBootstrapConfig): void {
     );
   }
 
-  if (!spec.secretKeyRef && spec.server?.secret_key === undefined) {
+  if (!spec.secretKeyRef) {
     throw new TypeKroError(
-      'searxngBootstrap KRO mode requires server.secret_key or secretKeyRef for enabled instances.',
+      'searxngBootstrap KRO mode requires secretKeyRef for enabled instances. Inline server.secret_key is direct-mode-only so plaintext credentials are not stored in KRO custom resources.',
       'REQUIRED_CONFIG_MISSING',
-      { field: 'server.secret_key', alternative: 'secretKeyRef', mode: 'kro' }
+      { field: 'secretKeyRef', mode: 'kro' }
     );
   }
 }
@@ -136,6 +136,14 @@ const searxngBootstrapComposition = kubernetesComposition(
     const enabledWhen = Cel.expr<boolean>(
       '!(has(schema.spec.enabled)) || schema.spec.enabled != false'
     );
+    // ArkType's cross-field `.narrow()` protects JavaScript factory calls, but
+    // KRO does not carry that predicate into the generated CRD schema. Raw
+    // GitOps clients can therefore submit an enabled instance without the
+    // required external reference. Fail closed at the graph boundary too:
+    // such an instance owns no Namespace, Secret, Deployment, ConfigMap, or
+    // Service. Inline secrets remain a direct-mode-only convenience so secret
+    // data never controls KRO resource activation or lives in an instance CR.
+    const credentialSourcePresentWhen = Cel.expr<boolean>('has(schema.spec.secretKeyRef)');
     const port = DEFAULT_SEARXNG_PORT;
     let deployment: ReturnType<typeof searxng> | undefined;
 
@@ -154,7 +162,7 @@ const searxngBootstrapComposition = kubernetesComposition(
         id: 'searxngNamespace',
       });
       if (isGraphMode) {
-        appendIncludeWhen(_ns, [enabledWhen]);
+        appendIncludeWhen(_ns, [enabledWhen, credentialSourcePresentWhen]);
       }
 
       // ── Settings ConfigMap ─────────────────────────────────────────────
@@ -264,7 +272,7 @@ ${redisSection}`;
         id: 'searxngConfig',
       });
       if (isGraphMode) {
-        appendIncludeWhen(_config, [enabledWhen]);
+        appendIncludeWhen(_config, [enabledWhen, credentialSourcePresentWhen]);
       }
 
       // ── Secret (SEARXNG_SECRET delivery) ───────────────────────────────
@@ -274,16 +282,19 @@ ${redisSection}`;
       //       mounts that existing Secret via valueFrom — the bootstrap does
       //       NOT create its own. This is the path for external-secrets
       //       workflows (Vault, AWS SM, external-secrets operator).
-      //   (2) Otherwise, the bootstrap creates a dedicated `{name}-secret`
-      //       Secret from `server.secret_key`. The plaintext stops at the
-      //       Secret's stringData and never enters the Deployment env.
+      //   (2) In direct mode, the bootstrap can instead create a dedicated
+      //       `{name}-secret` Secret from `server.secret_key`. The plaintext
+      //       stops at the Secret's stringData and never enters the Deployment
+      //       env. KRO mode requires the external-reference form.
       //
-      // The generated Secret is explicitly gated by the absence of
-      // `secretKeyRef`, so an external Secret remains externally owned. The
-      // Deployment itself is not gated on either credential branch: admission
-      // already requires one source, and secret-derived resource activation
-      // would turn sensitive data into structural planning control flow. Its
-      // `secretKeyRef` value instead selects the external or generated Secret.
+      // Direct mode suppresses the generated Secret when `secretKeyRef` is
+      // present, so an external Secret remains externally owned; KRO mode
+      // suppresses it unconditionally. The Deployment and every sibling are
+      // gated on credential-source PRESENCE so raw GitOps instances that
+      // bypass ArkType validation fail
+      // closed without creating a broken workload. Secret DATA never controls
+      // resource activation. The Deployment's `secretKeyRef` value selects the
+      // external or generated Secret for valid instances.
       //
       // Why `simple.Secret` is NOT used here: it eagerly base64-encodes
       // stringData values via `Buffer.from(...)` at composition time, which
@@ -326,10 +337,10 @@ ${redisSection}`;
       });
 
       if (isGraphMode) {
-        setIncludeWhen(generatedSecret, [
-          Cel.expr<boolean>('!has(schema.spec.secretKeyRef)'),
-          enabledWhen,
-        ]);
+        // Inline credentials are deliberately direct-mode-only. Keeping the
+        // generated Secret inactive in every KRO instance prevents plaintext
+        // credentials from becoming a supported CR storage path.
+        setIncludeWhen(generatedSecret, [Cel.expr<boolean>('false')]);
       } else if (hasDynamicSecretKeyRef) {
         setIncludeWhen(generatedSecret, [Cel.not(dynamicSecretKeyRef)]);
       } else if (spec.secretKeyRef) {
@@ -385,11 +396,7 @@ ${redisSection}`;
         id: 'searxngDeployment',
       });
       if (isGraphMode) {
-        // Admission already requires either secretKeyRef or server.secret_key.
-        // Repeating that choice as resource activation would make the
-        // sensitive plaintext path control resource existence and fail strict
-        // semantic planning even for the reference-only production path.
-        appendIncludeWhen(deployment, [enabledWhen]);
+        appendIncludeWhen(deployment, [enabledWhen, credentialSourcePresentWhen]);
       }
 
       // ── Service ────────────────────────────────────────────────────────
@@ -405,7 +412,7 @@ ${redisSection}`;
         id: 'searxngService',
       });
       if (isGraphMode) {
-        appendIncludeWhen(svc, [enabledWhen]);
+        appendIncludeWhen(svc, [enabledWhen, credentialSourcePresentWhen]);
       }
     }
 

--- a/src/factories/searxng/compositions/searxng-bootstrap.ts
+++ b/src/factories/searxng/compositions/searxng-bootstrap.ts
@@ -61,6 +61,11 @@ function appendIncludeWhen(resource: WeakKey, conditions: unknown[]): void {
   setIncludeWhen(resource, [...(getIncludeWhen(resource) ?? []), ...conditions]);
 }
 
+type SearxngKroFactory = KroResourceFactory<
+  SearxngBootstrapConfig,
+  typeof SearxngBootstrapStatusSchema.infer
+>;
+
 function validateKroBootstrapInstanceSpec(spec: SearxngBootstrapConfig): void {
   if (spec.enabled === false) {
     throw new TypeKroError(
@@ -89,8 +94,8 @@ function validateKroBootstrapInstanceSpec(spec: SearxngBootstrapConfig): void {
 }
 
 function withKroInstanceValidation(
-  factory: KroResourceFactory<SearxngBootstrapConfig, typeof SearxngBootstrapStatusSchema.infer>
-): KroResourceFactory<SearxngBootstrapConfig, typeof SearxngBootstrapStatusSchema.infer> {
+  factory: SearxngKroFactory
+): SearxngKroFactory {
   return new Proxy(factory, {
     get(target, prop, receiver) {
       if (prop === 'deploy') {
@@ -115,6 +120,16 @@ function withKroInstanceValidation(
             return target.toYaml(spec, options);
           }
           return target.toYaml();
+        };
+      }
+
+      if (prop === 'toAlchemyResources') {
+        return async (
+          spec: SearxngBootstrapConfig,
+          opts?: Parameters<SearxngKroFactory['toAlchemyResources']>[1]
+        ) => {
+          validateKroBootstrapInstanceSpec(spec);
+          return target.toAlchemyResources(spec, opts);
         };
       }
 

--- a/src/factories/searxng/compositions/searxng-bootstrap.ts
+++ b/src/factories/searxng/compositions/searxng-bootstrap.ts
@@ -136,12 +136,6 @@ const searxngBootstrapComposition = kubernetesComposition(
     const enabledWhen = Cel.expr<boolean>(
       '!(has(schema.spec.enabled)) || schema.spec.enabled != false'
     );
-    const generatedSecretKeyWhen = Cel.expr<boolean>(
-      'has(schema.spec.server) && has(schema.spec.server.secret_key)'
-    );
-    const secretSourceWhen = Cel.expr<boolean>(
-      'has(schema.spec.secretKeyRef) || (has(schema.spec.server) && has(schema.spec.server.secret_key))'
-    );
     const port = DEFAULT_SEARXNG_PORT;
     let deployment: ReturnType<typeof searxng> | undefined;
 
@@ -336,7 +330,6 @@ ${redisSection}`;
       if (isGraphMode) {
         setIncludeWhen(generatedSecret, [
           Cel.expr<boolean>('!has(schema.spec.secretKeyRef)'),
-          generatedSecretKeyWhen,
           enabledWhen,
         ]);
       } else if (hasDynamicSecretKeyRef) {
@@ -396,7 +389,11 @@ ${redisSection}`;
         id: 'searxngDeployment',
       });
       if (isGraphMode) {
-        appendIncludeWhen(deployment, [secretSourceWhen, enabledWhen]);
+        // Admission already requires either secretKeyRef or server.secret_key.
+        // Repeating that choice as resource activation would make the
+        // sensitive plaintext path control resource existence and fail strict
+        // semantic planning even for the reference-only production path.
+        appendIncludeWhen(deployment, [enabledWhen]);
       }
 
       // ── Service ────────────────────────────────────────────────────────

--- a/src/factories/searxng/types.ts
+++ b/src/factories/searxng/types.ts
@@ -150,10 +150,10 @@ const SearxngBootstrapBaseConfigSchema = type({
   /** Base URL for the instance. */
   'baseUrl?': 'string',
   /**
-   * Server configuration. When `secretKeyRef` is NOT provided, the bootstrap
-   * composition requires `server.secret_key`, creates a dedicated K8s Secret
-   * (`{name}-secret`), and mounts it via `valueFrom.secretKeyRef` on the
-   * Deployment.
+   * Server configuration. Direct mode can turn `server.secret_key` into a
+   * dedicated K8s Secret (`{name}-secret`). KRO mode rejects that plaintext
+   * field and requires `secretKeyRef`, keeping credentials out of the custom
+   * resource persistence boundary.
    */
   'server?': serverConfigShape,
   /**
@@ -161,10 +161,9 @@ const SearxngBootstrapBaseConfigSchema = type({
    * key. Use this with external-secrets-operator, Vault, or any workflow
    * where the Secret's lifecycle is managed outside TypeKro. When set,
    * the bootstrap SKIPS creating its own Secret and wires the existing
-   * one through to the Deployment via `valueFrom.secretKeyRef`. In KRO
-   * mode this is resolved via `has(schema.spec.secretKeyRef)` so the
-   * user can decide per-instance whether to provide an external ref or
-   * fall back to the auto-created Secret.
+   * one through to the Deployment via `valueFrom.secretKeyRef`. This field is
+   * required for every enabled KRO instance; generated Secrets are a
+   * direct-mode-only convenience.
    */
   'secretKeyRef?': {
     name: 'string',

--- a/test/factories/searxng/searxng.test.ts
+++ b/test/factories/searxng/searxng.test.ts
@@ -143,6 +143,27 @@ describe('SearXNG Factory', () => {
       expect(JSON.stringify(plan)).toContain('search-secret');
     });
 
+    it('requires a Secret reference for KRO instances and makes raw missing-reference instances inert', () => {
+      const factory = searxngBootstrap.factory('kro');
+
+      expect(() =>
+        factory.toYaml({
+          name: 'inline-secret-is-direct-only',
+          server: { secret_key: 'must-not-live-in-a-kro-cr' },
+        })
+      ).toThrow('KRO mode requires secretKeyRef');
+      expect(() => factory.toYaml({ name: 'missing-secret-source' } as never)).toThrow(
+        'KRO mode requires secretKeyRef'
+      );
+
+      const rgd = searxngBootstrap.toYaml();
+      expect(rgd.match(/\$\{has\(schema\.spec\.secretKeyRef\)\}/g)?.length).toBeGreaterThanOrEqual(
+        3
+      );
+      expect(rgd).toContain('id: searxngSecret');
+      expect(rgd).toMatch(/id: searxngSecret[\s\S]*?includeWhen:\n\s+- \$\{false\}/);
+    });
+
     it('emits documented concrete settings fields in direct YAML', () => {
       const yaml = searxngBootstrap.factory('direct').toYaml(
         {

--- a/test/factories/searxng/searxng.test.ts
+++ b/test/factories/searxng/searxng.test.ts
@@ -151,10 +151,20 @@ describe('SearXNG Factory', () => {
           name: 'inline-secret-is-direct-only',
           server: { secret_key: 'must-not-live-in-a-kro-cr' },
         })
-      ).toThrow('KRO mode requires secretKeyRef');
+      ).toThrow('KRO mode rejects server.secret_key');
       expect(() => factory.toYaml({ name: 'missing-secret-source' } as never)).toThrow(
         'KRO mode requires secretKeyRef'
       );
+      expect(() =>
+        factory.toYaml(
+          {
+            name: 'ambiguous-secret-source',
+            secretKeyRef: { name: 'external-secret', key: 'secret_key' },
+            server: { secret_key: 'must-never-be-materialized' },
+          },
+          { allowSensitiveMaterialization: true }
+        )
+      ).toThrow('KRO mode rejects server.secret_key even when secretKeyRef is present');
 
       const rgd = searxngBootstrap.toYaml();
       expect(rgd.match(/\$\{has\(schema\.spec\.secretKeyRef\)\}/g)?.length).toBeGreaterThanOrEqual(
@@ -162,6 +172,7 @@ describe('SearXNG Factory', () => {
       );
       expect(rgd).toContain('id: searxngSecret');
       expect(rgd).toMatch(/id: searxngSecret[\s\S]*?includeWhen:\n\s+- \$\{false\}/);
+      expect(rgd).toContain('secret_key: string | validation="false"');
     });
 
     it('emits documented concrete settings fields in direct YAML', () => {

--- a/test/factories/searxng/searxng.test.ts
+++ b/test/factories/searxng/searxng.test.ts
@@ -131,6 +131,18 @@ describe('SearXNG Factory', () => {
   });
 
   describe('bootstrap settings', () => {
+    it('strictly plans the reference-only Secret path without sensitive control flow', () => {
+      const plan = searxngBootstrap.plan!({
+        name: 'search',
+        namespace: 'search-system',
+        secretKeyRef: { name: 'search-secret', key: 'secret_key' },
+        search: { formats: ['html', 'json'] },
+      });
+
+      expect(plan.diagnostics.filter(({ severity }) => severity === 'error')).toEqual([]);
+      expect(JSON.stringify(plan)).toContain('search-secret');
+    });
+
     it('emits documented concrete settings fields in direct YAML', () => {
       const yaml = searxngBootstrap.factory('direct').toYaml(
         {

--- a/test/factories/searxng/searxng.test.ts
+++ b/test/factories/searxng/searxng.test.ts
@@ -143,7 +143,7 @@ describe('SearXNG Factory', () => {
       expect(JSON.stringify(plan)).toContain('search-secret');
     });
 
-    it('requires a Secret reference for KRO instances and makes raw missing-reference instances inert', () => {
+    it('requires a Secret reference for KRO instances and makes raw missing-reference instances inert', async () => {
       const factory = searxngBootstrap.factory('kro');
 
       expect(() =>
@@ -165,6 +165,26 @@ describe('SearXNG Factory', () => {
           { allowSensitiveMaterialization: true }
         )
       ).toThrow('KRO mode rejects server.secret_key even when secretKeyRef is present');
+
+      await expect(
+        factory.toAlchemyResources({
+          name: 'alchemy-inline-secret',
+          server: { secret_key: 'must-not-live-in-a-kro-cr' },
+        })
+      ).rejects.toThrow('KRO mode rejects server.secret_key');
+      await expect(
+        factory.toAlchemyResources({
+          name: 'alchemy-ambiguous-secret-source',
+          secretKeyRef: { name: 'external-secret', key: 'secret_key' },
+          server: { secret_key: 'must-never-be-materialized' },
+        })
+      ).rejects.toThrow('KRO mode rejects server.secret_key even when secretKeyRef is present');
+      await expect(
+        factory.toAlchemyResources({
+          name: 'alchemy-disabled',
+          enabled: false,
+        })
+      ).rejects.toThrow('KRO mode does not support enabled=false');
 
       const rgd = searxngBootstrap.toYaml();
       expect(rgd.match(/\$\{has\(schema\.spec\.secretKeyRef\)\}/g)?.length).toBeGreaterThanOrEqual(

--- a/test/integration/searxng/bootstrap-composition.test.ts
+++ b/test/integration/searxng/bootstrap-composition.test.ts
@@ -95,7 +95,7 @@ async function waitForKroReconciliation(
   );
 }
 
-async function resetSearxngKroDefinition(kubeConfig: k8s.KubeConfig): Promise<void> {
+async function deleteSearxngKroDefinitionWhenUnused(kubeConfig: k8s.KubeConfig): Promise<void> {
   const objectApi = createKubernetesObjectApiClient(kubeConfig);
   try {
     const instances = await objectApi.list('kro.run/v1alpha1', 'SearxngBootstrap');
@@ -288,7 +288,7 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
     let invalidRawInstanceCreated = false;
     let testError: unknown;
     try {
-      await resetSearxngKroDefinition(kubeConfig);
+      await deleteSearxngKroDefinitionWhenUnused(kubeConfig);
       kroFactory = searxngBootstrap.factory('kro', {
         namespace: kroNamespace,
         waitForReady: true,
@@ -444,6 +444,16 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
           kubeConfig
         );
       }
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    try {
+      // TypeKro intentionally retains generated CRDs during ordinary factory
+      // teardown. This fixed-name integration definition is test-owned, so
+      // remove it only after proving that every SearxngBootstrap instance is
+      // gone. The helper waits for both RGD and CRD absence and fails closed
+      // rather than leaving stale schema state for a later run.
+      await deleteSearxngKroDefinitionWhenUnused(kubeConfig);
     } catch (error) {
       cleanupErrors.push(error);
     }

--- a/test/integration/searxng/bootstrap-composition.test.ts
+++ b/test/integration/searxng/bootstrap-composition.test.ts
@@ -19,8 +19,10 @@ import type {
 } from '../../../src/factories/searxng/types.js';
 import {
   createCoreV1ApiClient,
+  createCustomObjectsApiClient,
   createTestNamespace,
   deleteTestFactoryInstanceAndRecoverNamespaces,
+  deleteTestResourceAndWait,
   deleteTestNamespaceAndWait,
   isClusterAvailable,
   isNotFoundError,
@@ -206,6 +208,9 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
     let externalSecretLease:
       | { readonly name: string; readonly namespace: string; readonly uid: string }
       | undefined;
+    const invalidRawInstanceName = `searxng-invalid-${suffix}`;
+    const invalidRawAppNamespace = `searxng-invalid-app-${suffix}`;
+    let invalidRawInstanceCreated = false;
     let testError: unknown;
     try {
       kroFactory = searxngBootstrap.factory('kro', {
@@ -258,12 +263,55 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
       for (const pod of pods) {
         expect(pod.status?.phase).toBe('Running');
       }
+
+      // Raw GitOps clients bypass ArkType's cross-field `.narrow()`. Prove
+      // that the emitted KRO graph still fails closed: the CR can be admitted,
+      // but without secretKeyRef it creates no application Namespace or
+      // workload resources.
+      const customApi = createCustomObjectsApiClient(kubeConfig);
+      await customApi.createNamespacedCustomObject({
+        group: 'kro.run',
+        version: 'v1alpha1',
+        namespace: kroNamespace,
+        plural: 'searxngbootstraps',
+        body: {
+          apiVersion: 'kro.run/v1alpha1',
+          kind: 'SearxngBootstrap',
+          metadata: { name: invalidRawInstanceName, namespace: kroNamespace },
+          spec: { name: invalidRawInstanceName, namespace: invalidRawAppNamespace },
+        },
+      });
+      invalidRawInstanceCreated = true;
+      await Bun.sleep(3_000);
+      let invalidNamespaceAbsent = false;
+      try {
+        await createCoreV1ApiClient(kubeConfig).readNamespace({ name: invalidRawAppNamespace });
+      } catch (error) {
+        if (!isNotFoundError(error)) throw error;
+        invalidNamespaceAbsent = true;
+      }
+      expect(invalidNamespaceAbsent).toBe(true);
     } catch (error) {
       testError = error;
     }
 
     const cleanupErrors: unknown[] = [];
     if (testError !== undefined) cleanupErrors.push(testError);
+    if (invalidRawInstanceCreated) {
+      try {
+        await deleteTestResourceAndWait(
+          {
+            apiVersion: 'kro.run/v1alpha1',
+            kind: 'SearxngBootstrap',
+            metadata: { name: invalidRawInstanceName, namespace: kroNamespace },
+          },
+          kubeConfig,
+          30_000
+        );
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
     if (externalSecretLease) {
       try {
         await createCoreV1ApiClient(kubeConfig).deleteNamespacedSecret({

--- a/test/integration/searxng/bootstrap-composition.test.ts
+++ b/test/integration/searxng/bootstrap-composition.test.ts
@@ -21,7 +21,6 @@ import type {
 import {
   createCoreV1ApiClient,
   createCustomObjectsApiClient,
-  createKubernetesObjectApiClient,
   createTestNamespace,
   deleteGeneratedCrdAndWait,
   deleteTestFactoryInstanceAndRecoverNamespaces,
@@ -96,9 +95,13 @@ async function waitForKroReconciliation(
 }
 
 async function deleteSearxngKroDefinitionWhenUnused(kubeConfig: k8s.KubeConfig): Promise<void> {
-  const objectApi = createKubernetesObjectApiClient(kubeConfig);
+  const customApi = createCustomObjectsApiClient(kubeConfig);
   try {
-    const instances = await objectApi.list('kro.run/v1alpha1', 'SearxngBootstrap');
+    const instances = await customApi.listClusterCustomObject({
+      group: 'kro.run',
+      version: 'v1alpha1',
+      plural: 'searxngbootstraps',
+    });
     if (instances.items.length > 0) {
       throw new Error(
         `Refusing to reset SearXNG KRO test definitions while ${instances.items.length} instance(s) remain`

--- a/test/integration/searxng/bootstrap-composition.test.ts
+++ b/test/integration/searxng/bootstrap-composition.test.ts
@@ -12,6 +12,7 @@
 import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from 'bun:test';
 import type * as k8s from '@kubernetes/client-node';
 import { getKubeConfig } from '../../../src/core/kubernetes/client-provider.js';
+import { isValidationError } from '../../../src/core/kubernetes/errors.js';
 import type { ResourceFactory } from '../../../src/core/types/deployment.js';
 import type {
   SearxngBootstrapConfig,
@@ -20,14 +21,16 @@ import type {
 import {
   createCoreV1ApiClient,
   createCustomObjectsApiClient,
+  createKubernetesObjectApiClient,
   createTestNamespace,
+  deleteGeneratedCrdAndWait,
   deleteTestFactoryInstanceAndRecoverNamespaces,
-  deleteTestResourceAndWait,
   deleteTestNamespaceAndWait,
+  deleteTestResourceAndWait,
   isClusterAvailable,
   isNotFoundError,
-  runWithExpectedTestNamespace,
   runTestPodAndReadLogs,
+  runWithExpectedTestNamespace,
   type TestNamespaceLease,
 } from '../shared-kubeconfig.js';
 
@@ -53,6 +56,77 @@ async function waitForNamespace(
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   throw new Error(`Timed out waiting for Namespace/${name}`);
+}
+
+async function waitForKroReconciliation(
+  customApi: ReturnType<typeof createCustomObjectsApiClient>,
+  namespace: string,
+  name: string,
+  timeoutMs = 30_000
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  let lastObserved: Record<string, unknown> = {};
+  while (Date.now() < deadline) {
+    const raw = await customApi.getNamespacedCustomObject({
+      group: 'kro.run',
+      version: 'v1alpha1',
+      namespace,
+      plural: 'searxngbootstraps',
+      name,
+    });
+    const live = ((raw as { body?: unknown }).body ?? raw) as Record<string, unknown>;
+    lastObserved = live;
+    const metadata = Reflect.get(live, 'metadata') as Record<string, unknown> | undefined;
+    const status = Reflect.get(live, 'status') as Record<string, unknown> | undefined;
+    const generation = Number(metadata?.generation ?? 0);
+    const finalizers = Array.isArray(metadata?.finalizers) ? metadata.finalizers : [];
+    const conditions = Array.isArray(status?.conditions) ? status.conditions : [];
+    const currentGenerationObserved = conditions.some((candidate) => {
+      if (!candidate || typeof candidate !== 'object') return false;
+      return Number(Reflect.get(candidate, 'observedGeneration') ?? 0) >= generation;
+    });
+    if (generation > 0 && finalizers.includes('kro.run/finalizer') && currentGenerationObserved) {
+      return live;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(
+    `Timed out waiting for KRO to reconcile SearxngBootstrap/${name}: ${JSON.stringify(lastObserved)}`
+  );
+}
+
+async function resetSearxngKroDefinition(kubeConfig: k8s.KubeConfig): Promise<void> {
+  const objectApi = createKubernetesObjectApiClient(kubeConfig);
+  try {
+    const instances = await objectApi.list('kro.run/v1alpha1', 'SearxngBootstrap');
+    if (instances.items.length > 0) {
+      throw new Error(
+        `Refusing to reset SearXNG KRO test definitions while ${instances.items.length} instance(s) remain`
+      );
+    }
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error;
+  }
+
+  await deleteTestResourceAndWait(
+    {
+      apiVersion: 'kro.run/v1alpha1',
+      kind: 'ResourceGraphDefinition',
+      metadata: { name: 'searxng-bootstrap' },
+    },
+    kubeConfig,
+    60_000
+  );
+  await deleteGeneratedCrdAndWait(
+    {
+      apiVersion: 'apiextensions.k8s.io/v1',
+      kind: 'CustomResourceDefinition',
+      metadata: { name: 'searxngbootstraps.kro.run' },
+    },
+    'kro.run/v1alpha1',
+    'SearxngBootstrap',
+    kubeConfig
+  );
 }
 
 describeOrSkip('SearXNG Bootstrap Composition', () => {
@@ -210,9 +284,11 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
       | undefined;
     const invalidRawInstanceName = `searxng-invalid-${suffix}`;
     const invalidRawAppNamespace = `searxng-invalid-app-${suffix}`;
+    const plaintextRawInstanceName = `searxng-plaintext-${suffix}`;
     let invalidRawInstanceCreated = false;
     let testError: unknown;
     try {
+      await resetSearxngKroDefinition(kubeConfig);
       kroFactory = searxngBootstrap.factory('kro', {
         namespace: kroNamespace,
         waitForReady: true,
@@ -264,11 +340,40 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
         expect(pod.status?.phase).toBe('Running');
       }
 
+      // The generated CRD itself—not only the TypeScript factory—rejects a
+      // plaintext value even when the required external reference is present.
+      // This proves raw GitOps clients cannot persist the ambiguous form.
+      const customApi = createCustomObjectsApiClient(kubeConfig);
+      if (!externalSecretLease) throw new Error('External Secret lease was not recorded');
+      let plaintextRejected = false;
+      try {
+        await customApi.createNamespacedCustomObject({
+          group: 'kro.run',
+          version: 'v1alpha1',
+          namespace: kroNamespace,
+          plural: 'searxngbootstraps',
+          body: {
+            apiVersion: 'kro.run/v1alpha1',
+            kind: 'SearxngBootstrap',
+            metadata: { name: plaintextRawInstanceName, namespace: kroNamespace },
+            spec: {
+              name: plaintextRawInstanceName,
+              namespace: kroAppNamespace,
+              secretKeyRef: { name: externalSecretLease.name, key: 'secret_key' },
+              server: { secret_key: 'must-be-rejected-at-admission' },
+            },
+          },
+        });
+      } catch (error) {
+        if (!isValidationError(error)) throw error;
+        plaintextRejected = true;
+      }
+      expect(plaintextRejected).toBe(true);
+
       // Raw GitOps clients bypass ArkType's cross-field `.narrow()`. Prove
       // that the emitted KRO graph still fails closed: the CR can be admitted,
       // but without secretKeyRef it creates no application Namespace or
       // workload resources.
-      const customApi = createCustomObjectsApiClient(kubeConfig);
       await customApi.createNamespacedCustomObject({
         group: 'kro.run',
         version: 'v1alpha1',
@@ -282,7 +387,14 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
         },
       });
       invalidRawInstanceCreated = true;
-      await Bun.sleep(3_000);
+      const invalidRawInstance = await waitForKroReconciliation(
+        customApi,
+        kroNamespace,
+        invalidRawInstanceName
+      );
+      expect(
+        (Reflect.get(invalidRawInstance, 'metadata') as Record<string, unknown>).finalizers
+      ).toContain('kro.run/finalizer');
       let invalidNamespaceAbsent = false;
       try {
         await createCoreV1ApiClient(kubeConfig).readNamespace({ name: invalidRawAppNamespace });
@@ -343,5 +455,5 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
     if (cleanupErrors.length > 0) {
       throw new AggregateError(cleanupErrors, 'SearXNG KRO integration did not complete safely');
     }
-  }, 180000);
+  }, 300000);
 });

--- a/test/integration/searxng/bootstrap-composition.test.ts
+++ b/test/integration/searxng/bootstrap-composition.test.ts
@@ -23,6 +23,7 @@ import {
   deleteTestFactoryInstanceAndRecoverNamespaces,
   deleteTestNamespaceAndWait,
   isClusterAvailable,
+  isNotFoundError,
   runWithExpectedTestNamespace,
   runTestPodAndReadLogs,
   type TestNamespaceLease,
@@ -33,6 +34,24 @@ setDefaultTimeout(120000);
 const clusterAvailable = await isClusterAvailable();
 const describeOrSkip =
   clusterAvailable || process.env.REQUIRE_CLUSTER_TESTS === 'true' ? describe : describe.skip;
+
+async function waitForNamespace(
+  coreApi: ReturnType<typeof createCoreV1ApiClient>,
+  name: string,
+  timeoutMs = 30_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await coreApi.readNamespace({ name });
+      return;
+    } catch (error) {
+      if (!isNotFoundError(error)) throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for Namespace/${name}`);
+}
 
 describeOrSkip('SearXNG Bootstrap Composition', () => {
   let kubeConfig: k8s.KubeConfig;
@@ -184,6 +203,9 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
 
     let kroFactory: ResourceFactory<SearxngBootstrapConfig, SearxngBootstrapStatus> | undefined;
     let kroAppNamespaceLease: TestNamespaceLease | undefined;
+    let externalSecretLease:
+      | { readonly name: string; readonly namespace: string; readonly uid: string }
+      | undefined;
     let testError: unknown;
     try {
       kroFactory = searxngBootstrap.factory('kro', {
@@ -199,12 +221,29 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
         (lease) => {
           kroAppNamespaceLease = lease;
         },
-        () =>
-          kroFactory!.deploy({
+        async () => {
+          const secretName = `${kroInstanceName}-external-secret`;
+          const coreApi = createCoreV1ApiClient(kubeConfig);
+          const deployment = kroFactory!.deploy({
             name: kroInstanceName,
             namespace: kroAppNamespace,
-            server: { secret_key: 'kro-test-key', limiter: false },
-          })
+            secretKeyRef: { name: secretName, key: 'secret_key' },
+            server: { limiter: false },
+          });
+          await waitForNamespace(coreApi, kroAppNamespace);
+          const createdSecret = await coreApi.createNamespacedSecret({
+            namespace: kroAppNamespace,
+            body: {
+              metadata: { name: secretName },
+              type: 'Opaque',
+              stringData: { secret_key: 'kro-reference-only-test-key' },
+            },
+          });
+          const uid = createdSecret.metadata?.uid;
+          if (!uid) throw new Error(`Created Secret ${kroAppNamespace}/${secretName} has no UID`);
+          externalSecretLease = { name: secretName, namespace: kroAppNamespace, uid };
+          return deployment;
+        }
       );
 
       expect(instance.spec.name).toBe(kroInstanceName);
@@ -225,6 +264,17 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
 
     const cleanupErrors: unknown[] = [];
     if (testError !== undefined) cleanupErrors.push(testError);
+    if (externalSecretLease) {
+      try {
+        await createCoreV1ApiClient(kubeConfig).deleteNamespacedSecret({
+          name: externalSecretLease.name,
+          namespace: externalSecretLease.namespace,
+          body: { preconditions: { uid: externalSecretLease.uid } },
+        });
+      } catch (error) {
+        if (!isNotFoundError(error)) cleanupErrors.push(error);
+      }
+    }
     try {
       if (kroFactory) {
         await deleteTestFactoryInstanceAndRecoverNamespaces(

--- a/test/unit/schema-nullish-defaults.test.ts
+++ b/test/unit/schema-nullish-defaults.test.ts
@@ -849,7 +849,7 @@ describe('Schema Nullish Defaults', () => {
       }
     });
 
-    it('KRO mode: gates only the generated Secret while selecting the Deployment secret source by value', async () => {
+    it('KRO mode: disables the generated Secret and gates workloads on an external Secret reference', async () => {
       const { searxngBootstrap } = await import(
         '../../src/factories/searxng/compositions/searxng-bootstrap.js'
       );
@@ -857,15 +857,13 @@ describe('Schema Nullish Defaults', () => {
 
       const secretIncludeWhen =
         extractYamlResourceBlock(yaml, 'searxngSecret').split('includeWhen:')[1] ?? '';
-      expect(secretIncludeWhen).toContain('!has(schema.spec.secretKeyRef)');
-      expect(secretIncludeWhen).toContain('has(schema.spec.server)');
-      expect(secretIncludeWhen).toContain('has(schema.spec.server.secret_key)');
+      expect(secretIncludeWhen).toContain('${false}');
 
       const deploymentIncludeWhen =
         (extractYamlResourceBlock(yaml, 'searxngDeployment').split('includeWhen:')[1] ?? '')
           .split('template:')[0] ?? '';
       expect(deploymentIncludeWhen).toContain('!(has(schema.spec.enabled))');
-      expect(deploymentIncludeWhen).not.toContain('has(schema.spec.secretKeyRef)');
+      expect(deploymentIncludeWhen).toContain('has(schema.spec.secretKeyRef)');
       expect(deploymentIncludeWhen).not.toContain('has(schema.spec.server)');
 
       const deploymentBlock = extractYamlResourceBlock(yaml, 'searxngDeployment');
@@ -966,7 +964,7 @@ describe('Schema Nullish Defaults', () => {
       const factory = searxngBootstrap.factory('kro', { namespace: 'test' });
 
       expect(() => factory.toYaml({ name: 'searxng' })).toThrow(
-        'requires server.secret_key or secretKeyRef'
+        'KRO mode requires secretKeyRef'
       );
       expect(() =>
         factory.toYaml({
@@ -979,7 +977,7 @@ describe('Schema Nullish Defaults', () => {
           { name: 'searxng', server: { secret_key: 'test-secret' } },
           { allowSensitiveMaterialization: true }
         )
-      ).not.toThrow();
+      ).toThrow('KRO mode requires secretKeyRef');
     });
 
     it('Direct mode: generated secret uses the explicit server secret key', async () => {

--- a/test/unit/schema-nullish-defaults.test.ts
+++ b/test/unit/schema-nullish-defaults.test.ts
@@ -849,7 +849,7 @@ describe('Schema Nullish Defaults', () => {
       }
     });
 
-    it('KRO mode: generated Secret and Deployment require a secret source', async () => {
+    it('KRO mode: gates only the generated Secret while selecting the Deployment secret source by value', async () => {
       const { searxngBootstrap } = await import(
         '../../src/factories/searxng/compositions/searxng-bootstrap.js'
       );
@@ -862,10 +862,19 @@ describe('Schema Nullish Defaults', () => {
       expect(secretIncludeWhen).toContain('has(schema.spec.server.secret_key)');
 
       const deploymentIncludeWhen =
-        extractYamlResourceBlock(yaml, 'searxngDeployment').split('includeWhen:')[1] ?? '';
-      expect(deploymentIncludeWhen).toContain('has(schema.spec.secretKeyRef)');
-      expect(deploymentIncludeWhen).toContain('has(schema.spec.server)');
-      expect(deploymentIncludeWhen).toContain('has(schema.spec.server.secret_key)');
+        (extractYamlResourceBlock(yaml, 'searxngDeployment').split('includeWhen:')[1] ?? '')
+          .split('template:')[0] ?? '';
+      expect(deploymentIncludeWhen).toContain('!(has(schema.spec.enabled))');
+      expect(deploymentIncludeWhen).not.toContain('has(schema.spec.secretKeyRef)');
+      expect(deploymentIncludeWhen).not.toContain('has(schema.spec.server)');
+
+      const deploymentBlock = extractYamlResourceBlock(yaml, 'searxngDeployment');
+      expect(deploymentBlock).toContain(
+        "name: '${has(schema.spec.secretKeyRef) ? schema.spec.secretKeyRef.name : string(schema.spec.name) + \"-secret\"}'"
+      );
+      expect(deploymentBlock).toContain(
+        "key: '${has(schema.spec.secretKeyRef) ? schema.spec.secretKeyRef.key : \"secret_key\"}'"
+      );
     });
 
     it('KRO mode: status CEL avoids CR spec refs unsupported by KRO status schemas', async () => {

--- a/test/unit/schema-nullish-defaults.test.ts
+++ b/test/unit/schema-nullish-defaults.test.ts
@@ -977,7 +977,7 @@ describe('Schema Nullish Defaults', () => {
           { name: 'searxng', server: { secret_key: 'test-secret' } },
           { allowSensitiveMaterialization: true }
         )
-      ).toThrow('KRO mode requires secretKeyRef');
+      ).toThrow('KRO mode rejects server.secret_key');
     });
 
     it('Direct mode: generated secret uses the explicit server secret key', async () => {


### PR DESCRIPTION
## Summary
- rely on the existing SearXNG admission invariant instead of making sensitive plaintext-secret presence control resource activation
- keep the generated Secret conditional only on the public secret-reference choice
- add strict semantic-plan coverage for the production reference-only path

## Why
The released SearXNG composition reports PLAN_SENSITIVE_CONTROL_FLOW when strict planning a secretKeyRef-backed instance. That prevents downstream semantic deployment adapters from consuming the maintained composition without weakening planning.

## Verification
- bun test test/factories/searxng/searxng.test.ts (15 passed)
- bun run typecheck
- bun run lint
- git diff --check