### PR TITLE
chore: release v0.33.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.33.8",
+  "version": "0.33.9",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

- release the ClickStack authenticated OTLP ingestion fix from #165
- release the SearXNG external-secret planning fix from #166
- bump package version to 0.33.9

## Verification

- bun run test (5,338 passed, 0 failed)
- bun run build
- bun run check:effect-cohort
- bun run test:integration:yaml
- bun run test:packed-imports

## Live verification note

The merged-tree OrbStack rerun could not start because the local OrbStack VM is currently stopped and exits during startup. Both source PRs passed their required GitHub checks; no live product assertion failed in this release branch.