### PR TITLE
fix(searxng): treat supplied namespaces as external

### DIFF
--- a/docs/api/searxng/index.md
+++ b/docs/api/searxng/index.md
@@ -40,6 +40,9 @@ const factory = searxngBootstrap.factory('direct', {
 
 await factory.deploy({
   name: 'searxng',
+  // Passing namespace uses this externally owned namespace. Omit it to let
+  // TypeKro create and own the default `searxng` namespace.
+  namespace: 'search',
   server: { secret_key: process.env.SEARXNG_SECRET_KEY!, limiter: false },
   // search.formats only takes effect in direct mode — see "Known Limitations" above
   search: { formats: ['html', 'json'] },
@@ -50,7 +53,7 @@ await factory.deploy({
 
 | Resource | Name | Type |
 |----------|------|------|
-| Namespace | `searxng` | Namespace |
+| Namespace | `searxng` | Namespace, created only when `namespace` is omitted |
 | Settings | `{name}-config` | ConfigMap |
 | Secret key | `{name}-secret` | Secret, created from inline `server.secret_key` in direct mode only |
 | Search engine | `{name}` | Deployment |
@@ -63,7 +66,7 @@ await factory.deploy({
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `name` | `string` | required | Instance name |
-| `namespace` | `string` | `'searxng'` | Target namespace |
+| `namespace` | `string` | — | Existing target namespace. Omit it to create and own the default `searxng` namespace. A supplied namespace is never deleted with the installation. |
 | `enabled` | `boolean` | `true` | Direct-mode only. When `false`, direct mode creates no SearXNG resources. KRO mode rejects disabled instances because status depends on the Deployment; omit the KRO instance instead. |
 | `image` | `string` | `'searxng/searxng:2026.3.29-7ac4ff39f'` | Container image (pinned to avoid breaking config changes between releases) |
 | `replicas` | `number` | `1` | Number of replicas |

--- a/src/core/expressions/composition/composition-analyzer-helpers.ts
+++ b/src/core/expressions/composition/composition-analyzer-helpers.ts
@@ -63,6 +63,28 @@ const KNOWN_FACTORY_NAMES = new Set([
   'ResourceQuota',
 ]);
 
+function pascalCaseFactoryName(name: string): string {
+  return name.length === 0 ? name : `${name[0]?.toUpperCase()}${name.slice(1)}`;
+}
+
+/**
+ * Factory modules conventionally export lower-camel functions (`namespace`,
+ * `configMap`, `deployment`) while the registry is keyed by the Kubernetes kind
+ * (`Namespace`, `ConfigMap`, `Deployment`). Treat those two spellings as the
+ * same factory identity during source analysis. Without this normalization an
+ * untaken native-JavaScript branch containing a lower-camel factory is invisible
+ * to differential capture and its resource silently disappears from KRO mode.
+ */
+function isKnownFactoryName(name: string): boolean {
+  const pascalName = pascalCaseFactoryName(name);
+  return (
+    isKnownFactory(name) ||
+    isKnownFactory(pascalName) ||
+    KNOWN_FACTORY_NAMES.has(name) ||
+    KNOWN_FACTORY_NAMES.has(pascalName)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Source extraction
 // ---------------------------------------------------------------------------
@@ -95,13 +117,13 @@ export function isFactoryCall(node: ASTNode): node is CallExpression {
   const callee = call.callee;
   if (callee.type === 'Identifier') {
     const name = (callee as Identifier).name;
-    return isKnownFactory(name) || KNOWN_FACTORY_NAMES.has(name);
+    return isKnownFactoryName(name);
   }
   if (callee.type === 'MemberExpression' && !callee.computed) {
     const property = callee.property as ASTNode | undefined;
     if (property?.type === 'Identifier') {
       const name = (property as Identifier).name;
-      return isKnownFactory(name) || KNOWN_FACTORY_NAMES.has(name);
+      return isKnownFactoryName(name);
     }
   }
   return false;

--- a/src/core/serialization/core.ts
+++ b/src/core/serialization/core.ts
@@ -168,7 +168,11 @@ function createStubResource(
   factoryName: string,
   resourceId: string
 ): Record<string, unknown> | null {
-  const kindInfo = getKindInfo(factoryName);
+  const pascalFactoryName =
+    factoryName.length === 0
+      ? factoryName
+      : `${factoryName[0]?.toUpperCase()}${factoryName.slice(1)}`;
+  const kindInfo = getKindInfo(factoryName) ?? getKindInfo(pascalFactoryName);
   if (!kindInfo) return null;
 
   const stub: Record<string, unknown> = {

--- a/src/core/serialization/core.ts
+++ b/src/core/serialization/core.ts
@@ -168,11 +168,13 @@ function createStubResource(
   factoryName: string,
   resourceId: string
 ): Record<string, unknown> | null {
-  const pascalFactoryName =
-    factoryName.length === 0
-      ? factoryName
-      : `${factoryName[0]?.toUpperCase()}${factoryName.slice(1)}`;
-  const kindInfo = getKindInfo(factoryName) ?? getKindInfo(pascalFactoryName);
+  // Lower-camel factory aliases are intentionally excluded here. The AST
+  // analyzer may use them to trigger a counterfactual branch capture, but a
+  // captured resource is admitted only when that execution actually registers
+  // it in the composition context. Fabricating a stub from a name such as
+  // `service(...)` would otherwise turn an unrelated local helper into a
+  // phantom Kubernetes Service.
+  const kindInfo = getKindInfo(factoryName);
   if (!kindInfo) return null;
 
   const stub: Record<string, unknown> = {

--- a/src/core/serialization/core.ts
+++ b/src/core/serialization/core.ts
@@ -962,7 +962,9 @@ function captureHybridRunResources(
       overrideValues
     );
 
-    const tempCtx = createCompositionContext('hybrid-capture');
+    const tempCtx = createCompositionContext('hybrid-capture', {
+      suppressResourceDiagnostics: true,
+    });
     runWithCompositionContext(tempCtx, () => {
       compositionFn(hybridSpec);
     });
@@ -1127,7 +1129,9 @@ function captureAnalyzedBranchResource(
       new Set(overrides.keys()),
       overrides
     );
-    const context = createCompositionContext(`analyzed-branch:${resourceId}`);
+    const context = createCompositionContext(`analyzed-branch:${resourceId}`, {
+      suppressResourceDiagnostics: true,
+    });
     runWithCompositionContext(context, () => compositionFn(constrainedSpec));
     return context.resources[resourceId] as Enhanced<unknown, unknown> | undefined;
   } catch {
@@ -1367,6 +1371,7 @@ function runResourceStatusBranch(
 ) {
   const branchCtx = createCompositionContext('resource-status-branch', {
     isReExecution: true,
+    suppressResourceDiagnostics: true,
   });
   branchCtx.liveStatusMap = createResourceStatusBranchMap(analysis, ternary, desiredConditionValue);
 

--- a/src/factories/searxng/compositions/searxng-bootstrap.ts
+++ b/src/factories/searxng/compositions/searxng-bootstrap.ts
@@ -1,7 +1,7 @@
 /**
  * SearXNG Bootstrap Composition
  *
- * Deploys a complete SearXNG instance: Namespace + ConfigMap + Deployment + Service.
+ * Deploys a complete SearXNG instance: optional Namespace + ConfigMap + Deployment + Service.
  * Settings are built from typed spec fields — no proxy objects pass through to YAML.
  *
  * @example
@@ -173,20 +173,24 @@ const searxngBootstrapComposition = kubernetesComposition(
 
     if (spec.enabled !== false) {
       // ── Namespace ──────────────────────────────────────────────────────
-
-      const _ns = namespace({
-        metadata: {
-          name: resolvedNamespace,
-          labels: {
-            'app.kubernetes.io/name': 'searxng',
-            'app.kubernetes.io/instance': spec.name,
-            'app.kubernetes.io/managed-by': 'typekro',
+      // Omitting namespace requests the TypeKro-owned default. Supplying one
+      // is an explicit external-ownership boundary, which is required when an
+      // existing Secret or another controller already owns the namespace.
+      if (!spec.namespace) {
+        const _ns = namespace({
+          metadata: {
+            name: resolvedNamespace,
+            labels: {
+              'app.kubernetes.io/name': 'searxng',
+              'app.kubernetes.io/instance': spec.name,
+              'app.kubernetes.io/managed-by': 'typekro',
+            },
           },
-        },
-        id: 'searxngNamespace',
-      });
-      if (isGraphMode) {
-        appendIncludeWhen(_ns, [enabledWhen, credentialSourcePresentWhen]);
+          id: 'searxngNamespace',
+        });
+        if (isGraphMode) {
+          appendIncludeWhen(_ns, [enabledWhen, credentialSourcePresentWhen]);
+        }
       }
 
       // ── Settings ConfigMap ─────────────────────────────────────────────

--- a/src/factories/searxng/index.ts
+++ b/src/factories/searxng/index.ts
@@ -15,6 +15,9 @@
  *
  * await factory.deploy({
  *   name: 'searxng',
+ *   // Passing namespace targets an externally owned namespace. Omit it to
+ *   // let TypeKro create and own the default `searxng` namespace.
+ *   namespace: 'search',
  *   search: { formats: ['html', 'json'] },
  *   server: { limiter: false, secret_key: 'change-me' },
  * });

--- a/src/factories/searxng/types.ts
+++ b/src/factories/searxng/types.ts
@@ -137,7 +137,7 @@ export interface SearxngStatus {
 const SearxngBootstrapBaseConfigSchema = type({
   /** Instance name. */
   name: 'string',
-  /** Target namespace (default: 'searxng'). */
+  /** Existing target namespace. Omit to create and own `searxng`. */
   'namespace?': 'string',
   /** Whether to create SearXNG resources (default: true). */
   'enabled?': 'boolean',

--- a/test/core/kro-instance-namespace-lifecycle.test.ts
+++ b/test/core/kro-instance-namespace-lifecycle.test.ts
@@ -129,15 +129,6 @@ describe('newly-covered built-ins hoist the owned namespace without the removed 
         },
       },
       {
-        name: 'searxngBootstrap',
-        factory: () => searxngBootstrap.factory('kro', { namespace: 'searxng' }),
-        spec: {
-          name: 'searxng',
-          namespace: 'searxng',
-          secretKeyRef: { name: 'searxng-secret', key: 'secret_key' },
-        },
-      },
-      {
         name: 'caddyIngress',
         factory: () => caddyIngress.factory('kro', { namespace: 'caddy' }),
         spec: { name: 'caddy', namespace: 'caddy', caddyfile: ':80 {\n  respond "ok"\n}\n' },
@@ -160,4 +151,22 @@ describe('newly-covered built-ins hoist the owned namespace without the removed 
       expect(yaml).toContain('argocd.argoproj.io/sync-options: Prune=false,Delete=false');
     });
   }
+
+  it('searxngBootstrap hoists the omitted default but treats a supplied namespace as external', () => {
+    const factory = searxngBootstrap.factory('kro', { namespace: 'typekro-system' });
+    const owned = factory.toYaml({
+      name: 'owned-searxng',
+      secretKeyRef: { name: 'searxng-secret', key: 'secret_key' },
+    });
+    const external = factory.toYaml({
+      name: 'external-searxng',
+      namespace: 'shared-search',
+      secretKeyRef: { name: 'searxng-secret', key: 'secret_key' },
+    });
+
+    expect(owned).toContain('typekro.io/kro-instance-namespace');
+    expect(owned).toContain('typekro.io/hoisted-namespaces: \'["searxng"]\'');
+    expect(external).toContain("typekro.io/hoisted-namespaces: '[]'");
+    expect(external).not.toContain('typekro.io/kro-instance-namespace');
+  });
 });

--- a/test/factories/searxng/searxng.test.ts
+++ b/test/factories/searxng/searxng.test.ts
@@ -131,6 +131,47 @@ describe('SearXNG Factory', () => {
   });
 
   describe('bootstrap settings', () => {
+    it('owns only the omitted default namespace and treats a supplied namespace as external', async () => {
+      const directFactory = searxngBootstrap.factory('direct');
+      const owned = directFactory.createResourceGraphForInstance({
+        name: 'owned-search',
+        server: { secret_key: 'owned-test-secret' },
+      });
+      const external = directFactory.createResourceGraphForInstance({
+        name: 'external-search',
+        namespace: 'shared-search',
+        secretKeyRef: { name: 'search-secret', key: 'secret_key' },
+      });
+
+      expect(owned.resources.map(({ manifest }) => manifest.kind)).toContain('Namespace');
+      expect(external.resources.map(({ manifest }) => manifest.kind)).not.toContain('Namespace');
+      expect(
+        external.resources
+          .filter(({ manifest }) => manifest.kind !== 'Namespace')
+          .every(({ manifest }) => manifest.metadata?.namespace === 'shared-search')
+      ).toBe(true);
+
+      const kroFactory = searxngBootstrap.factory('kro');
+      const externalDeclarations = await kroFactory.toAlchemyResources({
+        name: 'external-search',
+        namespace: 'shared-search',
+        secretKeyRef: { name: 'search-secret', key: 'secret_key' },
+      });
+      expect(
+        externalDeclarations.some(
+          (declaration) => declaration.props.resource.kind === 'Namespace'
+        )
+      ).toBe(false);
+
+      const ownedDeclarations = await kroFactory.toAlchemyResources({
+        name: 'owned-search',
+        secretKeyRef: { name: 'search-secret', key: 'secret_key' },
+      });
+      expect(
+        ownedDeclarations.some((declaration) => declaration.props.resource.kind === 'Namespace')
+      ).toBe(true);
+    });
+
     it('strictly plans the reference-only Secret path without sensitive control flow', () => {
       const plan = searxngBootstrap.plan!({
         name: 'search',

--- a/test/integration/searxng/bootstrap-composition.test.ts
+++ b/test/integration/searxng/bootstrap-composition.test.ts
@@ -2,7 +2,7 @@
  * SearXNG Bootstrap Composition Integration Tests
  *
  * Deploys a SearXNG instance to the cluster and verifies:
- * - All resources deploy successfully (Namespace, ConfigMap, Deployment, Service)
+ * - All workload resources deploy successfully into an externally owned Namespace
  * - Health endpoint responds
  * - JSON API works when enabled
  * - Status fields are correct
@@ -19,6 +19,7 @@ import type {
   SearxngBootstrapStatus,
 } from '../../../src/factories/searxng/types.js';
 import {
+  createAppsV1ApiClient,
   createCoreV1ApiClient,
   createCustomObjectsApiClient,
   createTestNamespace,
@@ -29,7 +30,6 @@ import {
   isClusterAvailable,
   isNotFoundError,
   runTestPodAndReadLogs,
-  runWithExpectedTestNamespace,
   type TestNamespaceLease,
 } from '../shared-kubeconfig.js';
 
@@ -146,6 +146,7 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
   beforeAll(async () => {
     kubeConfig = getKubeConfig({ skipTLSVerify: true });
     factoryNamespaceLease = await createTestNamespace(factoryNamespace, kubeConfig);
+    appNamespaceLease = await createTestNamespace(appNamespace, kubeConfig);
   });
 
   afterAll(async () => {
@@ -155,11 +156,18 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
         await deleteTestFactoryInstanceAndRecoverNamespaces(
           factory,
           directInstanceName,
-          appNamespaceLease ? [appNamespaceLease] : [],
+          [],
           kubeConfig,
           30_000,
           { scopes: ['cluster'] }
         );
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    if (appNamespaceLease) {
+      try {
+        await deleteTestNamespaceAndWait(appNamespaceLease, kubeConfig);
       } catch (error) {
         failures.push(error);
       }
@@ -186,22 +194,14 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
       kubeConfig,
     });
 
-    const instance = await runWithExpectedTestNamespace(
-      appNamespace,
-      kubeConfig,
-      (lease) => {
-        appNamespaceLease = lease;
+    const instance = await factory.deploy({
+      name: directInstanceName,
+      namespace: appNamespace,
+      server: {
+        secret_key: 'test-integration-key-not-for-production',
+        limiter: false,
       },
-      () =>
-        factory!.deploy({
-          name: directInstanceName,
-          namespace: appNamespace,
-          server: {
-            secret_key: 'test-integration-key-not-for-production',
-            limiter: false,
-          },
-        })
-    );
+    });
 
     // Status assertions
     expect(instance.spec.name).toBe(directInstanceName);
@@ -279,18 +279,20 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
     const kroNamespace = `typekro-kro-searxng-${suffix}`;
     const kroAppNamespace = `searxng-kro-${suffix}`;
     const kroNamespaceLease = await createTestNamespace(kroNamespace, kubeConfig);
+    const kroAppNamespaceLease = await createTestNamespace(kroAppNamespace, kubeConfig);
 
     let kroFactory: ResourceFactory<SearxngBootstrapConfig, SearxngBootstrapStatus> | undefined;
-    let kroAppNamespaceLease: TestNamespaceLease | undefined;
     let externalSecretLease:
       | { readonly name: string; readonly namespace: string; readonly uid: string }
       | undefined;
     const invalidRawInstanceName = `searxng-invalid-${suffix}`;
     const invalidRawAppNamespace = `searxng-invalid-app-${suffix}`;
     const plaintextRawInstanceName = `searxng-plaintext-${suffix}`;
+    let invalidRawAppNamespaceLease: TestNamespaceLease | undefined;
     let invalidRawInstanceCreated = false;
     let testError: unknown;
     try {
+      invalidRawAppNamespaceLease = await createTestNamespace(invalidRawAppNamespace, kubeConfig);
       await deleteSearxngKroDefinitionWhenUnused(kubeConfig);
       kroFactory = searxngBootstrap.factory('kro', {
         namespace: kroNamespace,
@@ -299,36 +301,25 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
         kubeConfig,
       });
 
-      const instance = await runWithExpectedTestNamespace(
-        kroAppNamespace,
-        kubeConfig,
-        (lease) => {
-          kroAppNamespaceLease = lease;
+      const secretName = `${kroInstanceName}-external-secret`;
+      const coreApi = createCoreV1ApiClient(kubeConfig);
+      const createdSecret = await coreApi.createNamespacedSecret({
+        namespace: kroAppNamespace,
+        body: {
+          metadata: { name: secretName },
+          type: 'Opaque',
+          stringData: { secret_key: 'kro-reference-only-test-key' },
         },
-        async () => {
-          const secretName = `${kroInstanceName}-external-secret`;
-          const coreApi = createCoreV1ApiClient(kubeConfig);
-          const deployment = kroFactory!.deploy({
-            name: kroInstanceName,
-            namespace: kroAppNamespace,
-            secretKeyRef: { name: secretName, key: 'secret_key' },
-            server: { limiter: false },
-          });
-          await waitForNamespace(coreApi, kroAppNamespace);
-          const createdSecret = await coreApi.createNamespacedSecret({
-            namespace: kroAppNamespace,
-            body: {
-              metadata: { name: secretName },
-              type: 'Opaque',
-              stringData: { secret_key: 'kro-reference-only-test-key' },
-            },
-          });
-          const uid = createdSecret.metadata?.uid;
-          if (!uid) throw new Error(`Created Secret ${kroAppNamespace}/${secretName} has no UID`);
-          externalSecretLease = { name: secretName, namespace: kroAppNamespace, uid };
-          return deployment;
-        }
-      );
+      });
+      const uid = createdSecret.metadata?.uid;
+      if (!uid) throw new Error(`Created Secret ${kroAppNamespace}/${secretName} has no UID`);
+      externalSecretLease = { name: secretName, namespace: kroAppNamespace, uid };
+      const instance = await kroFactory.deploy({
+        name: kroInstanceName,
+        namespace: kroAppNamespace,
+        secretKeyRef: { name: secretName, key: 'secret_key' },
+        server: { limiter: false },
+      });
 
       expect(instance.spec.name).toBe(kroInstanceName);
       expect(instance.status.ready).toBe(true);
@@ -375,8 +366,8 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
 
       // Raw GitOps clients bypass ArkType's cross-field `.narrow()`. Prove
       // that the emitted KRO graph still fails closed: the CR can be admitted,
-      // but without secretKeyRef it creates no application Namespace or
-      // workload resources.
+      // but without secretKeyRef it creates no workload resources in the
+      // explicitly pre-existing external Namespace.
       await customApi.createNamespacedCustomObject({
         group: 'kro.run',
         version: 'v1alpha1',
@@ -398,14 +389,33 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
       expect(
         (Reflect.get(invalidRawInstance, 'metadata') as Record<string, unknown>).finalizers
       ).toContain('kro.run/finalizer');
-      let invalidNamespaceAbsent = false;
-      try {
-        await createCoreV1ApiClient(kubeConfig).readNamespace({ name: invalidRawAppNamespace });
-      } catch (error) {
-        if (!isNotFoundError(error)) throw error;
-        invalidNamespaceAbsent = true;
-      }
-      expect(invalidNamespaceAbsent).toBe(true);
+      await waitForNamespace(createCoreV1ApiClient(kubeConfig), invalidRawAppNamespace);
+      const invalidCoreApi = createCoreV1ApiClient(kubeConfig);
+      const invalidAppsApi = createAppsV1ApiClient(kubeConfig);
+      expect(
+        (
+          await invalidCoreApi.listNamespacedConfigMap({
+            namespace: invalidRawAppNamespace,
+            fieldSelector: `metadata.name=${invalidRawInstanceName}-config`,
+          })
+        ).items
+      ).toHaveLength(0);
+      expect(
+        (
+          await invalidCoreApi.listNamespacedService({
+            namespace: invalidRawAppNamespace,
+            fieldSelector: `metadata.name=${invalidRawInstanceName}`,
+          })
+        ).items
+      ).toHaveLength(0);
+      expect(
+        (
+          await invalidAppsApi.listNamespacedDeployment({
+            namespace: invalidRawAppNamespace,
+            fieldSelector: `metadata.name=${invalidRawInstanceName}`,
+          })
+        ).items
+      ).toHaveLength(0);
     } catch (error) {
       testError = error;
     }
@@ -427,6 +437,19 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
         cleanupErrors.push(error);
       }
     }
+    try {
+      if (kroFactory) {
+        await deleteTestFactoryInstanceAndRecoverNamespaces(
+          kroFactory,
+          kroInstanceName,
+          [],
+          kubeConfig
+        );
+        await waitForNamespace(createCoreV1ApiClient(kubeConfig), kroAppNamespace);
+      }
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
     if (externalSecretLease) {
       try {
         await createCoreV1ApiClient(kubeConfig).deleteNamespacedSecret({
@@ -439,18 +462,6 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
       }
     }
     try {
-      if (kroFactory) {
-        await deleteTestFactoryInstanceAndRecoverNamespaces(
-          kroFactory,
-          kroInstanceName,
-          kroAppNamespaceLease ? [kroAppNamespaceLease] : [],
-          kubeConfig
-        );
-      }
-    } catch (error) {
-      cleanupErrors.push(error);
-    }
-    try {
       // TypeKro intentionally retains generated CRDs during ordinary factory
       // teardown. This fixed-name integration definition is test-owned, so
       // remove it only after proving that every SearxngBootstrap instance is
@@ -459,6 +470,18 @@ describeOrSkip('SearXNG Bootstrap Composition', () => {
       await deleteSearxngKroDefinitionWhenUnused(kubeConfig);
     } catch (error) {
       cleanupErrors.push(error);
+    }
+    try {
+      await deleteTestNamespaceAndWait(kroAppNamespaceLease, kubeConfig);
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (invalidRawAppNamespaceLease) {
+      try {
+        await deleteTestNamespaceAndWait(invalidRawAppNamespaceLease, kubeConfig);
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
     }
     try {
       await deleteTestNamespaceAndWait(kroNamespaceLease, kubeConfig);

--- a/test/unit/analysis-resource-diagnostics.test.ts
+++ b/test/unit/analysis-resource-diagnostics.test.ts
@@ -26,4 +26,23 @@ describe('analysis-only resource diagnostics', () => {
     expect(output).not.toContain('CephCluster');
     expect(output).not.toContain('CephObjectStore');
   });
+
+  it('does not emit namespace warnings while capturing an omitted-namespace branch', () => {
+    const moduleUrl = pathToFileURL(
+      resolve(import.meta.dir, '../../src/factories/searxng/index.ts')
+    ).href;
+    const result = Bun.spawnSync({
+      cmd: [process.execPath, '-e', `await import(${JSON.stringify(moduleUrl)});`],
+      cwd: resolve(import.meta.dir, '../..'),
+      env: { ...process.env, TYPEKRO_LOG_LEVEL: 'warn' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const output =
+      new TextDecoder().decode(result.stdout) + new TextDecoder().decode(result.stderr);
+
+    expect(result.exitCode).toBe(0);
+    expect(output).not.toContain('no namespace specified');
+    expect(output).not.toContain('Deployment');
+  });
 });

--- a/test/unit/differential-branch-capture.test.ts
+++ b/test/unit/differential-branch-capture.test.ts
@@ -50,6 +50,34 @@ function extractResourceSection(yaml: string, id: string): string | undefined {
 
 describe('Differential Branch Capture', () => {
   describe('if (!spec.optional) — resource creation in untaken branch', () => {
+    it('does not fabricate resources for lower-camel local helpers', () => {
+      const service = (_options: { id: string }) => ({ endpoint: 'https://example.test' });
+      const composition = kubernetesComposition(
+        {
+          name: 'lower-camel-helper',
+          apiVersion: 'test.io/v1alpha1',
+          kind: 'LowerCamelHelper',
+          spec: type({ name: 'string', 'label?': 'string' }),
+          status: type({ ready: 'boolean' }),
+        },
+        (spec) => {
+          if (!spec.label) {
+            service({ id: 'phantomService' });
+          }
+          ConfigMap({
+            name: `${spec.name}-config`,
+            data: { ready: 'true' },
+            id: 'config',
+          });
+          return { ready: true };
+        }
+      );
+
+      const yaml = composition.toYaml();
+      expect(yaml).not.toContain('id: phantomService');
+      expect(yaml).not.toContain('name: phantomService');
+    });
+
     it('captures lower-camel Kubernetes factories for KRO outer-resource lowering', async () => {
       const composition = kubernetesComposition(
         {

--- a/test/unit/differential-branch-capture.test.ts
+++ b/test/unit/differential-branch-capture.test.ts
@@ -23,6 +23,7 @@
 import { describe, expect, it } from 'bun:test';
 import { type } from 'arktype';
 import { kubernetesComposition } from '../../src/core/composition/imperative.js';
+import { namespace } from '../../src/factories/kubernetes/core/namespace.js';
 // Direct imports: the composition-analyzer's `isFactoryCall` only recognises
 // Identifier callees (`ConfigMap(...)`), not MemberExpression callees
 // (`simple.ConfigMap(...)`), so we import the factory functions by name
@@ -49,6 +50,54 @@ function extractResourceSection(yaml: string, id: string): string | undefined {
 
 describe('Differential Branch Capture', () => {
   describe('if (!spec.optional) — resource creation in untaken branch', () => {
+    it('captures lower-camel Kubernetes factories for KRO outer-resource lowering', async () => {
+      const composition = kubernetesComposition(
+        {
+          name: 'lower-camel-namespace',
+          apiVersion: 'test.io/v1alpha1',
+          kind: 'LowerCamelNamespace',
+          spec: type({ name: 'string', 'namespace?': 'string' }),
+          status: type({ ready: 'boolean' }),
+        },
+        (spec) => {
+          if (!spec.namespace) {
+            namespace({
+              metadata: { name: 'framework-owned' },
+              id: 'ownedNamespace',
+            });
+          }
+          ConfigMap({
+            name: `${spec.name}-config`,
+            namespace: spec.namespace ?? 'framework-owned',
+            data: { ready: 'true' },
+            id: 'config',
+          });
+          return { ready: true };
+        }
+      );
+
+      expect(composition.plan!({ name: 'owned' }).nodes.map(({ id }) => id)).toContain(
+        'ownedNamespace'
+      );
+
+      const factory = composition.factory('kro');
+      const owned = await factory.toAlchemyResources({ name: 'owned' });
+      const external = await factory.toAlchemyResources({
+        name: 'external',
+        namespace: 'shared',
+      });
+
+      expect(
+        owned.some(
+          ({ props }) =>
+            props.resource.kind === 'Namespace' &&
+            props.resource.metadata?.name === 'framework-owned'
+        )
+      ).toBe(true);
+      expect(external.some(({ props }) => props.resource.kind === 'Namespace')).toBe(false);
+      expect(factory.toYaml()).not.toContain('kind: Namespace');
+    });
+
     it('captures the resource and attaches a correct includeWhen', () => {
       const composition = kubernetesComposition(
         {


### PR DESCRIPTION
## Summary
- treat a supplied SearXNG namespace as externally owned and create the default namespace only when omitted
- fix differential composition analysis so idiomatic lower-camel Kubernetes factories in untaken native branches are captured in KRO plans
- update public docs and lifecycle tests for the omitted-owned / supplied-external contract

## Verification
- full unit suite: 5,340 passed, 13 skipped, 1 todo
- full build, library/example/test typechecks, lint, and diff checks passed
- focused OrbStack direct + KRO SearXNG integration: 3 passed
- live evidence covers external namespace retention, raw missing-credential fail-closed reconciliation, factory teardown, and RGD/generated-CRD cleanup
