### PR TITLE
chore: release v0.33.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typekro",
-  "version": "0.33.9",
+  "version": "0.33.10",
   "description": "A control plane aware framework for orchestrating kubernetes resources like a programmer.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

- release SearXNG external namespace ownership semantics from #168
- release safe lower-camel differential branch capture without phantom resource stubs
- bump package version to 0.33.10

## Verification

- focused analyzer and SearXNG tests: 45 passed
- full unit suite: 5,342 passed, 0 failed
- bun run build
- bun run test:packed-imports
- git diff --check